### PR TITLE
feat(form): add component unit tests

### DIFF
--- a/src/presentation/globals/presentation.types.d.ts
+++ b/src/presentation/globals/presentation.types.d.ts
@@ -39,5 +39,8 @@ export type AtomicElement = 'div' | 'span' | 'button' | 'li' | 'a';
 
 export type DivProps = React.ComponentPropsWithRef<'div'>;
 
-export type ButtonElementProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+export type ButtonElementProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  ref?: React.RefObject;
+};
+export type ButtonElementPropsWithRef = React.RefObject<ButtonElementProps>;
 export type AnchorElementProps = React.AnchorHTMLAttributes<HTMLAnchorElement>;

--- a/src/presentation/modules/form/components/MultipleSelectBox.tsx
+++ b/src/presentation/modules/form/components/MultipleSelectBox.tsx
@@ -88,20 +88,12 @@ export function MultipleSelectBox<TForm extends FieldValues, TName extends Field
             ))}
           </main>
           <aside className="flex flex-col items-center justify-between gap-2">
-            <button
-              type="button"
-              className="bg-middle border-bd-default fg-strong hover:bg-back block aspect-square size-fit cursor-pointer rounded border p-1 transition-colors"
-              onClick={openSelection}
-            >
+            <Button onClick={openSelection} variantConfig={{ type: 'square', color: 'subtle' }}>
               <IconCirclePlus strokeWidth="1" />
-            </button>
-            <button
-              type="button"
-              className="bg-middle border-bd-default fg-strong hover:bg-back block aspect-square size-fit cursor-pointer rounded border p-1 transition-colors"
-              onClick={clearAllItems}
-            >
+            </Button>
+            <Button onClick={clearAllItems} variantConfig={{ type: 'square', color: 'subtle' }}>
               <IconTrash strokeWidth="1" />
-            </button>
+            </Button>
           </aside>
         </Box>
         <ErrorMessage message={error} />

--- a/src/presentation/modules/form/components/MultipleSelectBox.tsx
+++ b/src/presentation/modules/form/components/MultipleSelectBox.tsx
@@ -88,10 +88,18 @@ export function MultipleSelectBox<TForm extends FieldValues, TName extends Field
             ))}
           </main>
           <aside className="flex flex-col items-center justify-between gap-2">
-            <Button onClick={openSelection} variantConfig={{ type: 'square', color: 'subtle' }}>
+            <Button
+              onClick={openSelection}
+              variantConfig={{ type: 'square', color: 'subtle' }}
+              aria-label="Add new element"
+            >
               <IconCirclePlus strokeWidth="1" />
             </Button>
-            <Button onClick={clearAllItems} variantConfig={{ type: 'square', color: 'subtle' }}>
+            <Button
+              onClick={clearAllItems}
+              variantConfig={{ type: 'square', color: 'subtle' }}
+              aria-label="Clear all elements"
+            >
               <IconTrash strokeWidth="1" />
             </Button>
           </aside>

