### PR TITLE
Rollback proxy filename to middleware configuration

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,3 @@
+export { default } from 'next-auth/middleware';
+
+export const config = { matcher: ['/dashboard'] };

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,9 +1,0 @@
-import { NextResponse } from 'next/server';
-
-export { default } from 'next-auth/middleware';
-
-export function proxy() {
-	return NextResponse.next();
-}
-
-export const config = { matcher: ['/dashboard'] };


### PR DESCRIPTION
**The original middleware was not deprecated**
So it's been rolled back to the initial structure