### PR TITLE
Update catch errors in infra respositories

### DIFF
--- a/src/modules/auth/infrastructure/next-auth/next-auth.repository.ts
+++ b/src/modules/auth/infrastructure/next-auth/next-auth.repository.ts
@@ -1,8 +1,8 @@
 import { IAuthRepository } from '../../domain/auth.respository';
 import { getCurrentSession } from './next-auth.currentsession';
 import { Failure, Success } from '@/shared/domain/result';
-import { AutenticationServiceUnavailable } from '../../domain/errors/auth.errors';
 import { AuthMapper } from '../auth.mapper';
+import { GlobalErrorMapper } from '@/shared/infrastructure/glolabError.mapper';
 
 export class NextAuthRepository implements IAuthRepository {
 	async getSession() {
@@ -11,10 +11,8 @@ export class NextAuthRepository implements IAuthRepository {
 			if (!session?.user) return Success(null);
 			const domainSession = AuthMapper.toDomain(session);
 			return Success(domainSession);
-		} catch {
-			return Failure(
-				new AutenticationServiceUnavailable('Autentication service unavailable')
-			);
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 }

--- a/src/modules/bodysection/infrastructure/prisma/bodysection.prisma.repository.ts
+++ b/src/modules/bodysection/infrastructure/prisma/bodysection.prisma.repository.ts
@@ -1,8 +1,8 @@
 import { IBodySectionRepository } from '../../domain/bodysection.repository';
 import { BodySectionMapper } from '../bodysection.mapper';
 import { Failure, Success } from '@/shared/domain/result';
-import { PrismaError } from '@/shared/infrastructure/prisma/prisma.errors';
 import { PrismaClient } from '@/prisma/client';
+import { GlobalErrorMapper } from '@/shared/infrastructure/glolabError.mapper';
 
 export class BodySectionPrismaReporisoty implements IBodySectionRepository {
 	constructor(private readonly prisma: PrismaClient) {}
@@ -13,8 +13,8 @@ export class BodySectionPrismaReporisoty implements IBodySectionRepository {
 				BodySectionMapper.toDomain(bodySection)
 			);
 			return Success(bodySectionsDomain);
-		} catch {
-			return Failure(new PrismaError('Error fetching bodysections'));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async findById(id: number) {
@@ -22,8 +22,8 @@ export class BodySectionPrismaReporisoty implements IBodySectionRepository {
 			const bodySection = await this.prisma.bodySections.findUnique({ where: { id } });
 			const result = bodySection ? BodySectionMapper.toDomain(bodySection) : null;
 			return Success(result);
-		} catch {
-			return Failure(new PrismaError('Error fetching bodysections'));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 }

--- a/src/modules/exercise/infrastructure/prisma/exercise.prisma.repository.ts
+++ b/src/modules/exercise/infrastructure/prisma/exercise.prisma.repository.ts
@@ -2,9 +2,9 @@ import { IExerciseRepository } from '@/modules/exercise/domain/exercise.reposito
 import { ExerciseMapper } from '@/modules/exercise/infrastructure/exercise.mapper';
 import { Failure, Success } from '@/shared/domain/result';
 import { Exercise } from '@/modules/exercise/domain/exercise.entity';
-import { PrismaError } from '@/shared/infrastructure/prisma/prisma.errors';
 import { PrismaClient } from '@/prisma/client';
 import { ExerciseProps } from '../../domain/exercise.types';
+import { GlobalErrorMapper } from '@/shared/infrastructure/glolabError.mapper';
 
 export class ExercisePrismaRepository implements IExerciseRepository {
 	constructor(private readonly prisma: PrismaClient) {}
@@ -13,8 +13,8 @@ export class ExercisePrismaRepository implements IExerciseRepository {
 		try {
 			const created = await this.prisma.exercises.create({ data: exercisePersistence });
 			return Success(ExerciseMapper.toDomain(created));
-		} catch {
-			return Failure(new PrismaError('Unavailable create service'));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async update(data: Exercise) {
@@ -25,8 +25,8 @@ export class ExercisePrismaRepository implements IExerciseRepository {
 				where: { id: exercisePersistence.id },
 			});
 			return Success(ExerciseMapper.toDomain(updated));
-		} catch {
-			return Failure(new PrismaError('Unavailable update service'));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async findAll() {
@@ -34,16 +34,16 @@ export class ExercisePrismaRepository implements IExerciseRepository {
 			const exercises = await this.prisma.exercises.findMany();
 			const domainExercises = exercises.map((exercise) => ExerciseMapper.toDomain(exercise));
 			return Success(domainExercises);
-		} catch {
-			return Failure(new PrismaError('Unavailable fetching service'));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async findById(id: ExerciseProps['id']) {
 		try {
 			const exercise = await this.prisma.exercises.findUnique({ where: { id } });
 			return Success(exercise ? ExerciseMapper.toDomain(exercise) : null);
-		} catch {
-			return Failure(new PrismaError('Unavailable fetching service'));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async findAllByUserId(userId: ExerciseProps['userId']) {
@@ -51,8 +51,8 @@ export class ExercisePrismaRepository implements IExerciseRepository {
 			const exercises = await this.prisma.exercises.findMany({ where: { userId } });
 			const domainExercises = exercises.map((exercise) => ExerciseMapper.toDomain(exercise));
 			return Success(domainExercises);
-		} catch {
-			return Failure(new PrismaError('Unavailable fetching service'));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 }

--- a/src/modules/exercise/link/muscle/infrastructure/prisma/exercise-to-muscle.prisma.repository.ts
+++ b/src/modules/exercise/link/muscle/infrastructure/prisma/exercise-to-muscle.prisma.repository.ts
@@ -1,9 +1,9 @@
 import { Failure, Success } from '@/shared/domain/result';
-import { PrismaError } from '@/shared/infrastructure/prisma/prisma.errors';
 import { PrismaClient } from '@/prisma/client';
 import { IExerciseToMuscleRepository } from '@/modules/exercise/link/muscle/domain/exercise-to-muscle.repository';
 import { ExerciseToMuscle } from '@/modules/exercise/link/muscle/domain/exercise-to-muscle.entity';
 import { ExerciseToMuscleMapper } from '@/modules/exercise/link/muscle/infrastructure/exercise-to-muscle.mapper';
+import { GlobalErrorMapper } from '@/shared/infrastructure/glolabError.mapper';
 
 export class ExerciseToMusclePrismaRepository implements IExerciseToMuscleRepository {
 	constructor(private readonly prisma: PrismaClient) {}
@@ -15,8 +15,8 @@ export class ExerciseToMusclePrismaRepository implements IExerciseToMuscleReposi
 			});
 			const result = ExerciseToMuscleMapper.toDomain(created);
 			return Success(result);
-		} catch {
-			return Failure(new PrismaError("Can't create relation Exercise-Muscle"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async findAll() {
@@ -26,8 +26,8 @@ export class ExerciseToMusclePrismaRepository implements IExerciseToMuscleReposi
 				ExerciseToMuscleMapper.toDomain(exercise)
 			);
 			return Success(domainExercises);
-		} catch {
-			return Failure(new PrismaError("Can't create find all relations Exercise-Muscle"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async findByExerciseId(exerciseId: ExerciseToMuscle['exerciseId']) {
@@ -37,8 +37,8 @@ export class ExerciseToMusclePrismaRepository implements IExerciseToMuscleReposi
 			});
 			const result = exercises.map((exercise) => ExerciseToMuscleMapper.toDomain(exercise));
 			return Success(result);
-		} catch {
-			return Failure(new PrismaError('Unavailable fetching service'));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async findByMuscleId(muscleId: ExerciseToMuscle['muscleId']) {
@@ -48,8 +48,8 @@ export class ExerciseToMusclePrismaRepository implements IExerciseToMuscleReposi
 			});
 			const result = exercises.map((exercise) => ExerciseToMuscleMapper.toDomain(exercise));
 			return Success(result);
-		} catch {
-			return Failure(new PrismaError('Unavailable fetching service'));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 
@@ -71,8 +71,8 @@ export class ExerciseToMusclePrismaRepository implements IExerciseToMuscleReposi
 			});
 			const result = exercise ? ExerciseToMuscleMapper.toDomain(exercise) : null;
 			return Success(result);
-		} catch {
-			return Failure(new PrismaError('Unavailable fetching service'));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 }

--- a/src/modules/exerciseinitialstats/infrastructure/prisma/exerciseinitialstats.prisma.repository.ts
+++ b/src/modules/exerciseinitialstats/infrastructure/prisma/exerciseinitialstats.prisma.repository.ts
@@ -1,9 +1,9 @@
 import { Failure, Success } from '@/shared/domain/result';
-import { PrismaError } from '@/shared/infrastructure/prisma/prisma.errors';
 import { IExerciseInitialStatsRepository } from '../../domain/exerciseinitialstats.repository';
 import { ExerciseInitialStatsMapper } from '../exerciseinitialstats.mapper';
 import { ExerciseInitialStats } from '../../domain/exerciseinitialstats.entity';
 import { PrismaClient } from '@/prisma/client';
+import { GlobalErrorMapper } from '@/shared/infrastructure/glolabError.mapper';
 
 export class ExerciseInitialStatsPrismaRepository implements IExerciseInitialStatsRepository {
 	constructor(private readonly prisma: PrismaClient) {}
@@ -15,8 +15,8 @@ export class ExerciseInitialStatsPrismaRepository implements IExerciseInitialSta
 			});
 			const result = new ExerciseInitialStats(created);
 			return Success(result);
-		} catch {
-			return Failure(new PrismaError("Can't create Exercise Initial Stats"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async update(data: ExerciseInitialStats) {
@@ -29,8 +29,8 @@ export class ExerciseInitialStatsPrismaRepository implements IExerciseInitialSta
 
 			const result = new ExerciseInitialStats(updated);
 			return Success(result);
-		} catch {
-			return Failure(new PrismaError("Can't update Exercise Initial Stats"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async findAll() {
@@ -41,8 +41,8 @@ export class ExerciseInitialStatsPrismaRepository implements IExerciseInitialSta
 			);
 
 			return Success(exerciseStatsDomain);
-		} catch {
-			return Failure(new PrismaError("Can't find all Exercise Initial Stats"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async findById(id: ExerciseInitialStats['id']) {
@@ -54,8 +54,8 @@ export class ExerciseInitialStatsPrismaRepository implements IExerciseInitialSta
 				? ExerciseInitialStatsMapper.toDomain(exerciseStats)
 				: null;
 			return Success(result);
-		} catch {
-			return Failure(new PrismaError("Can't find Exercise Initial Stats by id"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async findByExerciseId(exerciseId: ExerciseInitialStats['exerciseId']) {
@@ -67,8 +67,8 @@ export class ExerciseInitialStatsPrismaRepository implements IExerciseInitialSta
 				? ExerciseInitialStatsMapper.toDomain(exerciseStats)
 				: null;
 			return Success(result);
-		} catch {
-			return Failure(new PrismaError("Can't find Exercise Initial Stats by Exercise id"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 }

--- a/src/modules/muscle/infrastructure/prisma/muscle.prisma.repository.ts
+++ b/src/modules/muscle/infrastructure/prisma/muscle.prisma.repository.ts
@@ -1,8 +1,8 @@
 import { MuscleMapper } from '../muscle.mapper';
 import { Failure, Success } from '@/shared/domain/result';
-import { PrismaError } from '@/shared/infrastructure/prisma/prisma.errors';
 import { IMuscleRepository } from '../../domain/muscle.repository';
 import { PrismaClient } from '@/prisma/client';
+import { GlobalErrorMapper } from '@/shared/infrastructure/glolabError.mapper';
 
 export class MusclePrismaRepository implements IMuscleRepository {
 	constructor(private readonly prisma: PrismaClient) {}
@@ -11,8 +11,8 @@ export class MusclePrismaRepository implements IMuscleRepository {
 			const muscles = await this.prisma.muscles.findMany();
 			const domainMuscles = muscles.map((muscle) => MuscleMapper.toDomain(muscle));
 			return Success(domainMuscles);
-		} catch {
-			return Failure(new PrismaError("Can't find all Muscles"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async findById(id: number) {
@@ -22,8 +22,8 @@ export class MusclePrismaRepository implements IMuscleRepository {
 			});
 			const result = muscle ? MuscleMapper.toDomain(muscle) : null;
 			return Success(result);
-		} catch {
-			return Failure(new PrismaError("Can't find Muscle by id"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 }

--- a/src/modules/musculargroup/infrastructure/prisma/musculargroup.prisma.repository.ts
+++ b/src/modules/musculargroup/infrastructure/prisma/musculargroup.prisma.repository.ts
@@ -4,6 +4,7 @@ import { MuscularGroupMapper } from '../musculargroup.mapper';
 import { Failure, Success } from '@/shared/domain/result';
 import { PrismaError } from '@/shared/infrastructure/prisma/prisma.errors';
 import { MuscularGroupProps } from '../../domain/musculargroup.types';
+import { GlobalErrorMapper } from '@/shared/infrastructure/glolabError.mapper';
 
 export class MuscularGroupPrismaReporitory implements IMuscularGroupRepository {
 	async findAll() {
@@ -13,8 +14,8 @@ export class MuscularGroupPrismaReporitory implements IMuscularGroupRepository {
 				MuscularGroupMapper.toDomain(muscularGroup)
 			);
 			return Success(muscularGroupsDomain);
-		} catch {
-			return Failure(new PrismaError("Can't find all Muscular Groups"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async findById(id: MuscularGroupProps['id']) {
@@ -22,8 +23,8 @@ export class MuscularGroupPrismaReporitory implements IMuscularGroupRepository {
 			const muscularGroup = await prisma.muscularGroups.findUnique({ where: { id } });
 			const result = muscularGroup ? MuscularGroupMapper.toDomain(muscularGroup) : null;
 			return Success(result);
-		} catch {
-			return Failure(new PrismaError("Can't find Musulcar Group by id"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 }

--- a/src/modules/notification/infrastructure/prisma/notification.prisma.repository.ts
+++ b/src/modules/notification/infrastructure/prisma/notification.prisma.repository.ts
@@ -1,10 +1,10 @@
 import { Notification } from '../../domain/notification.entity';
 import { INotification } from '../../domain/notification.repository';
-import { PrismaError } from '@/shared/infrastructure/prisma/prisma.errors';
 import { Failure, Success } from '@/shared/domain/result';
 import { NotificationProps } from '../../domain/notification.types';
 import { NotificationMapper } from '../notification.mapper';
 import { PrismaClient } from '@/prisma/client';
+import { GlobalErrorMapper } from '@/shared/infrastructure/glolabError.mapper';
 
 export class NotificationPrismaRepository implements INotification {
 	constructor(private readonly prisma: PrismaClient) {}
@@ -16,8 +16,8 @@ export class NotificationPrismaRepository implements INotification {
 			});
 			const result = NotificationMapper.toDomain(created);
 			return Success(result);
-		} catch {
-			return Failure(new PrismaError("Can't create notification"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async update(data: Notification) {
@@ -29,8 +29,8 @@ export class NotificationPrismaRepository implements INotification {
 			});
 			const result = NotificationMapper.toDomain(updated);
 			return Success(result);
-		} catch {
-			return Failure(new PrismaError("Can't updated notification"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async findAll() {
@@ -40,8 +40,8 @@ export class NotificationPrismaRepository implements INotification {
 				NotificationMapper.toDomain(notification)
 			);
 			return Success(domainNotifications);
-		} catch {
-			return Failure(new PrismaError("Can't find all notifications"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async findById(id: NotificationProps['id']) {
@@ -49,8 +49,8 @@ export class NotificationPrismaRepository implements INotification {
 			const notification = await this.prisma.notifications.findUnique({ where: { id } });
 			const result = notification ? NotificationMapper.toDomain(notification) : null;
 			return Success(result);
-		} catch {
-			return Failure(new PrismaError("Can't find notification by id"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 }

--- a/src/modules/routine/infrastructure/prisma/routine.prisma.repository.ts
+++ b/src/modules/routine/infrastructure/prisma/routine.prisma.repository.ts
@@ -2,8 +2,8 @@ import { IRoutineRepository } from '../../domain/routine.repository';
 import { RoutineMapper } from '../routine.mapper';
 import { Routine } from '../../domain/routine.entity';
 import { Failure, Success } from '@/shared/domain/result';
-import { PrismaError } from '@/shared/infrastructure/prisma/prisma.errors';
 import { PrismaClient } from '@/prisma/client';
+import { GlobalErrorMapper } from '@/shared/infrastructure/glolabError.mapper';
 
 export class RoutinePrismaRepository implements IRoutineRepository {
 	constructor(private readonly prisma: PrismaClient) {}
@@ -13,8 +13,8 @@ export class RoutinePrismaRepository implements IRoutineRepository {
 			const created = await this.prisma.routines.create({ data: routinePersistence });
 			const result = RoutineMapper.toDomain(created);
 			return Success(result);
-		} catch {
-			return Failure(new PrismaError("Can't create Routine"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async update(data: Routine) {
@@ -26,8 +26,8 @@ export class RoutinePrismaRepository implements IRoutineRepository {
 			});
 			const result = RoutineMapper.toDomain(created);
 			return Success(result);
-		} catch {
-			return Failure(new PrismaError("Can't update Routine"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async findaAll() {
@@ -35,8 +35,8 @@ export class RoutinePrismaRepository implements IRoutineRepository {
 			const routines = await this.prisma.routines.findMany();
 			const routinesDomain = routines.map((routine) => RoutineMapper.toDomain(routine));
 			return Success(routinesDomain);
-		} catch {
-			return Failure(new PrismaError("Can't find all Routines"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async findById(id: string) {
@@ -44,8 +44,8 @@ export class RoutinePrismaRepository implements IRoutineRepository {
 			const routine = await this.prisma.routines.findUnique({ where: { id } });
 			const result = routine ? RoutineMapper.toDomain(routine) : null;
 			return Success(result);
-		} catch {
-			return Failure(new PrismaError("Can't find Routine by id"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 }

--- a/src/modules/routinedays/infrastructure/prisma/routinedays.prisma.repository.ts
+++ b/src/modules/routinedays/infrastructure/prisma/routinedays.prisma.repository.ts
@@ -3,8 +3,8 @@ import { RoutineDaysProps } from '../../domain/routinedays.types';
 import { RoutineDaysMapper } from '../routinedays.mapper';
 import { RoutineDays } from '../../domain/routinedays.entity';
 import { Failure, Success } from '@/shared/domain/result';
-import { PrismaError } from '@/shared/infrastructure/prisma/prisma.errors';
 import { PrismaClient } from '@/prisma/client';
+import { GlobalErrorMapper } from '@/shared/infrastructure/glolabError.mapper';
 
 export class RoutineDaysPrismaRepository implements IRoutineDaysRepository {
 	constructor(private readonly prisma: PrismaClient) {}
@@ -14,8 +14,8 @@ export class RoutineDaysPrismaRepository implements IRoutineDaysRepository {
 			const created = await this.prisma.routineDays.create({ data: routineDayPersistence });
 			const result = RoutineDaysMapper.toDomain(created);
 			return Success(result);
-		} catch {
-			return Failure(new PrismaError("Can't create Routine Days"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async update(data: RoutineDays) {
@@ -27,8 +27,8 @@ export class RoutineDaysPrismaRepository implements IRoutineDaysRepository {
 			});
 			const result = RoutineDaysMapper.toDomain(updated);
 			return Success(result);
-		} catch {
-			return Failure(new PrismaError("Can't update Routine Days"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async findAll() {
@@ -38,8 +38,8 @@ export class RoutineDaysPrismaRepository implements IRoutineDaysRepository {
 				RoutineDaysMapper.toDomain(routineDay)
 			);
 			return Success(routineDaysDomain);
-		} catch {
-			return Failure(new PrismaError("Can't find all Routine Days"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async findById(id: RoutineDaysProps['id']) {
@@ -47,8 +47,8 @@ export class RoutineDaysPrismaRepository implements IRoutineDaysRepository {
 			const routineDay = await this.prisma.routineDays.findUnique({ where: { id } });
 			const result = routineDay ? RoutineDaysMapper.toDomain(routineDay) : null;
 			return Success(result);
-		} catch {
-			return Failure(new PrismaError("Can't find Routine Days by id"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 }

--- a/src/modules/session/infrastructure/prisma/session.prisma.repository.ts
+++ b/src/modules/session/infrastructure/prisma/session.prisma.repository.ts
@@ -1,10 +1,10 @@
 import { Failure, Success } from '@/shared/domain/result';
-import { PrismaError } from '@/shared/infrastructure/prisma/prisma.errors';
 import { Session } from '../../domain/session.entity';
 import { ISessionRepository } from '../../domain/session.repository';
 import { SessionMapper } from '../session.mapper';
 import { SessionProps } from '../../domain/session.types';
 import { PrismaClient } from '@/prisma/client';
+import { GlobalErrorMapper } from '@/shared/infrastructure/glolabError.mapper';
 
 export class SessionPrismaRepository implements ISessionRepository {
 	constructor(private readonly prisma: PrismaClient) {}
@@ -14,8 +14,8 @@ export class SessionPrismaRepository implements ISessionRepository {
 			const created = await this.prisma.sessions.create({ data: sessionPersistence });
 			const result = SessionMapper.toDomain(created);
 			return Success(result);
-		} catch {
-			return Failure(new PrismaError("Can't create Session"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async update(data: Session) {
@@ -27,8 +27,8 @@ export class SessionPrismaRepository implements ISessionRepository {
 			});
 			const result = SessionMapper.toDomain(updated);
 			return Success(result);
-		} catch {
-			return Failure(new PrismaError("Can't update Session"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async findAll() {
@@ -36,8 +36,8 @@ export class SessionPrismaRepository implements ISessionRepository {
 			const sessions = await this.prisma.sessions.findMany();
 			const sessionsDomain = sessions.map((session) => SessionMapper.toDomain(session));
 			return Success(sessionsDomain);
-		} catch {
-			return Failure(new PrismaError("Can't create Session"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async findById(id: SessionProps['id']) {
@@ -45,8 +45,8 @@ export class SessionPrismaRepository implements ISessionRepository {
 			const session = await this.prisma.sessions.findUnique({ where: { id } });
 			const result = session ? SessionMapper.toDomain(session) : null;
 			return Success(result);
-		} catch {
-			return Failure(new PrismaError("Can't create Session"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 }

--- a/src/modules/session/link/infrastructure/prisma/session-to-exercise.prisma.repository.ts
+++ b/src/modules/session/link/infrastructure/prisma/session-to-exercise.prisma.repository.ts
@@ -1,10 +1,10 @@
 import { PrismaClient } from '@/prisma/client';
 import { Failure, Success } from '@/shared/domain/result';
-import { PrismaError } from '@/shared/infrastructure/prisma/prisma.errors';
 import { ISessionToExerciseRepository } from '../../domain/session-to-exercise.repository';
 import { SessionToExercise } from '../../domain/session-to-exercise.entity';
 import { SessionToExerciseMapper } from '../session-to-exercise.mapper';
 import { SessionToExerciseProps } from '../../domain/session-to-exercise.types';
+import { GlobalErrorMapper } from '@/shared/infrastructure/glolabError.mapper';
 
 export class SessionToExercisePrismaRepository implements ISessionToExerciseRepository {
 	constructor(private readonly prisma: PrismaClient) {}
@@ -16,8 +16,8 @@ export class SessionToExercisePrismaRepository implements ISessionToExerciseRepo
 			});
 			const result = SessionToExerciseMapper.toDomain(created);
 			return Success(result);
-		} catch {
-			return Failure(new PrismaError("Can't create Session-Exercise"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async findAll() {
@@ -27,8 +27,8 @@ export class SessionToExercisePrismaRepository implements ISessionToExerciseRepo
 				SessionToExerciseMapper.toDomain(session)
 			);
 			return Success(sessionsDomain);
-		} catch {
-			return Failure(new PrismaError("Can't find all Sessions-Exercises"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async listBySessionId(sessionId: SessionToExerciseProps['sessionId']) {
@@ -40,8 +40,8 @@ export class SessionToExercisePrismaRepository implements ISessionToExerciseRepo
 				SessionToExerciseMapper.toDomain(session)
 			);
 			return Success(sessionsDomain);
-		} catch {
-			return Failure(new PrismaError("Can't list Session-Exercise by Session id"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async listByExerciseId(exerciseId: SessionToExerciseProps['exerciseId']) {
@@ -53,8 +53,8 @@ export class SessionToExercisePrismaRepository implements ISessionToExerciseRepo
 				SessionToExerciseMapper.toDomain(session)
 			);
 			return Success(sessionsDomain);
-		} catch {
-			return Failure(new PrismaError("Can't list Session-Exercise by Exercise id"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 
@@ -76,8 +76,8 @@ export class SessionToExercisePrismaRepository implements ISessionToExerciseRepo
 			});
 			const result = session ? SessionToExerciseMapper.toDomain(session) : null;
 			return Success(result);
-		} catch {
-			return Failure(new PrismaError("Can't find Session-Exercise by ids"));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 }

--- a/src/modules/user/infrastructure/prisma/user.prisma.repository.ts
+++ b/src/modules/user/infrastructure/prisma/user.prisma.repository.ts
@@ -2,8 +2,8 @@ import { User } from '@/modules/user/domain/user.entity';
 import { IUserRepository } from '@/modules/user/domain/user.repository';
 import { UserMapper } from '@/modules/user/infrastructure/user.mapper';
 import { Failure, Success } from '@/shared/domain/result';
-import { PrismaError } from '@/shared/infrastructure/prisma/prisma.errors';
 import { PrismaClient } from '@/prisma/client';
+import { GlobalErrorMapper } from '@/shared/infrastructure/glolabError.mapper';
 
 export class UserPrismaRepository implements IUserRepository {
 	constructor(private readonly prisma: PrismaClient) {}
@@ -16,8 +16,8 @@ export class UserPrismaRepository implements IUserRepository {
 			});
 			const domainUser = UserMapper.toDomain(created);
 			return Success(domainUser);
-		} catch {
-			return Failure(new PrismaError('Unavailable create service'));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 
@@ -31,8 +31,8 @@ export class UserPrismaRepository implements IUserRepository {
 
 			const domainUser = UserMapper.toDomain(updated);
 			return Success(domainUser);
-		} catch {
-			return Failure(new PrismaError('Unavailable update service'));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 
@@ -41,8 +41,8 @@ export class UserPrismaRepository implements IUserRepository {
 			const users = await this.prisma.users.findMany();
 			const domainUsers = users.map((user) => UserMapper.toDomain(user));
 			return Success(domainUsers);
-		} catch (error) {
-			return Failure(new PrismaError('Unavailable prisma service'));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 
@@ -54,8 +54,8 @@ export class UserPrismaRepository implements IUserRepository {
 				},
 			});
 			return Success(user ? UserMapper.toDomain(user) : null);
-		} catch (error) {
-			return Failure(new PrismaError('Unavailable prisma service'));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 	async findByEmail(email: User['email']) {
@@ -66,8 +66,8 @@ export class UserPrismaRepository implements IUserRepository {
 				},
 			});
 			return Success(user ? UserMapper.toDomain(user) : null);
-		} catch (error) {
-			return Failure(new PrismaError('Unavailable prisma service'));
+		} catch (e) {
+			return Failure(GlobalErrorMapper.toDomainError(e));
 		}
 	}
 }


### PR DESCRIPTION
Update every infra repository catch. Changes:
- Catch error is received
- Every catch body use GlobalErrorMapper which uses the caught error
- The Failure response still being the same but returns the error instance mapped from GlobalErrorMapper.

Modules affected (infra technology they use): 
- Auth (Next Auth)
- Body Sections (Prisma)
- Exercise (Prisma)
- - Exercise to Muscle (Prisma)
- Exercise Initial Stats (Prisma)
- Muscle (Prisma)
- Muscular Group (Prisma)
- Notification (Prisma)
- Routine (Prisma)
- Routine Cycle (Prisma)
- Routine Days (Prisma)
- Session (Prisma)
-- Session to Exercise (Prisma)
- User (Prisma)