### PR TITLE
feat(css): add focus color variable

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -68,6 +68,8 @@
   --color-complete-dark: var(--color-green-500);
   --color-cancel-dark: var(--color-red-600);
   --color-unread-dark: var(--color-blue-500);
+  /* Accessibility */
+  --color-focus-dark: #fff;
 
   /* Light */
   /* Background */
@@ -86,6 +88,8 @@
   --color-complete-light: var(--color-green-700);
   --color-cancel-light: var(--color-red-700);
   --color-unread-light: var(--color-blue-700);
+  /* Accessibility */
+  --color-focus-light: #000;
 
   /* Dynamic Colors */
   /* Background */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -108,6 +108,8 @@
   --color-complete: var(--color-complete-dark);
   --color-cancel: var(--color-cancel-dark);
   --color-unread: var(--color-unread-dark);
+  /* Accessibility */
+  --color-focus: var(--color-focus-dark);
 }
 
 /* Light Color Versions */
@@ -128,6 +130,8 @@ html[data-theme='light'] {
   --color-complete: var(--color-complete-light);
   --color-cancel: var(--color-cancel-light);
   --color-unread: var(--color-unread-light);
+  /* Accessibility */
+  --color-focus: var(--color-focus-light);
 }
 
 body {

--- a/src/presentation/modules/form/components/ErrorMessage.test.tsx
+++ b/src/presentation/modules/form/components/ErrorMessage.test.tsx
@@ -1,0 +1,40 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { ErrorMessage } from '@/presentation/modules/form/components/ErrorMessage';
+
+describe('<ErrorMessage />', () => {
+  describe('Conditional Rendering', () => {
+    it('Should not be rendered when message prop is not provided', () => {
+      render(<ErrorMessage />);
+      expect(screen.queryByRole('paragraph')).not.toBeInTheDocument();
+    });
+
+    it('Should be rendered when error prop is provided', () => {
+      render(<ErrorMessage message="Error" />);
+      expect(screen.getByRole('paragraph')).toBeInTheDocument();
+    });
+  });
+
+  describe('Integration with Props', () => {
+    it('Should update text when rerendered', () => {
+      const { rerender } = render(<ErrorMessage message="Error" />);
+      expect(screen.getByText('Error')).toBeInTheDocument();
+      rerender(<ErrorMessage message="New error" />);
+      expect(screen.getByText('New error')).toBeInTheDocument();
+    });
+
+    it('Should dissapear when message prop goes from text to undefined ', () => {
+      const { rerender } = render(<ErrorMessage message="Error" />);
+      expect(screen.getByText('Error')).toBeInTheDocument();
+      rerender(<ErrorMessage />);
+      expect(screen.queryByText('Error')).not.toBeInTheDocument();
+    });
+
+    it('Should appear when message prop goes undefined to text ', () => {
+      const { rerender } = render(<ErrorMessage />);
+      expect(screen.queryByRole('paragraph')).not.toBeInTheDocument();
+      rerender(<ErrorMessage message="Error" />);
+      expect(screen.getByText('Error')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/presentation/modules/form/components/FormFieldSection.test.tsx
+++ b/src/presentation/modules/form/components/FormFieldSection.test.tsx
@@ -1,0 +1,86 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { FormFieldSection } from '@/presentation/modules/form/components/FormFieldSection';
+import { IconUser } from '@/presentation/globals/components/icons/outline/IconUser';
+
+describe('<FormFieldSection />', () => {
+  describe('Basic Rendering', () => {
+    it('Should be rendered with minimum props', () => {
+      render(<FormFieldSection title="Metrics">Anything</FormFieldSection>);
+      expect(screen.getByRole('region')).toBeInTheDocument();
+    });
+
+    it('Should render a heading element', () => {
+      render(<FormFieldSection title="Metrics">Anything</FormFieldSection>);
+      expect(screen.getByRole('heading')).toBeInTheDocument();
+    });
+
+    it('Should render a fieldset element', () => {
+      render(<FormFieldSection title="Metrics">Anything</FormFieldSection>);
+      expect(screen.getByRole('group')).toBeInTheDocument();
+    });
+
+    it('Should render children content', () => {
+      render(<FormFieldSection title="Metrics">Anything</FormFieldSection>);
+      expect(screen.getByText('Anything')).toBeInTheDocument();
+    });
+  });
+
+  describe('Conditional Rendering', () => {
+    it('Should not render an icon (svg element) when Icon prop not provided', () => {
+      render(<FormFieldSection title="Metrics">Anything</FormFieldSection>);
+      const component = screen.getByRole('region');
+      expect(component.querySelector('svg')).not.toBeInTheDocument();
+    });
+
+    it('Should render an icon (svg element) when Icon prop provided', () => {
+      render(
+        <FormFieldSection title="Metrics" Icon={IconUser}>
+          Anything
+        </FormFieldSection>
+      );
+      const component = screen.getByRole('region');
+      expect(component.querySelector('svg')).toBeInTheDocument();
+    });
+  });
+
+  describe('Integration with Props', () => {
+    it('Should have "Metrics" heading text when title prop provided', () => {
+      render(<FormFieldSection title="Metrics">Anything</FormFieldSection>);
+      expect(screen.getByRole('region', { name: /metrics/i })).toBeInTheDocument();
+    });
+
+    it('Should update heading text when rerendered', () => {
+      const { rerender } = render(<FormFieldSection title="Metrics">Anything</FormFieldSection>);
+      expect(screen.getByRole('region', { name: /metrics/i })).toBeInTheDocument();
+      rerender(<FormFieldSection title="Plan">Anything</FormFieldSection>);
+      expect(screen.queryByRole('region', { name: /metrics/i })).not.toBeInTheDocument();
+      expect(screen.getByRole('region', { name: /plan/i })).toBeInTheDocument();
+    });
+
+    it('Should update children content inside fieldset element when rerendered', () => {
+      const { rerender } = render(<FormFieldSection title="Metrics">Anything</FormFieldSection>);
+      expect(screen.getByRole('group')).toHaveTextContent('Anything');
+      rerender(<FormFieldSection title="Plan">Another</FormFieldSection>);
+      expect(screen.getByRole('group')).not.toHaveTextContent('Anything');
+      expect(screen.getByRole('group')).toHaveTextContent('Another');
+    });
+
+    it('Should have fieldset with "bg-primary" class when provided by className prop', () => {
+      render(
+        <FormFieldSection title="Metrics" className="bg-primary">
+          Anything
+        </FormFieldSection>
+      );
+      expect(screen.getByRole('region')).toBeInTheDocument();
+      expect(screen.getByRole('group')).toHaveClass('bg-primary');
+    });
+  });
+
+  describe('Integration with Props', () => {
+    it('Should have aria-label attribute with "Metrics" value', () => {
+      render(<FormFieldSection title="Metrics">Anything</FormFieldSection>);
+      expect(screen.getByRole('region')).toHaveAttribute('aria-label', 'Metrics');
+    });
+  });
+});

--- a/src/presentation/modules/form/components/FormFieldSection.tsx
+++ b/src/presentation/modules/form/components/FormFieldSection.tsx
@@ -8,11 +8,11 @@ type Props = {
 };
 export function FormFieldSection({ Icon, children, title, className }: Props) {
   return (
-    <section className="space-y-2">
-      <header className="fg-default border-b-bd-muted flex h-10 items-center gap-2 border-b">
+    <section className="space-y-2" aria-label={title}>
+      <h5 className="fg-default border-b-bd-muted flex h-10 items-center gap-2 border-b">
         {Icon && <Icon strokeWidth="1" />}
         <span className="truncate text-lg font-normal">{title}</span>
-      </header>
+      </h5>
       <fieldset className={className}>{children}</fieldset>
     </section>
   );

--- a/src/presentation/modules/form/components/Radiobutton.test.tsx
+++ b/src/presentation/modules/form/components/Radiobutton.test.tsx
@@ -1,0 +1,65 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { Radiobutton } from '@/presentation/modules/form/components/Radiobutton';
+import userEvent from '@testing-library/user-event';
+
+describe('<Radiobutton />', () => {
+  describe('Basic Rendering', () => {
+    it('Should be rendered with minimum props', () => {
+      render(<Radiobutton label="Strength" value="strength" />);
+      expect(screen.getByRole('radio')).toBeInTheDocument();
+    });
+  });
+
+  describe('Integration with Props', () => {
+    it('Should have "Strength" label text when is provided by label prop', () => {
+      render(<Radiobutton label="Strength" value="strength" />);
+      expect(screen.getByLabelText('Strength')).toBeInTheDocument();
+    });
+
+    it('Should have radio input checked when is provided by checked prop', () => {
+      render(<Radiobutton label="Strength" value="strength" checked />);
+      expect(screen.getByRole('radio')).toBeChecked();
+    });
+
+    it('Should not have radio input checked when checked prop is not provided', () => {
+      render(<Radiobutton label="Strength" value="strength" />);
+      expect(screen.getByRole('radio')).not.toBeChecked();
+    });
+
+    it('Should update radio input checked when rerendered', () => {
+      const { rerender } = render(<Radiobutton label="Strength" value="strength" />);
+      expect(screen.getByRole('radio')).not.toBeChecked();
+      rerender(<Radiobutton label="Strength" value="strength" checked />);
+      expect(screen.getByRole('radio')).toBeChecked();
+    });
+
+    it('Should update label text when rerendered', () => {
+      const { rerender } = render(<Radiobutton label="Strength" value="strength" />);
+      expect(screen.getByLabelText('Strength')).toBeInTheDocument();
+      rerender(<Radiobutton label="Resistance" value="strength" />);
+      expect(screen.queryByLabelText('Strength')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Resistance')).toBeInTheDocument();
+    });
+  });
+
+  describe('User Interactions', () => {
+    it('Should trigger onChange callback when clicked', async () => {
+      const fn = jest.fn();
+      const handleChange = (_e: React.ChangeEvent<HTMLInputElement>) => fn();
+      const user = userEvent.setup();
+      render(<Radiobutton onChange={handleChange} label="Strength" value="strength" />);
+      await user.click(screen.getByLabelText('Strength'));
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('Should support keyboard navigation (focus)', async () => {
+      const user = userEvent.setup();
+      render(<Radiobutton label="Strength" value="strength" />);
+      await user.tab();
+      expect(screen.getByRole('radio')).toHaveFocus();
+    });
+  });
+});

--- a/src/presentation/modules/form/components/Radiobutton.tsx
+++ b/src/presentation/modules/form/components/Radiobutton.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { twMerge } from 'tailwind-merge';
+import type { HTMLInputProps } from '@/presentation/modules/form/form.types';
 
 function RadiobuttonMark({ isChecked }: { isChecked: boolean }) {
   const borderColor = isChecked ? 'outline-bd-strong' : 'outline-bd-default';
@@ -14,12 +15,10 @@ function RadiobuttonMark({ isChecked }: { isChecked: boolean }) {
   );
 }
 
-type RadiobuttonProps = {
-  className?: string;
+type RadiobuttonProps = HTMLInputProps & {
   label: string;
   value: string;
   checked?: boolean;
-  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 };
 export function Radiobutton({
   className = '',
@@ -29,28 +28,27 @@ export function Radiobutton({
   onChange,
   ...props
 }: RadiobuttonProps) {
-  const [isChecked, setIsChecked] = useState(checked);
-
-  const labelCheckedClass = isChecked ? 'outline-subtle/50' : 'text-default/50 outline-subtle/20';
-
-  useEffect(() => {
-    if (checked !== isChecked) setIsChecked(checked);
-  }, [checked, isChecked]);
-
   return (
-    <label
-      className={`flex h-10 items-center gap-2 rounded px-2 py-1 outline transition-colors ${labelCheckedClass} ${className}`}
-    >
-      <RadiobuttonMark isChecked={isChecked} />
+    <label className="relative">
       <input
-        checked={isChecked}
+        checked={checked}
         type="radio"
         value={value}
         onChange={onChange}
-        className="hidden"
+        className="peer absolute size-0 opacity-0"
         {...props}
+        readOnly
       />
-      <span>{label}</span>
+      <div
+        className={twMerge(
+          'outline-focus flex h-10 items-center gap-2 rounded px-2 py-1 transition-colors peer-focus:outline-2',
+          checked ? '' : 'text-default/50',
+          className
+        )}
+      >
+        <RadiobuttonMark isChecked={checked} />
+        {label}
+      </div>
     </label>
   );
 }

--- a/src/presentation/modules/form/components/RadiobuttonGroup.test.tsx
+++ b/src/presentation/modules/form/components/RadiobuttonGroup.test.tsx
@@ -18,7 +18,7 @@ const options = [
   },
 ];
 
-describe('<Radiobutton />', () => {
+describe('<RadiobuttonGroup />', () => {
   describe('Basic Rendering', () => {
     it('Should be rendered with minimum props', () => {
       render(<RadiobuttonGroup options={[]} />);

--- a/src/presentation/modules/form/components/RadiobuttonGroup.test.tsx
+++ b/src/presentation/modules/form/components/RadiobuttonGroup.test.tsx
@@ -1,0 +1,83 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { RadiobuttonGroup } from '@/presentation/modules/form/components/RadiobuttonGroup';
+import userEvent from '@testing-library/user-event';
+
+const options = [
+  {
+    label: 'Strength',
+    value: 'strength',
+  },
+  {
+    label: 'Health',
+    value: 'health',
+  },
+  {
+    label: 'Hypertrophy',
+    value: 'hypertrophy',
+  },
+];
+
+describe('<Radiobutton />', () => {
+  describe('Basic Rendering', () => {
+    it('Should be rendered with minimum props', () => {
+      render(<RadiobuttonGroup options={[]} />);
+      expect(screen.getByRole('radiogroup')).toBeInTheDocument();
+    });
+
+    it('Should render radio input elements when at least one option provided', () => {
+      render(<RadiobuttonGroup options={[options[0]]} />);
+      expect(screen.getByRole('radiogroup')).toBeInTheDocument();
+      expect(screen.getByRole('radio')).toBeInTheDocument();
+    });
+  });
+
+  describe('Integration with Props', () => {
+    it('Should render {n} radio input elements when {n} options provided', () => {
+      render(<RadiobuttonGroup options={options} />);
+      expect(screen.getByRole('radiogroup')).toBeInTheDocument();
+      const radios = screen.getAllByRole('radio');
+      expect(radios.length).toBe(options.length);
+    });
+
+    it('Should render a radio input element with "Strength" label text when is provided by options prop', () => {
+      render(<RadiobuttonGroup options={[options[0]]} />);
+      expect(screen.getByRole('radio', { name: /strength/i })).toBeInTheDocument();
+    });
+
+    it('Should have radio input checked when its value is provided by checked prop', () => {
+      render(<RadiobuttonGroup options={options} checked="health" />);
+      expect(screen.getByRole('radio', { name: /health/i })).toBeChecked();
+    });
+
+    it('Should update radio input elements on options updating when rerendered', () => {
+      const { rerender } = render(<RadiobuttonGroup options={[]} />);
+      expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+      rerender(<RadiobuttonGroup options={options} checked="health" />);
+      expect(screen.getByRole('radio', { name: /health/i })).toBeInTheDocument();
+      rerender(<RadiobuttonGroup options={[options[0], options[2]]} checked="strength" />);
+      expect(screen.queryByRole('radio', { name: /health/i })).not.toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: /strength/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('User Interactions', () => {
+    it('Should trigger onChange callback when clicked', async () => {
+      const fn = jest.fn();
+      const user = userEvent.setup();
+      const handleChange = (_e: React.ChangeEvent<HTMLInputElement>) => fn();
+      render(<RadiobuttonGroup options={options} onChange={handleChange} />);
+      await user.click(screen.getByRole('radio', { name: /health/i }));
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('Should support keyboard navigation (focus)', async () => {
+      const user = userEvent.setup();
+      render(<RadiobuttonGroup options={options} />);
+      await user.tab();
+      expect(screen.getByRole('radio', { name: /strength/i })).toHaveFocus();
+    });
+  });
+});

--- a/src/presentation/modules/form/components/RadiobuttonGroup.tsx
+++ b/src/presentation/modules/form/components/RadiobuttonGroup.tsx
@@ -32,7 +32,7 @@ export function RadiobuttonGroup({
 
   return (
     <>
-      <div className={`${className}`}>
+      <div className={`${className}`} role="radiogroup">
         {options.map((option) => (
           <Radiobutton
             key={option.value}

--- a/src/presentation/modules/form/components/SelectBoxOption.test.tsx
+++ b/src/presentation/modules/form/components/SelectBoxOption.test.tsx
@@ -1,0 +1,85 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { SelectBoxOption } from '@/presentation/modules/form/components/SelectBoxOption';
+import userEvent from '@testing-library/user-event';
+
+const options = [
+  {
+    label: 'Strength',
+    value: 'strength',
+  },
+  {
+    label: 'Health',
+    value: 'health',
+  },
+  {
+    label: 'Hypertrophy',
+    value: 'hypertrophy',
+  },
+];
+
+describe('<SelectBoxOption />', () => {
+  describe('Basic Rendering', () => {
+    it('Should be rendered with minimum props', () => {
+      render(<SelectBoxOption onSelect={() => {}} option={options[0]} />);
+      expect(screen.getByLabelText(options[0].label)).toBeInTheDocument();
+    });
+  });
+
+  describe('Integration with Props', () => {
+    it('Should have radio input checked when isSelected prop provided as "true" ', () => {
+      render(<SelectBoxOption onSelect={() => {}} option={options[0]} isSelected />);
+      expect(screen.getByRole('checkbox')).toBeChecked();
+    });
+
+    it('Should not have radio input checked when isSelected prop is not provided (false)', () => {
+      render(<SelectBoxOption onSelect={() => {}} option={options[0]} />);
+      expect(screen.getByRole('checkbox')).not.toBeChecked();
+    });
+
+    it('Should update input check when rerendered', () => {
+      const { rerender } = render(<SelectBoxOption onSelect={() => {}} option={options[0]} />);
+      expect(screen.getByRole('checkbox')).not.toBeChecked();
+      rerender(<SelectBoxOption onSelect={() => {}} option={options[0]} isSelected />);
+      expect(screen.getByRole('checkbox')).toBeChecked();
+    });
+
+    it('Should update checkbox by option prop when rerendered', () => {
+      const { rerender } = render(<SelectBoxOption onSelect={() => {}} option={options[0]} />);
+      expect(screen.getByRole('checkbox', { name: /strength/i })).toBeInTheDocument();
+      rerender(<SelectBoxOption onSelect={() => {}} option={options[1]} />);
+      expect(screen.queryByRole('checkbox', { name: /strength/i })).not.toBeInTheDocument();
+      expect(screen.getByRole('checkbox', { name: /health/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('User Interactions', () => {
+    it('Should trigger onChange (onSelect) callback when clicked', async () => {
+      const fn = jest.fn();
+      const user = userEvent.setup();
+      const handleChange = (_v: string) => fn();
+      render(<SelectBoxOption onSelect={handleChange} option={options[0]} />);
+      await user.click(screen.getByLabelText(options[0].label));
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('Should support keyboard navigation (focus)', async () => {
+      const user = userEvent.setup();
+      render(<SelectBoxOption onSelect={() => {}} option={options[0]} />);
+      await user.tab();
+      expect(screen.getByRole('checkbox', { name: /strength/i })).toHaveFocus();
+    });
+
+    it('Should be highlighted when isSelected prop is "true"', async () => {
+      render(<SelectBoxOption onSelect={() => {}} option={options[0]} isSelected />);
+      expect(screen.getByText(options[0].label)).toHaveClass('border-complete');
+    });
+
+    it('Should not be highlighted when isSelected prop is not provided or as "false"', () => {
+      render(<SelectBoxOption onSelect={() => {}} option={options[0]} />);
+      expect(screen.getByText(options[0].label)).toHaveClass('border-subtle/20');
+    });
+  });
+});

--- a/src/presentation/modules/form/components/SelectBoxOption.tsx
+++ b/src/presentation/modules/form/components/SelectBoxOption.tsx
@@ -1,4 +1,5 @@
 import type { SelectOption } from '@/presentation/modules/form/form.types';
+import { twMerge } from 'tailwind-merge';
 
 export function SelectBoxOption({
   option,
@@ -13,11 +14,22 @@ export function SelectBoxOption({
     ? 'border-complete fg-complete font-medium light:fg-green-700 light:border-green-600'
     : 'border-subtle/20';
   return (
-    <label
-      className={`bg-middle hover:border-complete hover:fg-complete light:hover:fg-green-900 w-fit cursor-pointer rounded-lg border px-3 py-1 ${isActiveClass}`}
-    >
-      <span className="text-sm">{option.label}</span>
-      <input className="hidden" type="checkbox" onChange={() => onSelect(option.value)} />
+    <label className="relative">
+      <input
+        type="checkbox"
+        checked={isSelected}
+        onChange={() => onSelect(option.value)}
+        className="peer absolute size-0 opacity-0"
+        readOnly
+      />
+      <div
+        className={twMerge(
+          'outline-focus bg-middle hover:border-complete hover:fg-complete light:hover:fg-green-900 w-fit cursor-pointer rounded-lg border px-3 py-1 text-sm peer-focus:outline-2',
+          isActiveClass
+        )}
+      >
+        {option.label}
+      </div>
     </label>
   );
 }

--- a/src/presentation/modules/form/form.types.d.ts
+++ b/src/presentation/modules/form/form.types.d.ts
@@ -1,6 +1,8 @@
 import type { FieldArrayWithId } from 'react-hook-form';
 
-export type InputTextProps = React.InputHTMLAttributes<HTMLInputElement> & {
+export type HTMLInputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export type InputTextProps = InputProps & {
   error?: string;
   value?: string;
 };


### PR DESCRIPTION
## Summary
Add new focus color variable to standard focus color for navigable elements in the UI

## Changes
- Add static focus color for light theme
- Add static focus color for dark theme
- Add adaptable focus color to change between light-dark variants dynamically