--- a/src/presentation/modules/form/components/SortableInputItem.test.tsx
+++ b/src/presentation/modules/form/components/SortableInputItem.test.tsx
@@ -1,0 +1,110 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { SortableInputItem } from '@/presentation/modules/form/components/SortableInputItem';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('@dnd-kit/react/sortable', () => ({
+  SortableContext: ({ children }: any) => children,
+
+  useSortable: ({ id }: any) => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: jest.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+    id,
+  }),
+
+  arrayMove: (arr: any[], from: number, to: number) => {
+    const copy = [...arr];
+    const [item] = copy.splice(from, 1);
+    copy.splice(to, 0, item);
+    return copy;
+  },
+}));
+
+const options = [
+  {
+    label: 'Strength',
+    value: 'strength',
+  },
+  {
+    label: 'Health',
+    value: 'health',
+  },
+];
+
+const testId = 'sortable-item';
+
+describe('<SortableInputItem />', () => {
+  describe('Basic Rendering', () => {
+    it('Should be rendered with minimum props', () => {
+      render(<SortableInputItem index={0} item={options[0]} onRemoveOption={() => {}} />);
+      expect(screen.getByTestId(testId)).toBeInTheDocument();
+    });
+
+    it('Should have button drag item', () => {
+      render(<SortableInputItem index={0} item={options[0]} onRemoveOption={() => {}} />);
+      expect(screen.getByRole('button', { name: /drag item/i })).toBeInTheDocument();
+    });
+
+    it('Should have button to remove item', () => {
+      render(<SortableInputItem index={0} item={options[0]} onRemoveOption={() => {}} />);
+      expect(screen.getByRole('button', { name: /remove item/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('Integration with Props', () => {
+    it('Should have text when provided in item prop label', () => {
+      render(<SortableInputItem index={0} item={options[0]} onRemoveOption={() => {}} />);
+      expect(screen.getByText(options[0].label)).toBeInTheDocument();
+    });
+
+    it('Should have number {n + 1} when n is provided by index prop', () => {
+      render(<SortableInputItem index={0} item={options[0]} onRemoveOption={() => {}} />);
+      expect(screen.getByText('1')).toBeInTheDocument();
+    });
+
+    it('Should update text when rerendered', () => {
+      const { rerender } = render(
+        <SortableInputItem index={0} item={options[0]} onRemoveOption={() => {}} />
+      );
+      expect(screen.getByText(options[0].label)).toBeInTheDocument();
+      rerender(<SortableInputItem index={0} item={options[1]} onRemoveOption={() => {}} />);
+      expect(screen.queryByText(options[0].label)).not.toBeInTheDocument();
+      expect(screen.getByText(options[1].label)).toBeInTheDocument();
+    });
+
+    it('Should update number when rerendered', () => {
+      const { rerender } = render(
+        <SortableInputItem index={0} item={options[0]} onRemoveOption={() => {}} />
+      );
+      expect(screen.getByText('1')).toBeInTheDocument();
+      rerender(<SortableInputItem index={1} item={options[0]} onRemoveOption={() => {}} />);
+      expect(screen.queryByText('1')).not.toBeInTheDocument();
+      expect(screen.getByText('2')).toBeInTheDocument();
+    });
+  });
+
+  describe('User Interactions', () => {
+    it('Should trigger onRemove callback when remove item button clicked', async () => {
+      const fn = jest.fn();
+      const user = userEvent.setup();
+      render(<SortableInputItem index={0} item={options[0]} onRemoveOption={fn} />);
+      await user.click(screen.getByRole('button', { name: /remove item/i }));
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('Should support keyboard navigation (focus)', async () => {
+      const user = userEvent.setup();
+      render(<SortableInputItem index={0} item={options[0]} onRemoveOption={() => {}} />);
+      await user.tab();
+      expect(screen.getByRole('button', { name: /drag item/i })).toHaveFocus();
+      await user.tab();
+      expect(screen.getByRole('button', { name: /remove item/i })).toHaveFocus();
+    });
+  });
+});

--- a/src/presentation/modules/form/components/SortableInputItem.tsx
+++ b/src/presentation/modules/form/components/SortableInputItem.tsx
@@ -1,6 +1,7 @@
 import { useSortable } from '@dnd-kit/react/sortable';
 import { IconGripVertical } from '@/presentation/globals/components/icons/outline/IconGripVertical';
 import { IconTrash } from '@/presentation/globals/components/icons/outline/IconTrash';
+import { Button } from '@/presentation/modules/button/components/Button';
 import type { SelectOption } from '@/presentation/modules/form/form.types';
 
 type Props = {
@@ -24,23 +25,24 @@ export function SortableInputItem({ item, index, onRemoveOption }: Props) {
       ref={ref}
     >
       <div className="flex w-full items-center">
-        <button
-          type="button"
-          className="flex aspect-square w-8 cursor-pointer items-center justify-center"
+        <Button
+          variantConfig={{ type: 'square', color: 'simple' }}
+          className="cursor-grab"
           ref={handleRef}
+          aria-label="Drag item"
         >
           <IconGripVertical className="size-5" />
-        </button>
+        </Button>
         <span className="px-2 text-sm">{index + 1}</span>
         <div>{item.label}</div>
       </div>
-      <button
-        type="button"
+      <Button
+        variantConfig={{ type: 'square', color: 'simple' }}
         onClick={handleRemoveOption}
-        className="flex aspect-square size-8 cursor-pointer items-center justify-center hover:text-current/50"
+        aria-label="Remove item"
       >
         <IconTrash className="size-5" />
-      </button>
+      </Button>
     </div>
   );
 }

--- a/src/presentation/modules/form/components/SortableInputItem.tsx
+++ b/src/presentation/modules/form/components/SortableInputItem.tsx
@@ -23,6 +23,7 @@ export function SortableInputItem({ item, index, onRemoveOption }: Props) {
     <div
       className="bg-middle flex min-h-10 w-full items-center gap-2 rounded-lg py-1 pr-3 pl-1"
       ref={ref}
+      data-testid="sortable-item"
     >
       <div className="flex w-full items-center">
         <Button


### PR DESCRIPTION
## Summary
Add unit tests for the rest of form components with simple logic. The mentioned components include:
- SortableInputItem

## Changes
- Add correspondent unit test mocking `@dnd-kit/react/sortable` dependency. testing:
- - Basic rendering
- - Integration with props
- - User interactions
- - Accessibility