### PR TITLE
feat: add test to shared components

### DIFF
--- a/src/presentation/globals/components/DraggableBadge.test.tsx
+++ b/src/presentation/globals/components/DraggableBadge.test.tsx
@@ -1,0 +1,65 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { DraggableBadge } from './DraggableBadge';
+import userEvent from '@testing-library/user-event';
+
+describe('<DraggableBadge />', () => {
+  const dataTestId = 'draggable-badge-item';
+  describe('Basic Rendering', () => {
+    it('should render correctly with minimum props', () => {
+      render(<DraggableBadge data-testid={dataTestId} />);
+      expect(screen.getByTestId(dataTestId)).toBeInTheDocument();
+    });
+    it('should render correctly with children text', () => {
+      render(<DraggableBadge data-testid={dataTestId}>Draggable Item</DraggableBadge>);
+      expect(screen.getByTestId(dataTestId)).toHaveTextContent('Draggable Item');
+    });
+  });
+
+  describe('Conditional Rendering', () => {
+    it('should not render a button when onRemove callback not provided', async () => {
+      render(<DraggableBadge data-testid={dataTestId} />);
+      expect(screen.getByTestId(dataTestId)).toBeInTheDocument();
+      const button = screen.queryByLabelText('Remove item');
+      expect(button).not.toBeInTheDocument();
+    });
+
+    it('should not render a button when onRemove callback provided', () => {
+      render(<DraggableBadge data-testid={dataTestId} onRemove={() => {}} />);
+      expect(screen.getByTestId(dataTestId)).toBeInTheDocument();
+      expect(screen.getByRole('button')).toBeInTheDocument();
+    });
+  });
+
+  describe('Integration with Props', () => {
+    it('should integrate with Div props', () => {
+      render(<DraggableBadge role="region" aria-label="Draggable item" className="test-class" />);
+      const element = screen.getByLabelText('Draggable item');
+      expect(element).toBeInTheDocument();
+      expect(element).toHaveRole('region');
+      expect(element).toHaveClass('test-class');
+    });
+  });
+
+  describe('User Interaction', () => {
+    it('should trigger onRemove callback when close button clicked', async () => {
+      const user = userEvent.setup();
+      const fn = jest.fn();
+      render(<DraggableBadge data-testid={dataTestId} onRemove={fn} />);
+      expect(screen.getByTestId(dataTestId)).toBeInTheDocument();
+      const button = screen.getByRole('button');
+      await user.click(button);
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should have close button with aria-label when onRemove provided', () => {
+      render(<DraggableBadge data-testid={dataTestId} onRemove={() => {}} />);
+      const element = screen.getByTestId(dataTestId);
+      expect(element).toBeInTheDocument();
+      const closeBtn = screen.getByRole('button', { name: /remove item/i });
+      expect(closeBtn).toBeInTheDocument();
+    });
+  });
+});

--- a/src/presentation/globals/components/DraggableBadge.tsx
+++ b/src/presentation/globals/components/DraggableBadge.tsx
@@ -22,7 +22,11 @@ export function DraggableBadge(props: Props) {
       <IconGripVertical className="size-4" />
       <span className="w-15 truncate">{children}</span>
       {onRemove && (
-        <Button variantConfig={{ type: 'square', size: 'xs', color: 'simple' }} onClick={onRemove}>
+        <Button
+          variantConfig={{ type: 'square', size: 'xs', color: 'simple' }}
+          aria-label="Remove item"
+          onClick={onRemove}
+        >
           <IconXMark className="size-5" />
         </Button>
       )}

--- a/src/presentation/globals/components/DropdownList.test.tsx
+++ b/src/presentation/globals/components/DropdownList.test.tsx
@@ -1,0 +1,102 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { DropdownList } from './DropdownList';
+import userEvent from '@testing-library/user-event';
+
+describe('<DropdownList />', () => {
+  const values = [
+    { value: 'option1', label: 'Option 1' },
+    { value: 'option2', label: 'Option 2' },
+  ];
+  describe('Basic Rendering', () => {
+    it('should be rendered with minimum props', () => {
+      render(<DropdownList values={[]} />);
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+    });
+
+    it('should be rendered with option element', () => {
+      render(<DropdownList values={[]} />);
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+      expect(screen.getByRole('option')).toBeInTheDocument();
+    });
+  });
+
+  describe('Integration with Props', () => {
+    it('should have correct class', () => {
+      render(<DropdownList values={[]} className="test-class" />);
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+      expect(screen.getByRole('combobox')).toHaveClass('test-class');
+    });
+
+    it('should have n option elements when n values provided', () => {
+      render(<DropdownList values={values} />);
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: /option 1/i })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: /option 2/i })).toBeInTheDocument();
+    });
+
+    it('should have default option selected', () => {
+      render(<DropdownList values={values} selectedValue="option2" />);
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+      expect(screen.getByRole('combobox')).toHaveValue('option2');
+    });
+
+    it('should update value when rerendered', () => {
+      const { rerender } = render(<DropdownList values={values} selectedValue="option2" />);
+      expect(screen.getByRole('combobox')).toHaveValue('option2');
+      rerender(<DropdownList values={values} selectedValue="option1" />);
+      expect(screen.getByRole('combobox')).toHaveValue('option1');
+    });
+  });
+
+  describe('Internal State', () => {
+    it('should change value when differente option selected', async () => {
+      const user = userEvent.setup();
+      const fn = jest.fn();
+      render(<DropdownList values={values} onChange={(_e) => fn()} />);
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+
+      await user.selectOptions(screen.getByRole('combobox'), 'option2');
+
+      expect(screen.getByRole('combobox')).toHaveValue('option2');
+    });
+  });
+
+  describe('User Interactions', () => {
+    it('should call onChange callback when different option selected', async () => {
+      const user = userEvent.setup();
+      const fn = jest.fn();
+      render(<DropdownList values={values} onChange={(_e) => fn()} />);
+      const select = screen.getByRole('combobox');
+      expect(select).toBeInTheDocument();
+
+      await user.selectOptions(select, 'option2');
+
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Accesibility', () => {
+    it('should support keyboard navigation (focus)', async () => {
+      const user = userEvent.setup();
+      render(<DropdownList values={[]} />);
+      await user.tab();
+      expect(screen.getByRole('combobox')).toHaveFocus();
+    });
+
+    it('should have default option disabled when 0 values provided', () => {
+      render(<DropdownList values={[]} />);
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: /no options found/i })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: /no options found/i })).toBeDisabled();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should have rendered default option when 0 values provided', () => {
+      render(<DropdownList values={[]} />);
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: /no options found/i })).toBeInTheDocument();
+    });
+  });
+});

--- a/src/presentation/globals/components/DropdownList.tsx
+++ b/src/presentation/globals/components/DropdownList.tsx
@@ -22,6 +22,7 @@ export function DropdownList({
 
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     onChange?.(e);
+    setSelectedOption(e.currentTarget.value);
   };
 
   useEffect(() => {
@@ -34,6 +35,11 @@ export function DropdownList({
       onChange={handleChange}
       value={selectedOption}
     >
+      {values.length === 0 && (
+        <option value="" disabled>
+          No options found
+        </option>
+      )}
       {values.map((value) => (
         <option key={value.value} value={value.value} className="bg-back">
           {value.label}


### PR DESCRIPTION
## Summary
Add test for relevant shared components (DropdownList and DraggableBadge)

## Issue
This PR closes #98 

## Changes
- Fix controlled select issue, adding updating when onChange triggered
- Add test for `DraggableBadge` component covering: 
- - Basic rendering
- - Conditional rendering
- - Integration with props
- - User interactions
- - Accessibility
- Add test for `DropdownList` component covering: 
- - Basic rendering 
- - Integration with props
- - Internal state
- - User interactions
- - Accessibility
- - Edge cases

## How to test
1. Run `pnpm test`
2. There are 45 total test at least and 4 suites (2 more)