### PR TITLE
refactor(styles): update style colors and spacing

### DIFF
--- a/src/app/dashboard/(routine)/exercises/page.tsx
+++ b/src/app/dashboard/(routine)/exercises/page.tsx
@@ -15,11 +15,10 @@ export default async function ExercisesPage() {
     <PageContainer>
       <PageHeader title="Exercises" className="flex items-center justify-between">
         <Link
-          variantConfig={{ color: 'primary' }}
+          variant={{ color: 'primary', type: 'iconText' }}
           href="/dashboard/exercises/create"
-          className="gap-1 pl-3"
+          Icon={IconPlus}
         >
-          <IconPlus className="size-5" strokeWidth="2" />
           Add Exercise
         </Link>
       </PageHeader>

--- a/src/app/dashboard/(routine)/routines/[id]/page.tsx
+++ b/src/app/dashboard/(routine)/routines/[id]/page.tsx
@@ -11,7 +11,7 @@ export default function RoutinesPage() {
   return (
     <PageContainer>
       <PageHeader title={id} className="flex items-center justify-between">
-        <Link href={`/dashboard/routines/${id}/add-session`} variantConfig={{ color: 'primary' }}>
+        <Link href={`/dashboard/routines/${id}/add-session`} variant={{ color: 'primary' }}>
           Add Session
         </Link>
       </PageHeader>

--- a/src/app/dashboard/(routine)/routines/page.tsx
+++ b/src/app/dashboard/(routine)/routines/page.tsx
@@ -18,11 +18,10 @@ export default async function RoutinesPage() {
         description="Create and manage your routines to automate tasks and workflows."
       >
         <Link
-          variantConfig={{ color: 'primary' }}
+          variant={{ color: 'primary', type: 'iconText' }}
+          Icon={IconPlus}
           href="/dashboard/routines/create"
-          className="gap-1 pl-3"
         >
-          <IconPlus className="size-5" strokeWidth="2" />
           Add Routine
         </Link>
       </PageHeader>

--- a/src/app/dashboard/(routine)/sessions/[id]/page.tsx
+++ b/src/app/dashboard/(routine)/sessions/[id]/page.tsx
@@ -5,13 +5,18 @@ import { PageContainer } from '@/presentation/modules/dashboard/components/page/
 import { PageContent } from '@/presentation/modules/dashboard/components/page/PageContent';
 import { PageHeader } from '@/presentation/modules/dashboard/components/page/PageHeader';
 import { Link } from '@/presentation/modules/button/components/Link';
+import { IconPlus } from '@/presentation/globals/components/icons/outline/IconPlus';
 
 export default function RoutinesPage() {
   const id = useParams().id as string;
   return (
     <PageContainer>
       <PageHeader title={id} className="flex items-center justify-between">
-        <Link href={`/dashboard/sessions/${id}/add-exercise`} variantConfig={{ color: 'primary' }}>
+        <Link
+          href={`/dashboard/sessions/${id}/add-exercise`}
+          variant={{ color: 'primary', type: 'iconText' }}
+          Icon={IconPlus}
+        >
           Add Exercises
         </Link>
       </PageHeader>

--- a/src/app/dashboard/(routine)/sessions/page.tsx
+++ b/src/app/dashboard/(routine)/sessions/page.tsx
@@ -13,11 +13,10 @@ export default async function SessionsPage() {
     <PageContainer>
       <PageHeader title="Sessions" description="Manage your days planifications" className="">
         <Link
-          variantConfig={{ color: 'primary' }}
+          variant={{ color: 'primary', type: 'iconText' }}
+          Icon={IconPlus}
           href="/dashboard/sessions/create"
-          className="gap-1 pl-3"
         >
-          <IconPlus className="size-5" strokeWidth="2" />
           Add Session
         </Link>
       </PageHeader>

--- a/src/app/dashboard/muscles/page.tsx
+++ b/src/app/dashboard/muscles/page.tsx
@@ -42,7 +42,7 @@ export default async function MuscularGroupsPage() {
           <BodySectionCards sections={bodySections} />
         </section>
         <div>
-          <h2 className="fg-strong text-2xl font-medium">Muscular Groups</h2>
+          <h2 className="text-strong text-2xl font-medium">Muscular Groups</h2>
         </div>
         <section>
           <MuscularGroupsTable muscles={muscles} />

--- a/src/app/dashboard/muscles/page.tsx
+++ b/src/app/dashboard/muscles/page.tsx
@@ -42,7 +42,7 @@ export default async function MuscularGroupsPage() {
           <BodySectionCards sections={bodySections} />
         </section>
         <div>
-          <h2 className="text-strong text-2xl font-medium">Muscular Groups</h2>
+          <h2 className="text-fg-strong text-2xl font-medium">Muscular Groups</h2>
         </div>
         <section>
           <MuscularGroupsTable muscles={muscles} />

--- a/src/app/dev/buttons/components/DevButtons.tsx
+++ b/src/app/dev/buttons/components/DevButtons.tsx
@@ -12,8 +12,8 @@ export function DevButtons({ className, colors }: Props) {
   return (
     <div className={className}>
       {colors.map((color) => (
-        <div key={color} className="bg-middle w-fit space-y-4 p-8">
-          <header className="fg-strong font-funnel-display text-2xl font-medium">
+        <div key={color} className="bg-base w-fit space-y-4 p-8">
+          <header className="text-strong font-funnel-display text-2xl font-medium">
             {color?.toUpperCase()}
           </header>
           <main className="flex items-start gap-2 *:space-y-4">

--- a/src/app/dev/buttons/components/DevButtons.tsx
+++ b/src/app/dev/buttons/components/DevButtons.tsx
@@ -12,7 +12,7 @@ export function DevButtons({ className, colors }: Props) {
   return (
     <div className={className}>
       {colors.map((color) => (
-        <div key={color} className="bg-base w-fit space-y-4 p-8">
+        <div key={color} className="bg-fill-base w-fit space-y-4 p-8">
           <header className="text-strong font-funnel-display text-2xl font-medium">
             {color?.toUpperCase()}
           </header>

--- a/src/app/dev/buttons/components/DevButtons.tsx
+++ b/src/app/dev/buttons/components/DevButtons.tsx
@@ -13,7 +13,7 @@ export function DevButtons({ className, colors }: Props) {
     <div className={className}>
       {colors.map((color) => (
         <div key={color} className="bg-fill-base w-fit space-y-4 p-8">
-          <header className="text-strong font-funnel-display text-2xl font-medium">
+          <header className="text-fg-strong font-funnel-display text-2xl font-medium">
             {color?.toUpperCase()}
           </header>
           <main className="flex items-start gap-2 *:space-y-4">

--- a/src/app/dev/buttons/components/DevButtons.tsx
+++ b/src/app/dev/buttons/components/DevButtons.tsx
@@ -1,6 +1,6 @@
 import { IconRocket } from '@/presentation/globals/components/icons/outline/IconRocket';
 import type { ButtonVariantProps } from '@/presentation/modules/button/button.config';
-import { Link } from '@/presentation/modules/button/components/Link';
+import { Button } from '@/presentation/modules/button/components/Button';
 
 type Props = {
   colors: ButtonVariantProps['color'][];
@@ -18,12 +18,22 @@ export function DevButtons({ className, colors }: Props) {
           </header>
           <main className="flex items-start gap-2 *:space-y-4">
             <div>
-              <p>Normal</p>
-              <AllButtonSizes type="normal" color={color} />
+              <p>Icon Text</p>
+              <AllButtonSizes variant={{ color, type: 'iconText' }} Icon={IconRocket}>
+                Button
+              </AllButtonSizes>
             </div>
             <div>
-              <p>Thin</p>
-              <AllButtonSizes type="square" color={color} />
+              <p>Text</p>
+              <AllButtonSizes variant={{ color, type: 'text' }}>Button</AllButtonSizes>
+            </div>
+            <div>
+              <p>Icon</p>
+              <AllButtonSizes
+                variant={{ color, type: 'icon' }}
+                Icon={IconRocket}
+                aria-label="Launch"
+              />
             </div>
           </main>
         </div>
@@ -32,27 +42,13 @@ export function DevButtons({ className, colors }: Props) {
   );
 }
 
-function AllButtonSizes({
-  color,
-  type,
-}: {
-  color: ButtonVariantProps['color'];
-  type?: ButtonVariantProps['type'];
-}) {
+function AllButtonSizes(props: React.ComponentProps<typeof Button>) {
   return (
     <div className="space-y-2">
-      <Link href="#" variantConfig={{ size: 'xs', color, type }}>
-        {type === 'normal' ? 'Button XS' : <IconRocket />}
-      </Link>
-      <Link href="#" variantConfig={{ size: 'sm', color, type }}>
-        {type === 'normal' ? 'Button SM' : <IconRocket />}
-      </Link>
-      <Link href="#" variantConfig={{ size: 'md', color, type }}>
-        {type === 'normal' ? 'Button MD' : <IconRocket />}
-      </Link>
-      <Link href="#" variantConfig={{ size: 'lg', color, type }}>
-        {type === 'normal' ? 'Button LG' : <IconRocket className="size-6" />}
-      </Link>
+      <Button {...props} variantConfig={{ ...props.variant, size: 'lg' }} />
+      <Button {...props} variantConfig={{ ...props.variant, size: 'md' }} />
+      <Button {...props} variantConfig={{ ...props.variant, size: 'sm' }} />
+      <Button {...props} variantConfig={{ ...props.variant, size: 'xs' }} />
     </div>
   );
 }

--- a/src/app/dev/buttons/components/DevButtons.tsx
+++ b/src/app/dev/buttons/components/DevButtons.tsx
@@ -45,10 +45,10 @@ export function DevButtons({ className, colors }: Props) {
 function AllButtonSizes(props: React.ComponentProps<typeof Button>) {
   return (
     <div className="space-y-2">
-      <Button {...props} variantConfig={{ ...props.variant, size: 'lg' }} />
-      <Button {...props} variantConfig={{ ...props.variant, size: 'md' }} />
-      <Button {...props} variantConfig={{ ...props.variant, size: 'sm' }} />
-      <Button {...props} variantConfig={{ ...props.variant, size: 'xs' }} />
+      <Button {...props} variant={{ ...props.variant, size: 'lg' }} />
+      <Button {...props} variant={{ ...props.variant, size: 'md' }} />
+      <Button {...props} variant={{ ...props.variant, size: 'sm' }} />
+      <Button {...props} variant={{ ...props.variant, size: 'xs' }} />
     </div>
   );
 }

--- a/src/app/dev/buttons/page.tsx
+++ b/src/app/dev/buttons/page.tsx
@@ -6,7 +6,7 @@ export default function ButtonsPage() {
     <div>
       <Link href="/dev">Back</Link>
       <DevButtons
-        colors={['primary', 'primaryDeluxe', 'simple', 'subtle']}
+        colors={['primary', 'subtle', 'simple']}
         className="flex flex-wrap items-start gap-4"
       />
     </div>

--- a/src/app/dev/buttons/page.tsx
+++ b/src/app/dev/buttons/page.tsx
@@ -6,7 +6,7 @@ export default function ButtonsPage() {
     <div>
       <Link href="/dev">Back</Link>
       <DevButtons
-        colors={['primary', 'subtle', 'simple']}
+        colors={['primary', 'subtle', 'outline', 'simple']}
         className="flex flex-wrap items-start gap-4"
       />
     </div>

--- a/src/app/dev/buttons/page.tsx
+++ b/src/app/dev/buttons/page.tsx
@@ -6,7 +6,7 @@ export default function ButtonsPage() {
     <div>
       <Link href="/dev">Back</Link>
       <DevButtons
-        colors={['primary', 'subtle', 'outline', 'simple']}
+        colors={['primary', 'subtle', 'outline', 'simple', 'danger']}
         className="flex flex-wrap items-start gap-4"
       />
     </div>

--- a/src/app/dev/card/page.tsx
+++ b/src/app/dev/card/page.tsx
@@ -12,17 +12,17 @@ export default function DevCardPage() {
       <Link href="/dev">Back</Link>
       <div className="space-y-8">
         <section className="space-y-4">
-          <h2 className="fg-strong text-4xl">Sizes</h2>
+          <h2 className="text-strong text-4xl">Sizes</h2>
           <DevCardSizes className="flex items-center gap-8" />
         </section>
 
         <section className="space-y-4">
-          <h2 className="fg-strong text-4xl">Colors</h2>
+          <h2 className="text-strong text-4xl">Colors</h2>
           <DevCardColors className="flex items-center gap-8" />
         </section>
 
         <section className="space-y-4">
-          <h2 className="fg-strong text-4xl">Types</h2>
+          <h2 className="text-strong text-4xl">Types</h2>
           <main className="flex items-center gap-8">
             <Card className="h-50 space-y-4" width="md">
               <CardHeader>
@@ -41,7 +41,7 @@ export default function DevCardPage() {
         </section>
 
         <section className="space-y-4">
-          <h2 className="fg-strong text-4xl">Highlighted Borders</h2>
+          <h2 className="text-strong text-4xl">Highlighted Borders</h2>
           <DevCardColors border="highlighted" className="flex items-center gap-8" />
         </section>
       </div>

--- a/src/app/dev/card/page.tsx
+++ b/src/app/dev/card/page.tsx
@@ -12,17 +12,17 @@ export default function DevCardPage() {
       <Link href="/dev">Back</Link>
       <div className="space-y-8">
         <section className="space-y-4">
-          <h2 className="text-strong text-4xl">Sizes</h2>
+          <h2 className="text-fg-strong text-4xl">Sizes</h2>
           <DevCardSizes className="flex items-center gap-8" />
         </section>
 
         <section className="space-y-4">
-          <h2 className="text-strong text-4xl">Colors</h2>
+          <h2 className="text-fg-strong text-4xl">Colors</h2>
           <DevCardColors className="flex items-center gap-8" />
         </section>
 
         <section className="space-y-4">
-          <h2 className="text-strong text-4xl">Types</h2>
+          <h2 className="text-fg-strong text-4xl">Types</h2>
           <main className="flex items-center gap-8">
             <Card className="h-50 space-y-4" width="md">
               <CardHeader>
@@ -41,7 +41,7 @@ export default function DevCardPage() {
         </section>
 
         <section className="space-y-4">
-          <h2 className="text-strong text-4xl">Highlighted Borders</h2>
+          <h2 className="text-fg-strong text-4xl">Highlighted Borders</h2>
           <DevCardColors border="highlighted" className="flex items-center gap-8" />
         </section>
       </div>

--- a/src/app/dev/colors/page.tsx
+++ b/src/app/dev/colors/page.tsx
@@ -1,0 +1,88 @@
+import { Link } from '@/presentation/modules/button/components/Link';
+
+function SectionHeading({ text }: { text: string }) {
+  return <h3 className="text-strong font-funnel-display text-2xl">{text}</h3>;
+}
+
+export default function ColorsPage() {
+  return (
+    <div>
+      <Link href="/dev">Back</Link>
+      <div className="mt-8 space-y-8">
+        <div className="grid grid-cols-[156px_1fr] items-center">
+          <SectionHeading text="Brand" />
+          <ul className="flex items-center gap-4">
+            <li className="text-primary flex items-center gap-2 rounded p-2">
+              <div className="bg-primary size-8 rounded-full"></div>
+              Primary
+            </li>
+            <li className="text-secondary flex items-center gap-2 rounded p-2">
+              <div className="bg-secondary size-8 rounded-full"></div>
+              Secondary
+            </li>
+            <li className="text-tertiary flex items-center gap-2 rounded p-2">
+              <div className="bg-tertiary size-8 rounded-full"></div>
+              Tertiary
+            </li>
+            <li className="text-accent flex items-center gap-2 rounded p-2">
+              <div className="bg-accent size-8 rounded-full"></div>
+              Accent
+            </li>
+          </ul>
+        </div>
+
+        <div className="grid grid-cols-[156px_1fr] items-center">
+          <SectionHeading text="Text" />
+          <ul className="flex items-center justify-start gap-8">
+            <li className="text-strong">Strong</li>
+            <li className="text-default">Default</li>
+            <li className="text-muted">Muted</li>
+          </ul>
+        </div>
+
+        <div className="grid grid-cols-[156px_1fr] items-center">
+          <SectionHeading text="Fill" />
+          <ul className="flex items-center justify-start gap-8">
+            <li className="bg-front rounded p-2">Front</li>
+            <li className="bg-base rounded p-2">Middle</li>
+            <li className="bg-back rounded p-2">Back</li>
+          </ul>
+        </div>
+
+        <div className="grid grid-cols-[156px_1fr] items-center">
+          <SectionHeading text="Border" />
+          <ul className="flex items-center justify-start gap-8 *:border">
+            <li className="border-bd-strong rounded p-2">Strong</li>
+            <li className="border-bd-default rounded p-2">Default</li>
+            <li className="border-bd-muted rounded p-2">Muted</li>
+          </ul>
+        </div>
+
+        <div className="grid grid-cols-[156px_1fr] items-center">
+          <SectionHeading text="Status" />
+          <ul className="flex items-center justify-start gap-8">
+            <li className="text-complete flex items-center gap-2 rounded p-2">
+              <div className="bg-complete size-8 rounded-full"></div>
+              Complete
+            </li>
+            <li className="text-cancel flex items-center gap-2 rounded p-2">
+              <div className="bg-cancel size-8 rounded-full"></div>
+              Cancel
+            </li>
+            <li className="text-unread flex items-center gap-2 rounded p-2">
+              <div className="bg-unread size-8 rounded-full"></div>
+              Unread
+            </li>
+          </ul>
+        </div>
+
+        <div className="grid grid-cols-[156px_1fr] items-center">
+          <SectionHeading text="Accessibility" />
+          <ul className="flex items-center justify-start gap-8">
+            <li className="outline-focus rounded-full px-4 py-2 outline-2">Focus</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dev/colors/page.tsx
+++ b/src/app/dev/colors/page.tsx
@@ -60,18 +60,22 @@ export default function ColorsPage() {
 
         <div className="grid grid-cols-[156px_1fr] items-center">
           <SectionHeading text="Status" />
-          <ul className="flex items-center justify-start gap-8">
-            <li className="text-complete flex items-center gap-2 rounded p-2">
-              <div className="bg-complete size-8 rounded-full"></div>
+          <ul className="flex items-center justify-start gap-8 rounded-full *:px-4 *:py-2">
+            <li className="border-success-bd bg-success-fill text-success flex items-center gap-2 rounded border">
+              <div className="bg-success size-8 rounded-full"></div>
               Complete
             </li>
-            <li className="text-cancel flex items-center gap-2 rounded p-2">
-              <div className="bg-cancel size-8 rounded-full"></div>
+            <li className="border-danger-bd bg-danger-fill text-danger flex items-center gap-2 rounded border">
+              <div className="bg-danger size-8 rounded-full"></div>
               Cancel
             </li>
-            <li className="text-unread flex items-center gap-2 rounded p-2">
-              <div className="bg-unread size-8 rounded-full"></div>
+            <li className="border-info-bd bg-info-fill text-info flex items-center gap-2 rounded border">
+              <div className="bg-info size-8 rounded-full"></div>
               Unread
+            </li>
+            <li className="border-warning-bd bg-warning-fill text-warning flex items-center gap-2 rounded border">
+              <div className="bg-warning size-8 rounded-full"></div>
+              Warning
             </li>
           </ul>
         </div>

--- a/src/app/dev/colors/page.tsx
+++ b/src/app/dev/colors/page.tsx
@@ -43,9 +43,9 @@ export default function ColorsPage() {
         <div className="grid grid-cols-[156px_1fr] items-center">
           <SectionHeading text="Fill" />
           <ul className="flex items-center justify-start gap-8">
-            <li className="bg-front rounded p-2">Front</li>
-            <li className="bg-base rounded p-2">Middle</li>
-            <li className="bg-back rounded p-2">Back</li>
+            <li className="bg-fill-middle rounded p-2">Front</li>
+            <li className="bg-fill-base rounded p-2">Middle</li>
+            <li className="bg-fill-back rounded p-2">Back</li>
           </ul>
         </div>
 

--- a/src/app/dev/colors/page.tsx
+++ b/src/app/dev/colors/page.tsx
@@ -1,7 +1,7 @@
 import { Link } from '@/presentation/modules/button/components/Link';
 
 function SectionHeading({ text }: { text: string }) {
-  return <h3 className="text-strong font-funnel-display text-2xl">{text}</h3>;
+  return <h3 className="text-fg-strong font-funnel-display text-2xl">{text}</h3>;
 }
 
 export default function ColorsPage() {
@@ -34,9 +34,9 @@ export default function ColorsPage() {
         <div className="grid grid-cols-[156px_1fr] items-center">
           <SectionHeading text="Text" />
           <ul className="flex items-center justify-start gap-8">
-            <li className="text-strong">Strong</li>
-            <li className="text-default">Default</li>
-            <li className="text-muted">Muted</li>
+            <li className="text-fg-strong">Strong</li>
+            <li className="text-fg-default">Default</li>
+            <li className="text-fg-subtle">Muted</li>
           </ul>
         </div>
 

--- a/src/app/dev/colors/page.tsx
+++ b/src/app/dev/colors/page.tsx
@@ -36,7 +36,8 @@ export default function ColorsPage() {
           <ul className="flex items-center justify-start gap-8">
             <li className="text-fg-strong">Strong</li>
             <li className="text-fg-default">Default</li>
-            <li className="text-fg-subtle">Muted</li>
+            <li className="text-fg-subtle">Subtle</li>
+            <li className="text-fg-muted">Muted</li>
           </ul>
         </div>
 

--- a/src/app/dev/form/components/DevFormComponents.tsx
+++ b/src/app/dev/form/components/DevFormComponents.tsx
@@ -91,11 +91,13 @@ export function DevFormComponents({ className }: Props) {
       <DevFormGroup className={className}>
         <Label title="Form buttons" htmlFor="">
           <div className="flex items-center gap-2">
-            <Button variantConfig={{ color: 'simple', type: 'square' }}>
-              <IconXMark />
-            </Button>
-            <Button variantConfig={{ color: 'simple' }}>Cancel</Button>
-            <Button variantConfig={{ color: 'primary' }}>Done</Button>
+            <Button
+              variant={{ color: 'simple', type: 'icon' }}
+              Icon={IconXMark}
+              aria-label="Close"
+            />
+            <Button variant={{ color: 'simple' }}>Cancel</Button>
+            <Button variant={{ color: 'primary' }}>Done</Button>
           </div>
         </Label>
       </DevFormGroup>

--- a/src/app/dev/form/components/DevSelectBox.tsx
+++ b/src/app/dev/form/components/DevSelectBox.tsx
@@ -16,7 +16,7 @@ export function DevSelectBox() {
   };
   return (
     <Label title="Select Box" htmlFor="select-box">
-      <Button variantConfig={{ color: 'subtle' }} onClick={handleOpen}>
+      <Button variant={{ color: 'subtle' }} onClick={handleOpen}>
         Open Select Box
       </Button>
       <SelectBox

--- a/src/app/dev/form/page.tsx
+++ b/src/app/dev/form/page.tsx
@@ -17,10 +17,10 @@ export default function FormPage() {
           <DevFormComponents className="outline-bd-default" />
         </Group>
         <Group title="Middle">
-          <DevFormComponents className="bg-base outline-bd-default" />
+          <DevFormComponents className="bg-fill-base outline-bd-default" />
         </Group>
         <Group title="Front">
-          <DevFormComponents className="bg-front outline-bd-default" />
+          <DevFormComponents className="bg-fill-middle outline-bd-default" />
         </Group>
       </section>
     </div>

--- a/src/app/dev/form/page.tsx
+++ b/src/app/dev/form/page.tsx
@@ -3,7 +3,7 @@ import { DevFormComponents } from './components/DevFormComponents';
 
 const Group = ({ title, children }: { title: string; children: React.ReactNode }) => (
   <div className="w-100 space-y-4">
-    <h5 className="font-funnel-display fg-strong text-center text-4xl font-bold">{title}</h5>
+    <h5 className="font-funnel-display text-strong text-center text-4xl font-bold">{title}</h5>
     <div>{children}</div>
   </div>
 );
@@ -17,7 +17,7 @@ export default function FormPage() {
           <DevFormComponents className="outline-bd-default" />
         </Group>
         <Group title="Middle">
-          <DevFormComponents className="bg-middle outline-bd-default" />
+          <DevFormComponents className="bg-base outline-bd-default" />
         </Group>
         <Group title="Front">
           <DevFormComponents className="bg-front outline-bd-default" />

--- a/src/app/dev/form/page.tsx
+++ b/src/app/dev/form/page.tsx
@@ -3,7 +3,7 @@ import { DevFormComponents } from './components/DevFormComponents';
 
 const Group = ({ title, children }: { title: string; children: React.ReactNode }) => (
   <div className="w-100 space-y-4">
-    <h5 className="font-funnel-display text-strong text-center text-4xl font-bold">{title}</h5>
+    <h5 className="font-funnel-display text-fg-strong text-center text-4xl font-bold">{title}</h5>
     <div>{children}</div>
   </div>
 );

--- a/src/app/dev/page.tsx
+++ b/src/app/dev/page.tsx
@@ -4,6 +4,9 @@ export default function DevPage() {
   return (
     <ul className="space-y-4">
       <li>
+        <Link href="/dev/colors">Colors</Link>
+      </li>
+      <li>
         <Link href="/dev/buttons">Buttons</Link>
       </li>
       <li>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,10 +10,6 @@
 
 @custom-variant light (&:where([data-theme=light], [data-theme=light] *));
 
-@utility fg-* {
-  color: --value(--color-*);
-}
-
 @utility no-scrollbar {
   &::-webkit-scrollbar {
     display: none;
@@ -52,62 +48,86 @@
 	*/
 
   /* Dark */
+
   /* Background */
   --color-back-dark: #0a0a0a;
-  --color-middle-dark: #0c0c0c;
-  --color-front-dark: #121212;
+  --color-base-dark: #0c0c0c;
+  --color-middle-dark: #121212;
+  --color-front-dark: #161616;
+  --color-top-dark: #202020;
+
   /* Foreground */
   --color-strong-dark: #fafafa;
   --color-default-dark: #c0c0c0;
+  --color-subtle-dark: #a0a0a0;
   --color-muted-dark: #a0a0a0;
+
   /* Borders */
   --color-bd-strong-dark: #272727;
   --color-bd-default-dark: #202020;
   --color-bd-muted-dark: #1a1a1a;
+
   /* Status */
   --color-complete-dark: var(--color-green-500);
   --color-cancel-dark: var(--color-red-600);
   --color-unread-dark: var(--color-blue-500);
+
   /* Accessibility */
   --color-focus-dark: #fff;
 
   /* Light */
+
   /* Background */
   --color-back-light: #f8f8ff;
-  --color-middle-light: #fcfcff;
-  --color-front-light: #eaeafa;
+  --color-base-light: #fcfcff;
+  --color-middle-light: #eaeafa;
+  --color-front-light: #e8e8fa;
+  --color-top-light: #e4e4fa;
+
   /* Foreground */
   --color-strong-light: #050505;
   --color-default-light: #2a2a2a;
+  --color-subtle-light: #2a2a2a;
   --color-muted-light: #4a4a4a;
+
   /* Borders */
   --color-bd-strong-light: #d0d0d0;
   --color-bd-default-light: #d9d9d9;
   --color-bd-muted-light: #e0e0e0;
+
   /* Status */
   --color-complete-light: var(--color-green-700);
   --color-cancel-light: var(--color-red-700);
   --color-unread-light: var(--color-blue-700);
+
   /* Accessibility */
   --color-focus-light: #000;
 
   /* Dynamic Colors */
+
   /* Background */
   --color-back: var(--color-back-dark);
+  --color-base: var(--color-base-dark);
   --color-middle: var(--color-middle-dark);
   --color-front: var(--color-front-dark);
+  --color-top: var(--color-top-dark);
+
   /* Foreground */
   --color-strong: var(--color-strong-dark);
   --color-default: var(--color-default-dark);
+  --color-subtle: var(--color-subtle-dark);
   --color-muted: var(--color-muted-dark);
+
   /* Border */
   --color-bd-strong: var(--color-bd-strong-dark);
   --color-bd-default: var(--color-bd-default-dark);
   --color-bd-muted: var(--color-bd-muted-dark);
+
   /* Status */
   --color-complete: var(--color-complete-dark);
   --color-cancel: var(--color-cancel-dark);
   --color-unread: var(--color-unread-dark);
+
   /* Accessibility */
   --color-focus: var(--color-focus-dark);
 }
@@ -116,20 +136,27 @@
 html[data-theme='light'] {
   /* Backgound Colors*/
   --color-back: var(--color-back-light);
+  --color-base: var(--color-base-light);
   --color-middle: var(--color-middle-light);
   --color-front: var(--color-front-light);
+  --color-top: var(--color-top-light);
+
   /* Foreground Colors */
   --color-strong: var(--color-strong-light);
   --color-default: var(--color-default-light);
+  --color-subtle: var(--color-subtle-light);
   --color-muted: var(--color-muted-light);
+
   /* Border Colors */
   --color-bd-strong: var(--color-bd-strong-light);
   --color-bd-default: var(--color-bd-default-light);
   --color-bd-muted: var(--color-bd-muted-light);
+
   /* Status */
   --color-complete: var(--color-complete-light);
   --color-cancel: var(--color-cancel-light);
   --color-unread: var(--color-unread-light);
+
   /* Accessibility */
   --color-focus: var(--color-focus-light);
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -50,11 +50,11 @@
   /* Dark */
 
   /* Background */
-  --color-back-dark: #0a0a0a;
-  --color-base-dark: #0c0c0c;
-  --color-middle-dark: #121212;
-  --color-front-dark: #161616;
-  --color-top-dark: #202020;
+  --color-fill-back-dark: #0a0a0a;
+  --color-fill-base-dark: #0c0c0c;
+  --color-fill-middle-dark: #121212;
+  --color-fill-front-dark: #161616;
+  --color-fill-top-dark: #202020;
 
   /* Foreground */
   --color-strong-dark: #fafafa;
@@ -78,11 +78,11 @@
   /* Light */
 
   /* Background */
-  --color-back-light: #f8f8ff;
-  --color-base-light: #fcfcff;
-  --color-middle-light: #eaeafa;
-  --color-front-light: #e8e8fa;
-  --color-top-light: #e4e4fa;
+  --color-fill-back-light: #f8f8ff;
+  --color-fill-base-light: #fcfcff;
+  --color-fill-middle-light: #eaeafa;
+  --color-fill-front-light: #e8e8fa;
+  --color-fill-top-light: #e4e4fa;
 
   /* Foreground */
   --color-strong-light: #050505;
@@ -106,11 +106,11 @@
   /* Dynamic Colors */
 
   /* Background */
-  --color-back: var(--color-back-dark);
-  --color-base: var(--color-base-dark);
-  --color-middle: var(--color-middle-dark);
-  --color-front: var(--color-front-dark);
-  --color-top: var(--color-top-dark);
+  --color-fill-back: var(--color-fill-back-dark);
+  --color-fill-base: var(--color-fill-base-dark);
+  --color-fill-middle: var(--color-fill-middle-dark);
+  --color-fill-front: var(--color-fill-front-dark);
+  --color-fill-top: var(--color-fill-top-dark);
 
   /* Foreground */
   --color-strong: var(--color-strong-dark);
@@ -135,11 +135,11 @@
 /* Light Color Versions */
 html[data-theme='light'] {
   /* Backgound Colors*/
-  --color-back: var(--color-back-light);
-  --color-base: var(--color-base-light);
-  --color-middle: var(--color-middle-light);
-  --color-front: var(--color-front-light);
-  --color-top: var(--color-top-light);
+  --color-fill-back: var(--color-fill-back-light);
+  --color-fill-base: var(--color-fill-base-light);
+  --color-fill-middle: var(--color-fill-middle-light);
+  --color-fill-front: var(--color-fill-front-light);
+  --color-fill-top: var(--color-fill-top-light);
 
   /* Foreground Colors */
   --color-strong: var(--color-strong-light);
@@ -163,7 +163,7 @@ html[data-theme='light'] {
 
 body {
   position: relative;
-  background: var(--color-back);
+  background: var(--color-fill-back);
   color: var(--color-default);
   font-family: 'Outfit', sans-serif;
   font-size: 1rem;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -68,9 +68,21 @@
   --color-bd-muted-dark: #1a1a1a;
 
   /* Status */
-  --color-complete-dark: var(--color-green-500);
-  --color-cancel-dark: var(--color-red-600);
-  --color-unread-dark: var(--color-blue-500);
+  --color-success-dark: var(--color-green-500);
+  --color-success-fg-dark: var(--color-green-600);
+  --color-success-fill-dark: var(--color-green-900);
+
+  --color-danger-dark: var(--color-red-600);
+  --color-danger-fg-dark: var(--color-red-700);
+  --color-danger-fill-dark: var(--color-red-900);
+
+  --color-info-dark: var(--color-blue-500);
+  --color-info-bd-dark: var(--color-blue-600);
+  --color-info-fill-dark: var(--color-blue-900);
+
+  --color-warning-dark: var(--color-yellow-500);
+  --color-warning-fg-dark: var(--color-yellow-600);
+  --color-warning-fill-dark: var(--color-yellow-900);
 
   /* Accessibility */
   --color-focus-dark: #fff;
@@ -96,9 +108,21 @@
   --color-bd-muted-light: #e0e0e0;
 
   /* Status */
-  --color-complete-light: var(--color-green-700);
-  --color-cancel-light: var(--color-red-700);
-  --color-unread-light: var(--color-blue-700);
+  --color-success-light: var(--color-green-700);
+  --color-success-bd-light: var(--color-green-800);
+  --color-success-fill-light: var(--color-green-900);
+
+  --color-danger-light: var(--color-red-700);
+  --color-danger-bd-light: var(--color-red-800);
+  --color-danger-fill-light: var(--color-red-900);
+
+  --color-info-light: var(--color-blue-700);
+  --color-info-bd-light: var(--color-blue-800);
+  --color-info-fill-light: var(--color-blue-900);
+
+  --color-warning-light: var(--color-yellow-600);
+  --color-warning-bd-light: var(--color-yellow-700);
+  --color-warning-fill-light: var(--color-yellow-800);
 
   /* Accessibility */
   --color-focus-light: #000;
@@ -124,9 +148,21 @@
   --color-bd-muted: var(--color-bd-muted-dark);
 
   /* Status */
-  --color-complete: var(--color-complete-dark);
-  --color-cancel: var(--color-cancel-dark);
-  --color-unread: var(--color-unread-dark);
+  --color-success: var(--color-success-dark);
+  --color-success-bd: var(--color-success-bd-dark);
+  --color-success-fill: var(--color-success-fill-dark);
+
+  --color-danger: var(--color-danger-dark);
+  --color-danger-bd: var(--color-danger-bd-dark);
+  --color-danger-fill: var(--color-danger-fill-dark);
+
+  --color-info: var(--color-info-dark);
+  --color-info-bd: var(--color-info-bd-dark);
+  --color-info-fill: var(--color-info-fill-dark);
+
+  --color-warning: var(--color-warning-dark);
+  --color-warning-bd: var(--color-warning-bd-dark);
+  --color-warning-fill: var(--color-warning-fill-dark);
 
   /* Accessibility */
   --color-focus: var(--color-focus-dark);
@@ -153,9 +189,21 @@ html[data-theme='light'] {
   --color-bd-muted: var(--color-bd-muted-light);
 
   /* Status */
-  --color-complete: var(--color-complete-light);
-  --color-cancel: var(--color-cancel-light);
-  --color-unread: var(--color-unread-light);
+  --color-success: var(--color-success-light);
+  --color-success-bd: var(--color-success-bd-light);
+  --color-success-fill: var(--color-success-fill-light);
+
+  --color-danger: var(--color-danger-light);
+  --color-danger-bd: var(--color-danger-bd-light);
+  --color-danger-fill: var(--color-danger-fill-light);
+
+  --color-info: var(--color-info-light);
+  --color-info-bd: var(--color-info-bd-light);
+  --color-info-fill: var(--color-info-fill-light);
+
+  --color-warning: var(--color-warning-light);
+  --color-warning-bd: var(--color-warning-bd-light);
+  --color-warning-fill: var(--color-warning-fill-light);
 
   /* Accessibility */
   --color-focus: var(--color-focus-light);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -57,10 +57,10 @@
   --color-fill-top-dark: #202020;
 
   /* Foreground */
-  --color-strong-dark: #fafafa;
-  --color-default-dark: #c0c0c0;
-  --color-subtle-dark: #a0a0a0;
-  --color-muted-dark: #a0a0a0;
+  --color-fg-strong-dark: #fafafa;
+  --color-fg-default-dark: #c0c0c0;
+  --color-fg-subtle-dark: #a0a0a0;
+  --color-fg-muted-dark: #a0a0a0;
 
   /* Borders */
   --color-bd-strong-dark: #272727;
@@ -85,10 +85,10 @@
   --color-fill-top-light: #e4e4fa;
 
   /* Foreground */
-  --color-strong-light: #050505;
-  --color-default-light: #2a2a2a;
-  --color-subtle-light: #2a2a2a;
-  --color-muted-light: #4a4a4a;
+  --color-fg-strong-light: #050505;
+  --color-fg-default-light: #2a2a2a;
+  --color-fg-subtle-light: #2a2a2a;
+  --color-fg-muted-light: #4a4a4a;
 
   /* Borders */
   --color-bd-strong-light: #d0d0d0;
@@ -113,10 +113,10 @@
   --color-fill-top: var(--color-fill-top-dark);
 
   /* Foreground */
-  --color-strong: var(--color-strong-dark);
-  --color-default: var(--color-default-dark);
-  --color-subtle: var(--color-subtle-dark);
-  --color-muted: var(--color-muted-dark);
+  --color-fg-strong: var(--color-fg-strong-dark);
+  --color-fg-default: var(--color-fg-default-dark);
+  --color-fg-subtle: var(--color-fg-subtle-dark);
+  --color-fg-muted: var(--color-fg-muted-dark);
 
   /* Border */
   --color-bd-strong: var(--color-bd-strong-dark);
@@ -142,10 +142,10 @@ html[data-theme='light'] {
   --color-fill-top: var(--color-fill-top-light);
 
   /* Foreground Colors */
-  --color-strong: var(--color-strong-light);
-  --color-default: var(--color-default-light);
-  --color-subtle: var(--color-subtle-light);
-  --color-muted: var(--color-muted-light);
+  --color-fg-strong: var(--color-fg-strong-light);
+  --color-fg-default: var(--color-fg-default-light);
+  --color-fg-subtle: var(--color-fg-subtle-light);
+  --color-fg-muted: var(--color-fg-muted-light);
 
   /* Border Colors */
   --color-bd-strong: var(--color-bd-strong-light);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -65,11 +65,11 @@
 
   /* Status */
   --color-success-dark: #00c951;
-  --color-success-fg-dark: #0bbv3f;
+  --color-success-bd-dark: #0bbc3f;
   --color-success-fill-dark: #07480f;
 
   --color-danger-dark: #e7000b;
-  --color-danger-fg-dark: #a30a11;
+  --color-danger-bd-dark: #a30a11;
   --color-danger-fill-dark: #480003;
 
   --color-info-dark: #3694ff;
@@ -77,7 +77,7 @@
   --color-info-fill-dark: #112b62;
 
   --color-warning-dark: #efef1c;
-  --color-warning-fg-dark: #bcaf20;
+  --color-warning-bd-dark: #bcaf20;
   --color-warning-fill-dark: #5c550c;
 
   /* Accessibility */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -106,7 +106,7 @@
   /* Status */
   --color-success-light: #369a00;
   --color-success-bd-light: #33be17;
-  --color-success-fill-light: #02fe70;
+  --color-success-fill-light: #a2fe70;
 
   --color-danger-light: #ba0000;
   --color-danger-bd-light: #ef1e1e;
@@ -118,7 +118,7 @@
 
   --color-warning-light: #869800;
   --color-warning-bd-light: #bfc500;
-  --color-warning-fill-light: #f0ff9c;
+  --color-warning-fill-light: #e6f97b;
 
   /* Accessibility */
   --color-focus-light: #000;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,11 +25,6 @@
   --color-tertiary: #eb5e31;
   --color-accent: #e6a737;
 
-  /* Utility Colors */
-
-  --color-subtle: var(--color-zinc-600);
-  --color-full-black: #0a0a0a;
-
   /* Font families */
 
   --font-funnel-display: var(--font-funnel-display);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -95,8 +95,8 @@
   /* Foreground */
   --color-fg-strong-light: #050505;
   --color-fg-default-light: #2a2a2a;
-  --color-fg-subtle-light: #2a2a2a;
-  --color-fg-muted-light: #4a4a4a;
+  --color-fg-subtle-light: #4a4a4a;
+  --color-fg-muted-light: #6a6a6a;
 
   /* Borders */
   --color-bd-strong-light: #d0d0d0;
@@ -104,21 +104,21 @@
   --color-bd-muted-light: #e0e0e0;
 
   /* Status */
-  --color-success-light: var(--color-green-700);
-  --color-success-bd-light: var(--color-green-800);
-  --color-success-fill-light: var(--color-green-900);
+  --color-success-light: #369a00;
+  --color-success-bd-light: #33be17;
+  --color-success-fill-light: #02fe70;
 
-  --color-danger-light: var(--color-red-700);
-  --color-danger-bd-light: var(--color-red-800);
-  --color-danger-fill-light: var(--color-red-900);
+  --color-danger-light: #ba0000;
+  --color-danger-bd-light: #ef1e1e;
+  --color-danger-fill-light: #ff6e6e;
 
-  --color-info-light: var(--color-blue-700);
-  --color-info-bd-light: var(--color-blue-800);
-  --color-info-fill-light: var(--color-blue-900);
+  --color-info-light: #2f5dd0;
+  --color-info-bd-light: #7e80ff;
+  --color-info-fill-light: #b2a9ff;
 
-  --color-warning-light: var(--color-yellow-600);
-  --color-warning-bd-light: var(--color-yellow-700);
-  --color-warning-fill-light: var(--color-yellow-800);
+  --color-warning-light: #869800;
+  --color-warning-bd-light: #bfc500;
+  --color-warning-fill-light: #f0ff9c;
 
   /* Accessibility */
   --color-focus-light: #000;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -20,6 +20,7 @@
   /* Brand Colors */
 
   --color-primary: #bd1e01;
+  --color-primary-dark: #771b0a;
   --color-secondary: #bc7700;
   --color-tertiary: #eb5e31;
   --color-accent: #e6a737;
@@ -51,16 +52,16 @@
 
   /* Background */
   --color-fill-back-dark: #0a0a0a;
-  --color-fill-base-dark: #0c0c0c;
-  --color-fill-middle-dark: #121212;
-  --color-fill-front-dark: #161616;
-  --color-fill-top-dark: #202020;
+  --color-fill-base-dark: #0e0e0e;
+  --color-fill-middle-dark: #131313;
+  --color-fill-front-dark: #171717;
+  --color-fill-top-dark: #1a1a1a;
 
   /* Foreground */
   --color-fg-strong-dark: #fafafa;
   --color-fg-default-dark: #c0c0c0;
   --color-fg-subtle-dark: #a0a0a0;
-  --color-fg-muted-dark: #a0a0a0;
+  --color-fg-muted-dark: #707070;
 
   /* Borders */
   --color-bd-strong-dark: #272727;
@@ -68,21 +69,21 @@
   --color-bd-muted-dark: #1a1a1a;
 
   /* Status */
-  --color-success-dark: var(--color-green-500);
-  --color-success-fg-dark: var(--color-green-600);
-  --color-success-fill-dark: var(--color-green-900);
+  --color-success-dark: #00c951;
+  --color-success-fg-dark: #0bbv3f;
+  --color-success-fill-dark: #07480f;
 
-  --color-danger-dark: var(--color-red-600);
-  --color-danger-fg-dark: var(--color-red-700);
-  --color-danger-fill-dark: var(--color-red-900);
+  --color-danger-dark: #e7000b;
+  --color-danger-fg-dark: #a30a11;
+  --color-danger-fill-dark: #480003;
 
-  --color-info-dark: var(--color-blue-500);
-  --color-info-bd-dark: var(--color-blue-600);
-  --color-info-fill-dark: var(--color-blue-900);
+  --color-info-dark: #3694ff;
+  --color-info-bd-dark: #1d5bb9;
+  --color-info-fill-dark: #112b62;
 
-  --color-warning-dark: var(--color-yellow-500);
-  --color-warning-fg-dark: var(--color-yellow-600);
-  --color-warning-fill-dark: var(--color-yellow-900);
+  --color-warning-dark: #efef1c;
+  --color-warning-fg-dark: #bcaf20;
+  --color-warning-fill-dark: #5c550c;
 
   /* Accessibility */
   --color-focus-dark: #fff;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -68,9 +68,9 @@
   --color-success-bd-dark: #0bbc3f;
   --color-success-fill-dark: #07480f;
 
-  --color-danger-dark: #e7000b;
-  --color-danger-bd-dark: #a30a11;
-  --color-danger-fill-dark: #480003;
+  --color-danger-dark: #ff3c45;
+  --color-danger-bd-dark: #130a11;
+  --color-danger-fill-dark: #730005;
 
   --color-info-dark: #3694ff;
   --color-info-bd-dark: #1d5bb9;

--- a/src/modules/auth/presentation/ui/components/LogInButton.tsx
+++ b/src/modules/auth/presentation/ui/components/LogInButton.tsx
@@ -7,7 +7,7 @@ export function LogInButton() {
   const { handleLogin } = useLogin();
 
   return (
-    <Button type="button" variantConfig={{ size: 'sm', color: 'primary' }} onClick={handleLogin}>
+    <Button type="button" variant={{ size: 'sm', color: 'primary' }} onClick={handleLogin}>
       Log in
     </Button>
   );

--- a/src/modules/auth/presentation/ui/components/LogOutButton.tsx
+++ b/src/modules/auth/presentation/ui/components/LogOutButton.tsx
@@ -6,7 +6,7 @@ import { useLogout } from '@/modules/auth/presentation/ui/hooks/useLogout';
 export function LogOutButton() {
   const { handleLogout } = useLogout();
   return (
-    <Button type="button" variantConfig={{ color: 'subtle', size: 'sm' }} onClick={handleLogout}>
+    <Button type="button" variant={{ color: 'subtle', size: 'sm' }} onClick={handleLogout}>
       Log Out
     </Button>
   );

--- a/src/modules/exercise/presentation/components/ExerciseCard.tsx
+++ b/src/modules/exercise/presentation/components/ExerciseCard.tsx
@@ -27,11 +27,11 @@ export function ExerciseCard({ exercise }: { exercise: ExerciseDTO }) {
             />
           ))}
         </CardTagsWrapperFade>
-        <section className="text-strong flex items-center gap-4">
+        <section className="text-fg-strong flex items-center gap-4">
           <span className="text-5xl">{`${sets} x ${reps}`}</span>
           <div className="bg-fill-middle border-bd-muted w-fit rounded-full border px-3 py-0.5">
             <span className="text-2xl">{weight}</span>{' '}
-            <span className="text-default text-xl font-light">lb</span>
+            <span className="text-fg-default text-xl font-light">lb</span>
           </div>
         </section>
       </CardMain>

--- a/src/modules/exercise/presentation/components/ExerciseCard.tsx
+++ b/src/modules/exercise/presentation/components/ExerciseCard.tsx
@@ -27,11 +27,11 @@ export function ExerciseCard({ exercise }: { exercise: ExerciseDTO }) {
             />
           ))}
         </CardTagsWrapperFade>
-        <section className="fg-strong flex items-center gap-4">
+        <section className="text-strong flex items-center gap-4">
           <span className="text-5xl">{`${sets} x ${reps}`}</span>
           <div className="bg-front border-bd-muted w-fit rounded-full border px-3 py-0.5">
             <span className="text-2xl">{weight}</span>{' '}
-            <span className="fg-default text-xl font-light">lb</span>
+            <span className="text-default text-xl font-light">lb</span>
           </div>
         </section>
       </CardMain>

--- a/src/modules/exercise/presentation/components/ExerciseCard.tsx
+++ b/src/modules/exercise/presentation/components/ExerciseCard.tsx
@@ -29,7 +29,7 @@ export function ExerciseCard({ exercise }: { exercise: ExerciseDTO }) {
         </CardTagsWrapperFade>
         <section className="text-strong flex items-center gap-4">
           <span className="text-5xl">{`${sets} x ${reps}`}</span>
-          <div className="bg-front border-bd-muted w-fit rounded-full border px-3 py-0.5">
+          <div className="bg-fill-middle border-bd-muted w-fit rounded-full border px-3 py-0.5">
             <span className="text-2xl">{weight}</span>{' '}
             <span className="text-default text-xl font-light">lb</span>
           </div>

--- a/src/modules/exercise/presentation/components/ExercisesTable.tsx
+++ b/src/modules/exercise/presentation/components/ExercisesTable.tsx
@@ -29,8 +29,8 @@ export function ExercisesTable({ exercises }: Props) {
       <TableBody>
         {exercises.map(({ id, name, description, sets, reps, weight, createdAt }, index) => (
           <TableBodyRow key={id}>
-            <td className="fg-muted w-10 text-center font-light md:w-12">{index + 1}</td>
-            <td className="fg-strong truncate">{name}</td>
+            <td className="text-muted w-10 text-center font-light md:w-12">{index + 1}</td>
+            <td className="text-strong truncate">{name}</td>
             <td className="hidden w-[40%] truncate pr-4 xl:table-cell">{description}</td>
             <td className="text-center">{sets}</td>
             <td className="text-center">{reps}</td>

--- a/src/modules/exercise/presentation/components/ExercisesTable.tsx
+++ b/src/modules/exercise/presentation/components/ExercisesTable.tsx
@@ -29,8 +29,8 @@ export function ExercisesTable({ exercises }: Props) {
       <TableBody>
         {exercises.map(({ id, name, description, sets, reps, weight, createdAt }, index) => (
           <TableBodyRow key={id}>
-            <td className="text-muted w-10 text-center font-light md:w-12">{index + 1}</td>
-            <td className="text-strong truncate">{name}</td>
+            <td className="text-fg-subtle w-10 text-center font-light md:w-12">{index + 1}</td>
+            <td className="text-fg-strong truncate">{name}</td>
             <td className="hidden w-[40%] truncate pr-4 xl:table-cell">{description}</td>
             <td className="text-center">{sets}</td>
             <td className="text-center">{reps}</td>

--- a/src/modules/exercise/presentation/components/ExercisesTable.tsx
+++ b/src/modules/exercise/presentation/components/ExercisesTable.tsx
@@ -39,14 +39,18 @@ export function ExercisesTable({ exercises }: Props) {
             <td>
               <ul className="flex w-full items-center justify-center">
                 <li>
-                  <Button variantConfig={{ color: 'simple', type: 'square' }}>
-                    <IconEdit className="size-5" />
-                  </Button>
+                  <Button
+                    variant={{ color: 'simple', type: 'icon' }}
+                    aria-label="Edit exercise"
+                    Icon={IconEdit}
+                  />
                 </li>
                 <li>
-                  <Button variantConfig={{ color: 'simple', type: 'square' }}>
-                    <IconTrash className="size-5" />
-                  </Button>
+                  <Button
+                    variant={{ color: 'simple', type: 'icon' }}
+                    aria-label="Delete exercise"
+                    Icon={IconTrash}
+                  />
                 </li>
               </ul>
             </td>

--- a/src/modules/exercise/presentation/ui/components/ExerciseList.tsx
+++ b/src/modules/exercise/presentation/ui/components/ExerciseList.tsx
@@ -40,8 +40,8 @@ export function ExerciseRow({
       <span className="text-left">{name}</span>
       <div className="grid grid-cols-[1fr_auto_1fr] gap-0.5">
         <span className="text-right">{sets}</span>
-        <span className="text-default/50 flex items-center justify-center">
-          <IconXMark className="text-muted size-3" strokeWidth="3" />
+        <span className="text-fg-default/50 flex items-center justify-center">
+          <IconXMark className="text-fg-subtle size-3" strokeWidth="3" />
         </span>
         <span className="text-left">{reps}</span>
       </div>

--- a/src/modules/exercise/presentation/ui/components/ExerciseList.tsx
+++ b/src/modules/exercise/presentation/ui/components/ExerciseList.tsx
@@ -41,7 +41,7 @@ export function ExerciseRow({
       <div className="grid grid-cols-[1fr_auto_1fr] gap-0.5">
         <span className="text-right">{sets}</span>
         <span className="text-default/50 flex items-center justify-center">
-          <IconXMark className="fg-muted size-3" strokeWidth="3" />
+          <IconXMark className="text-muted size-3" strokeWidth="3" />
         </span>
         <span className="text-left">{reps}</span>
       </div>

--- a/src/modules/muscle/presentation/ui/components/MuscularGroupTable.tsx
+++ b/src/modules/muscle/presentation/ui/components/MuscularGroupTable.tsx
@@ -33,8 +33,8 @@ export async function MuscularGroupsTable({ muscles }: { muscles: MuscleDTO[] })
       <TableBody>
         {muscularGroups.map(({ name, muscles, section }, index) => (
           <TableBodyRow key={name}>
-            <td className="text-muted pl-4 font-light">{index + 1}</td>
-            <td className="text-strong">{name}</td>
+            <td className="text-fg-subtle pl-4 font-light">{index + 1}</td>
+            <td className="text-fg-strong">{name}</td>
             <td className="text-sm">
               <div className="bg-fill-middle w-fit rounded-full px-3 py-1 font-light">
                 {section.name}

--- a/src/modules/muscle/presentation/ui/components/MuscularGroupTable.tsx
+++ b/src/modules/muscle/presentation/ui/components/MuscularGroupTable.tsx
@@ -33,8 +33,8 @@ export async function MuscularGroupsTable({ muscles }: { muscles: MuscleDTO[] })
       <TableBody>
         {muscularGroups.map(({ name, muscles, section }, index) => (
           <TableBodyRow key={name}>
-            <td className="fg-muted pl-4 font-light">{index + 1}</td>
-            <td className="fg-strong">{name}</td>
+            <td className="text-muted pl-4 font-light">{index + 1}</td>
+            <td className="text-strong">{name}</td>
             <td className="text-sm">
               <div className="bg-front w-fit rounded-full px-3 py-1 font-light">{section.name}</div>
             </td>

--- a/src/modules/muscle/presentation/ui/components/MuscularGroupTable.tsx
+++ b/src/modules/muscle/presentation/ui/components/MuscularGroupTable.tsx
@@ -36,17 +36,22 @@ export async function MuscularGroupsTable({ muscles }: { muscles: MuscleDTO[] })
             <td className="text-muted pl-4 font-light">{index + 1}</td>
             <td className="text-strong">{name}</td>
             <td className="text-sm">
-              <div className="bg-front w-fit rounded-full px-3 py-1 font-light">{section.name}</div>
+              <div className="bg-fill-middle w-fit rounded-full px-3 py-1 font-light">
+                {section.name}
+              </div>
             </td>
             <td className="text-sm">
               <div className="hidden w-fit items-center gap-2 lg:flex">
                 {muscles.map((m) => (
-                  <div key={m} className="bg-front mx-auto w-fit rounded-full px-3 py-1 font-light">
+                  <div
+                    key={m}
+                    className="bg-fill-middle mx-auto w-fit rounded-full px-3 py-1 font-light"
+                  >
                     {m}
                   </div>
                 ))}
               </div>
-              <div className="bg-front w-fit rounded-full px-3 py-1 font-light lg:hidden">
+              <div className="bg-fill-middle w-fit rounded-full px-3 py-1 font-light lg:hidden">
                 {`${muscles.length} muscles`}
               </div>
             </td>

--- a/src/modules/notification/presentation/ui/components/Notification.tsx
+++ b/src/modules/notification/presentation/ui/components/Notification.tsx
@@ -25,7 +25,7 @@ export function Notification({
         <header className="relative w-fit">
           <Link href={url || '/dashboard/notifications'} className="flex w-fit items-center gap-2">
             <h3
-              className={`line-clamp-1 w-fit text-base ${notSeen ? 'text-strong font-medium' : ''}`}
+              className={`line-clamp-1 w-fit text-base ${notSeen ? 'text-fg-strong font-medium' : ''}`}
             >
               {title}
             </h3>
@@ -35,12 +35,14 @@ export function Notification({
           )}
         </header>
         <footer>
-          <p className={`text-sm font-light ${notSeen ? '' : 'text-default/60'}`}>
+          <p className={`text-sm font-light ${notSeen ? '' : 'text-fg-default/60'}`}>
             <span className="line-clamp-1">{description}</span>
           </p>
         </footer>
       </main>
-      <aside className="text-default/50 w-fit text-center text-sm whitespace-nowrap">{date}</aside>
+      <aside className="text-fg-default/50 w-fit text-center text-sm whitespace-nowrap">
+        {date}
+      </aside>
       <div className="flex items-center gap-2">
         <Button
           type="button"

--- a/src/modules/notification/presentation/ui/components/Notification.tsx
+++ b/src/modules/notification/presentation/ui/components/Notification.tsx
@@ -12,7 +12,7 @@ export function Notification({
 }) {
   const { title, description, date, notSeen, url } = data;
 
-  const notificationClass = notSeen ? 'bg-middle' : '';
+  const notificationClass = notSeen ? 'bg-base' : '';
 
   return (
     <article
@@ -25,7 +25,7 @@ export function Notification({
         <header className="relative w-fit">
           <Link href={url || '/dashboard/notifications'} className="flex w-fit items-center gap-2">
             <h3
-              className={`line-clamp-1 w-fit text-base ${notSeen ? 'fg-strong font-medium' : ''}`}
+              className={`line-clamp-1 w-fit text-base ${notSeen ? 'text-strong font-medium' : ''}`}
             >
               {title}
             </h3>

--- a/src/modules/notification/presentation/ui/components/Notification.tsx
+++ b/src/modules/notification/presentation/ui/components/Notification.tsx
@@ -12,7 +12,7 @@ export function Notification({
 }) {
   const { title, description, date, notSeen, url } = data;
 
-  const notificationClass = notSeen ? 'bg-base' : '';
+  const notificationClass = notSeen ? 'bg-fill-base' : '';
 
   return (
     <article

--- a/src/modules/notification/presentation/ui/components/Notification.tsx
+++ b/src/modules/notification/presentation/ui/components/Notification.tsx
@@ -31,7 +31,7 @@ export function Notification({
             </h3>
           </Link>
           {notSeen && (
-            <span className="bg-unread absolute inset-y-0 left-full my-auto ml-2 block size-2 rounded-full"></span>
+            <span className="bg-info absolute inset-y-0 left-full my-auto ml-2 block size-2 rounded-full"></span>
           )}
         </header>
         <footer>

--- a/src/modules/notification/presentation/ui/components/Notification.tsx
+++ b/src/modules/notification/presentation/ui/components/Notification.tsx
@@ -46,15 +46,14 @@ export function Notification({
       <div className="flex items-center gap-2">
         <Button
           type="button"
-          variantConfig={{
-            type: 'square',
+          variant={{
             color: 'subtle',
             size: 'sm',
+            type: 'icon',
           }}
-          className="text-red-800/80"
-        >
-          <IconTrash className="size-4" strokeWidth="2" />
-        </Button>
+          aria-label="Edit exercise"
+          Icon={IconTrash}
+        />
       </div>
     </article>
   );

--- a/src/modules/notification/presentation/ui/components/Notification.tsx
+++ b/src/modules/notification/presentation/ui/components/Notification.tsx
@@ -47,8 +47,8 @@ export function Notification({
         <Button
           type="button"
           variant={{
-            color: 'subtle',
-            size: 'sm',
+            color: 'muted',
+            size: 'xs',
             type: 'icon',
           }}
           aria-label="Edit exercise"

--- a/src/modules/notification/presentation/ui/components/NotificationsCounter.tsx
+++ b/src/modules/notification/presentation/ui/components/NotificationsCounter.tsx
@@ -1,6 +1,6 @@
 export function NotificationsCounter({ count }: { count: number }) {
   return (
-    <div className="bg-unread fg-white border-unread grid size-4 place-items-center rounded-full border">
+    <div className="bg-unread border-unread grid size-4 place-items-center rounded-full border text-white">
       <span className="block w-fit text-xs font-medium">{count}</span>
     </div>
   );

--- a/src/modules/notification/presentation/ui/components/NotificationsCounter.tsx
+++ b/src/modules/notification/presentation/ui/components/NotificationsCounter.tsx
@@ -1,6 +1,6 @@
 export function NotificationsCounter({ count }: { count: number }) {
   return (
-    <div className="bg-unread border-unread grid size-4 place-items-center rounded-full border text-white">
+    <div className="bg-info border-info grid size-4 place-items-center rounded-full border text-white">
       <span className="block w-fit text-xs font-medium">{count}</span>
     </div>
   );

--- a/src/modules/routine/presentation/ui/components/fields/RoutineSessionPlanDroppableItem.tsx
+++ b/src/modules/routine/presentation/ui/components/fields/RoutineSessionPlanDroppableItem.tsx
@@ -21,9 +21,9 @@ export function RoutineSessionPlanDroppableItem({ id, text, children, dndConfig,
   return (
     <div
       ref={ref}
-      className={`bg-back h-20 rounded text-sm ${dndConfig.droppedId ? 'outline-bd-default outline' : 'opacity-80'}`}
+      className={`bg-fill-back h-20 rounded text-sm ${dndConfig.droppedId ? 'outline-bd-default outline' : 'opacity-80'}`}
     >
-      <header className="bg-base border-bd-muted flex h-9 items-center justify-between rounded-t border px-1.5 leading-none">
+      <header className="bg-fill-base border-bd-muted flex h-9 items-center justify-between rounded-t border px-1.5 leading-none">
         <h4 className={dndConfig.droppedId ? 'text-strong font-medium' : ''}>{text}</h4>
         {onAdd !== undefined && (
           <Button

--- a/src/modules/routine/presentation/ui/components/fields/RoutineSessionPlanDroppableItem.tsx
+++ b/src/modules/routine/presentation/ui/components/fields/RoutineSessionPlanDroppableItem.tsx
@@ -23,8 +23,8 @@ export function RoutineSessionPlanDroppableItem({ id, text, children, dndConfig,
       ref={ref}
       className={`bg-back h-20 rounded text-sm ${dndConfig.droppedId ? 'outline-bd-default outline' : 'opacity-80'}`}
     >
-      <header className="bg-middle border-bd-muted flex h-9 items-center justify-between rounded-t border px-1.5 leading-none">
-        <h4 className={dndConfig.droppedId ? 'fg-strong font-medium' : ''}>{text}</h4>
+      <header className="bg-base border-bd-muted flex h-9 items-center justify-between rounded-t border px-1.5 leading-none">
+        <h4 className={dndConfig.droppedId ? 'text-strong font-medium' : ''}>{text}</h4>
         {onAdd !== undefined && (
           <Button
             aria-label="Select a session"

--- a/src/modules/routine/presentation/ui/components/fields/RoutineSessionPlanDroppableItem.tsx
+++ b/src/modules/routine/presentation/ui/components/fields/RoutineSessionPlanDroppableItem.tsx
@@ -24,7 +24,7 @@ export function RoutineSessionPlanDroppableItem({ id, text, children, dndConfig,
       className={`bg-fill-back h-20 rounded text-sm ${dndConfig.droppedId ? 'outline-bd-default outline' : 'opacity-80'}`}
     >
       <header className="bg-fill-base border-bd-muted flex h-9 items-center justify-between rounded-t border px-1.5 leading-none">
-        <h4 className={dndConfig.droppedId ? 'text-strong font-medium' : ''}>{text}</h4>
+        <h4 className={dndConfig.droppedId ? 'text-fg-strong font-medium' : ''}>{text}</h4>
         {onAdd !== undefined && (
           <Button
             aria-label="Select a session"

--- a/src/modules/routine/presentation/ui/components/fields/RoutineSessionPlanDroppableItem.tsx
+++ b/src/modules/routine/presentation/ui/components/fields/RoutineSessionPlanDroppableItem.tsx
@@ -27,14 +27,13 @@ export function RoutineSessionPlanDroppableItem({ id, text, children, dndConfig,
         <h4 className={dndConfig.droppedId ? 'text-fg-strong font-medium' : ''}>{text}</h4>
         {onAdd !== undefined && (
           <Button
-            aria-label="Select a session"
             title="Select a session"
-            variantConfig={{ color: 'simple', type: 'square' }}
-            className="size-7 rounded-lg"
+            variant={{ color: 'simple', type: 'icon' }}
             onClick={onAdd}
-          >
-            <IconPlus className="size-4" />
-          </Button>
+            className="size-7 rounded-lg"
+            Icon={IconPlus}
+            aria-label="Select a session"
+          />
         )}
       </header>
       <main className="w-full p-2">{children}</main>

--- a/src/modules/routine/presentation/ui/routine.ui.config.ts
+++ b/src/modules/routine/presentation/ui/routine.ui.config.ts
@@ -6,8 +6,9 @@ export const routineDayItemClassConfig = tv({
     status: {
       canceled: 'light:border-red-300 light:text-red-400 border-red-950 text-red-800',
       completed: 'light:border-green-400 light:text-green-600 border-green-950 text-green-800',
-      current: 'fg-strong light:bg-green-600 light:border-green-600 border-green-800 bg-green-800',
-      next: 'border-subtle/50 fg-strong',
+      current:
+        'text-strong light:bg-green-600 light:border-green-600 border-green-800 bg-green-800',
+      next: 'border-subtle/50 text-strong',
     },
     type: {
       rest: 'opacity-50',

--- a/src/modules/routine/presentation/ui/routine.ui.config.ts
+++ b/src/modules/routine/presentation/ui/routine.ui.config.ts
@@ -7,8 +7,8 @@ export const routineDayItemClassConfig = tv({
       canceled: 'light:border-red-300 light:text-red-400 border-red-950 text-red-800',
       completed: 'light:border-green-400 light:text-green-600 border-green-950 text-green-800',
       current:
-        'text-strong light:bg-green-600 light:border-green-600 border-green-800 bg-green-800',
-      next: 'border-subtle/50 text-strong',
+        'text-fg-strong light:bg-green-600 light:border-green-600 border-green-800 bg-green-800',
+      next: 'border-subtle/50 text-fg-strong',
     },
     type: {
       rest: 'opacity-50',

--- a/src/modules/routine/presentation/ui/routine.ui.config.ts
+++ b/src/modules/routine/presentation/ui/routine.ui.config.ts
@@ -8,7 +8,7 @@ export const routineDayItemClassConfig = tv({
       completed: 'light:border-green-400 light:text-green-600 border-green-950 text-green-800',
       current:
         'text-fg-strong light:bg-green-600 light:border-green-600 border-green-800 bg-green-800',
-      next: 'border-subtle/50 text-fg-strong',
+      next: 'border-bd-default text-fg-strong',
     },
     type: {
       rest: 'opacity-50',

--- a/src/modules/session/presentation/ui/components/FormSessionsBox.tsx
+++ b/src/modules/session/presentation/ui/components/FormSessionsBox.tsx
@@ -18,7 +18,7 @@ export function FormSessionsBox() {
       <aside>
         <Link
           href="/dashboard/routines/create/sessions"
-          className="border-subtle/20 fg-strong block aspect-square cursor-pointer rounded border bg-zinc-900 p-1 transition-colors hover:bg-zinc-800/80"
+          className="border-subtle/20 text-strong block aspect-square cursor-pointer rounded border bg-zinc-900 p-1 transition-colors hover:bg-zinc-800/80"
         >
           <IconCirclePlus strokeWidth="1" />
         </Link>

--- a/src/modules/session/presentation/ui/components/FormSessionsBox.tsx
+++ b/src/modules/session/presentation/ui/components/FormSessionsBox.tsx
@@ -12,13 +12,13 @@ export function FormSessionsBox() {
         {sessions.length > 0 ? (
           sessions.map((session, index) => <p key={index}>{session.name}</p>)
         ) : (
-          <p className="text-default/50 text-base font-light">No sessions added</p>
+          <p className="text-fg-default/50 text-base font-light">No sessions added</p>
         )}
       </main>
       <aside>
         <Link
           href="/dashboard/routines/create/sessions"
-          className="border-subtle/20 text-strong block aspect-square cursor-pointer rounded border bg-zinc-900 p-1 transition-colors hover:bg-zinc-800/80"
+          className="border-subtle/20 text-fg-strong block aspect-square cursor-pointer rounded border bg-zinc-900 p-1 transition-colors hover:bg-zinc-800/80"
         >
           <IconCirclePlus strokeWidth="1" />
         </Link>

--- a/src/modules/session/presentation/ui/components/FormSessionsBox.tsx
+++ b/src/modules/session/presentation/ui/components/FormSessionsBox.tsx
@@ -18,7 +18,7 @@ export function FormSessionsBox() {
       <aside>
         <Link
           href="/dashboard/routines/create/sessions"
-          className="border-subtle/20 text-fg-strong block aspect-square cursor-pointer rounded border bg-zinc-900 p-1 transition-colors hover:bg-zinc-800/80"
+          className="border-bd-default text-fg-strong block aspect-square cursor-pointer rounded border bg-zinc-900 p-1 transition-colors hover:bg-zinc-800/80"
         >
           <IconCirclePlus strokeWidth="1" />
         </Link>

--- a/src/modules/session/presentation/ui/components/LastSessions.tsx
+++ b/src/modules/session/presentation/ui/components/LastSessions.tsx
@@ -88,7 +88,7 @@ function SessionListItem({
         <StatusIcon status={status} className="size-5" />
         {name}
       </span>
-      <span className="text-default/50 flex items-center gap-4 text-right text-sm font-light">
+      <span className="text-fg-default/50 flex items-center gap-4 text-right text-sm font-light">
         {date}
         <TypeDayIcon type={type} className="size-5" />
       </span>

--- a/src/modules/session/presentation/ui/components/SessionDetails.tsx
+++ b/src/modules/session/presentation/ui/components/SessionDetails.tsx
@@ -47,7 +47,7 @@ export function SessionDetails({
         </main>
         {session.date && (
           <aside>
-            <span className="bg-subtle/5 text-default/50 rounded-full px-3 py-1 text-sm">
+            <span className="bg-subtle/5 text-fg-default/50 rounded-full px-3 py-1 text-sm">
               {session.date}
             </span>
           </aside>
@@ -56,7 +56,7 @@ export function SessionDetails({
       <main className="font-light">
         <ul>
           <li
-            className={`text-default/50 grid w-full gap-1 text-center text-sm font-light ${withStatusGridClass}`}
+            className={`text-fg-default/50 grid w-full gap-1 text-center text-sm font-light ${withStatusGridClass}`}
           >
             {withStatus && <span></span>}
             <span className="text-left">Exercise</span>

--- a/src/modules/session/presentation/ui/components/SessionDetails.tsx
+++ b/src/modules/session/presentation/ui/components/SessionDetails.tsx
@@ -47,7 +47,7 @@ export function SessionDetails({
         </main>
         {session.date && (
           <aside>
-            <span className="bg-subtle/5 text-fg-default/50 rounded-full px-3 py-1 text-sm">
+            <span className="text-fg-default/50 bg-fill-middle rounded-full px-3 py-1 text-sm">
               {session.date}
             </span>
           </aside>

--- a/src/modules/session/presentation/ui/components/SessionExerciseList.tsx
+++ b/src/modules/session/presentation/ui/components/SessionExerciseList.tsx
@@ -21,7 +21,7 @@ export function SessionExercisesList({ exercises }: { exercises: ExerciseDTO[] }
 
       {exercises.map(({ name, sets, reps, weight, id }, index) => (
         <SessionExerciseRow key={id}>
-          <li className="text-muted">{index + 1}</li>
+          <li className="text-fg-subtle">{index + 1}</li>
           <li className="truncate">{name}</li>
           <li className="text-center">{sets}</li>
           <li className="text-center">{reps}</li>
@@ -29,7 +29,7 @@ export function SessionExercisesList({ exercises }: { exercises: ExerciseDTO[] }
         </SessionExerciseRow>
       ))}
       <li className="flex items-center justify-center">
-        <IconDots className="text-muted/50" />
+        <IconDots className="text-fg-subtle/50" />
       </li>
     </ul>
   );

--- a/src/modules/session/presentation/ui/components/SessionExerciseList.tsx
+++ b/src/modules/session/presentation/ui/components/SessionExerciseList.tsx
@@ -21,7 +21,7 @@ export function SessionExercisesList({ exercises }: { exercises: ExerciseDTO[] }
 
       {exercises.map(({ name, sets, reps, weight, id }, index) => (
         <SessionExerciseRow key={id}>
-          <li className="fg-muted">{index + 1}</li>
+          <li className="text-muted">{index + 1}</li>
           <li className="truncate">{name}</li>
           <li className="text-center">{sets}</li>
           <li className="text-center">{reps}</li>

--- a/src/modules/session/presentation/ui/components/SessionExerciseRow.tsx
+++ b/src/modules/session/presentation/ui/components/SessionExerciseRow.tsx
@@ -7,7 +7,12 @@ type Props = {
 
 export function SessionExerciseRow({ children, header }: Props) {
   return (
-    <li className={twMerge('py-0.5', header ? 'text-strong font-normal' : 'text-muted font-light')}>
+    <li
+      className={twMerge(
+        'py-0.5',
+        header ? 'text-fg-strong font-normal' : 'text-fg-subtle font-light'
+      )}
+    >
       <ul className="grid grid-cols-[1rem_1fr_3rem_3rem_3rem] place-content-center gap-1">
         {children}
       </ul>

--- a/src/modules/session/presentation/ui/components/SessionExerciseRow.tsx
+++ b/src/modules/session/presentation/ui/components/SessionExerciseRow.tsx
@@ -7,7 +7,7 @@ type Props = {
 
 export function SessionExerciseRow({ children, header }: Props) {
   return (
-    <li className={twMerge('py-0.5', header ? 'fg-strong font-normal' : 'fg-muted font-light')}>
+    <li className={twMerge('py-0.5', header ? 'text-strong font-normal' : 'text-muted font-light')}>
       <ul className="grid grid-cols-[1rem_1fr_3rem_3rem_3rem] place-content-center gap-1">
         {children}
       </ul>

--- a/src/modules/status/components/StatusIcons.tsx
+++ b/src/modules/status/components/StatusIcons.tsx
@@ -3,11 +3,11 @@ import { SIconCircleCheck } from '@/presentation/globals/components/icons/solid/
 import { SIconCircleX } from '@/presentation/globals/components/icons/solid/SIconCircleX';
 
 export function CompletedIcon({ className }: { className?: string }) {
-  return <SIconCircleCheck className={`${className} fg-complete`} />;
+  return <SIconCircleCheck className={`${className} text-complete`} />;
 }
 
 export function CanceledIcon({ className }: { className?: string }) {
-  return <SIconCircleX className={`${className} fg-cancel`} />;
+  return <SIconCircleX className={`${className} text-cancel`} />;
 }
 
 export function PendingIcon({ className }: { className?: string }) {

--- a/src/modules/status/components/StatusIcons.tsx
+++ b/src/modules/status/components/StatusIcons.tsx
@@ -3,11 +3,11 @@ import { SIconCircleCheck } from '@/presentation/globals/components/icons/solid/
 import { SIconCircleX } from '@/presentation/globals/components/icons/solid/SIconCircleX';
 
 export function CompletedIcon({ className }: { className?: string }) {
-  return <SIconCircleCheck className={`${className} text-complete`} />;
+  return <SIconCircleCheck className={`${className} text-success`} />;
 }
 
 export function CanceledIcon({ className }: { className?: string }) {
-  return <SIconCircleX className={`${className} text-cancel`} />;
+  return <SIconCircleX className={`${className} text-danger`} />;
 }
 
 export function PendingIcon({ className }: { className?: string }) {

--- a/src/modules/tracking/presentation/ui/components/ActivitiesToday.tsx
+++ b/src/modules/tracking/presentation/ui/components/ActivitiesToday.tsx
@@ -64,14 +64,15 @@ export function ActivitiesToday({ className }: { className?: string }) {
       <footer>
         <Button
           type="button"
-          variantConfig={{
+          variant={{
             size: 'sm',
             color: 'primary',
+            type: 'iconText',
           }}
           className="flex items-center gap-1"
+          Icon={IconCirclePlus}
         >
-          <IconCirclePlus className="size-5" />
-          <span>Register</span>
+          Register
         </Button>
       </footer>
     </Card>

--- a/src/modules/tracking/presentation/ui/components/BestRecords.tsx
+++ b/src/modules/tracking/presentation/ui/components/BestRecords.tsx
@@ -14,13 +14,13 @@ function BestRecordItem({ record }: { record: BestRecordItemType }) {
   return (
     <article className="bg-subtle/5 rounded-lg px-4 py-1">
       <header className="flex items-center justify-between">
-        <h3 className="fg-strong">{name}</h3>
+        <h3 className="text-strong">{name}</h3>
         <aside>
-          <span className="fg-default/50 text-sm font-light">{date}</span>
+          <span className="text-default/50 text-sm font-light">{date}</span>
         </aside>
       </header>
       <main className="flex items-baseline gap-1">
-        <span className="fg-strong text-base">{value}</span>{' '}
+        <span className="text-strong text-base">{value}</span>{' '}
         <span className="text-sm font-light">{metric}</span>
       </main>
     </article>

--- a/src/modules/tracking/presentation/ui/components/BestRecords.tsx
+++ b/src/modules/tracking/presentation/ui/components/BestRecords.tsx
@@ -14,13 +14,13 @@ function BestRecordItem({ record }: { record: BestRecordItemType }) {
   return (
     <article className="bg-subtle/5 rounded-lg px-4 py-1">
       <header className="flex items-center justify-between">
-        <h3 className="text-strong">{name}</h3>
+        <h3 className="text-fg-strong">{name}</h3>
         <aside>
-          <span className="text-default/50 text-sm font-light">{date}</span>
+          <span className="text-fg-default/50 text-sm font-light">{date}</span>
         </aside>
       </header>
       <main className="flex items-baseline gap-1">
-        <span className="text-strong text-base">{value}</span>{' '}
+        <span className="text-fg-strong text-base">{value}</span>{' '}
         <span className="text-sm font-light">{metric}</span>
       </main>
     </article>

--- a/src/modules/tracking/presentation/ui/components/BestRecords.tsx
+++ b/src/modules/tracking/presentation/ui/components/BestRecords.tsx
@@ -12,7 +12,7 @@ type BestRecordItemType = {
 function BestRecordItem({ record }: { record: BestRecordItemType }) {
   const { name, metric, value, date } = record;
   return (
-    <article className="bg-subtle/5 rounded-lg px-4 py-1">
+    <article className="bg-fill-middle rounded-lg px-4 py-1">
       <header className="flex items-center justify-between">
         <h3 className="text-fg-strong">{name}</h3>
         <aside>

--- a/src/modules/tracking/presentation/ui/components/Counter.tsx
+++ b/src/modules/tracking/presentation/ui/components/Counter.tsx
@@ -3,7 +3,7 @@ import type { IconTypes } from '@/presentation/globals/presentation.types';
 export function Counter({ className, number }: { className?: string; number: number }) {
   return (
     <span
-      className={`font-funnel-display fg-accent p-0.5 text-3xl leading-none font-medium ${className}`}
+      className={`font-funnel-display text-accent p-0.5 text-3xl leading-none font-medium ${className}`}
     >
       {number}
     </span>
@@ -11,5 +11,5 @@ export function Counter({ className, number }: { className?: string; number: num
 }
 
 export function CounterIcon({ icon: Icon }: { icon: IconTypes }) {
-  return <Icon className="fg-accent size-8" strokeWidth="2" />;
+  return <Icon className="text-accent size-8" strokeWidth="2" />;
 }

--- a/src/modules/tracking/presentation/ui/components/CurrentGoals.tsx
+++ b/src/modules/tracking/presentation/ui/components/CurrentGoals.tsx
@@ -29,13 +29,13 @@ function GoalItem({ className = '', goal }: { className?: string; goal: GoalItem
 
   return (
     <article
-      className={`bg-subtle/5 text-strong flex flex-col gap-1 rounded-lg px-4 py-2 ${completedClass} ${className}`}
+      className={`bg-subtle/5 text-fg-strong flex flex-col gap-1 rounded-lg px-4 py-2 ${completedClass} ${className}`}
     >
       <header className="flex items-center justify-between gap-2">
         <h3 className="text-base">{name}</h3>
         <aside>
           <span
-            className={`font-light ${completedClass || 'text-default/50'}`}
+            className={`font-light ${completedClass || 'text-fg-default/50'}`}
           >{`${value} / ${target}`}</span>
         </aside>
       </header>

--- a/src/modules/tracking/presentation/ui/components/CurrentGoals.tsx
+++ b/src/modules/tracking/presentation/ui/components/CurrentGoals.tsx
@@ -8,7 +8,7 @@ function PercentageBar({ value, target }: { value: number; target: number }) {
   return (
     <div className="bg-subtle/20 h-1 w-full overflow-hidden rounded-full">
       <div
-        className={`bg-complete h-1 rounded-full transition-all duration-500 ${styles['animate-scale-x-right']}`}
+        className={`bg-success h-1 rounded-full transition-all duration-500 ${styles['animate-scale-x-right']}`}
         style={{ width: `${percentage}%` }}
       ></div>
     </div>
@@ -25,7 +25,7 @@ type GoalItemType = {
 function GoalItem({ className = '', goal }: { className?: string; goal: GoalItemType }) {
   const { name, value, target } = goal;
 
-  const completedClass = value >= target ? 'text-complete' : '';
+  const completedClass = value >= target ? 'text-success' : '';
 
   return (
     <article

--- a/src/modules/tracking/presentation/ui/components/CurrentGoals.tsx
+++ b/src/modules/tracking/presentation/ui/components/CurrentGoals.tsx
@@ -25,11 +25,11 @@ type GoalItemType = {
 function GoalItem({ className = '', goal }: { className?: string; goal: GoalItemType }) {
   const { name, value, target } = goal;
 
-  const completedClass = value >= target ? 'fg-complete' : '';
+  const completedClass = value >= target ? 'text-complete' : '';
 
   return (
     <article
-      className={`bg-subtle/5 fg-strong flex flex-col gap-1 rounded-lg px-4 py-2 ${completedClass} ${className}`}
+      className={`bg-subtle/5 text-strong flex flex-col gap-1 rounded-lg px-4 py-2 ${completedClass} ${className}`}
     >
       <header className="flex items-center justify-between gap-2">
         <h3 className="text-base">{name}</h3>

--- a/src/modules/tracking/presentation/ui/components/CurrentGoals.tsx
+++ b/src/modules/tracking/presentation/ui/components/CurrentGoals.tsx
@@ -6,7 +6,7 @@ import styles from '@/modules/tracking/presentation/ui/components/CurrentGoals.m
 function PercentageBar({ value, target }: { value: number; target: number }) {
   const percentage = Math.min((value / target) * 100, 100);
   return (
-    <div className="bg-subtle/20 h-1 w-full overflow-hidden rounded-full">
+    <div className="bg-fill-top h-1 w-full overflow-hidden rounded-full">
       <div
         className={`bg-success h-1 rounded-full transition-all duration-500 ${styles['animate-scale-x-right']}`}
         style={{ width: `${percentage}%` }}
@@ -29,7 +29,7 @@ function GoalItem({ className = '', goal }: { className?: string; goal: GoalItem
 
   return (
     <article
-      className={`bg-subtle/5 text-fg-strong flex flex-col gap-1 rounded-lg px-4 py-2 ${completedClass} ${className}`}
+      className={`bg-fill-middle text-fg-strong flex flex-col gap-1 rounded-lg px-4 py-2 ${completedClass} ${className}`}
     >
       <header className="flex items-center justify-between gap-2">
         <h3 className="text-base">{name}</h3>

--- a/src/modules/tracking/presentation/ui/components/CurrentWeekStatus.tsx
+++ b/src/modules/tracking/presentation/ui/components/CurrentWeekStatus.tsx
@@ -56,14 +56,14 @@ function StatusDay({ status, className }: { status: StatusDayType; className?: s
   if (status === 'completed')
     return (
       <span className={` ${className}`}>
-        <StatusDaySolidIcon className="text-complete" icon={SIconCircleCheck} />
+        <StatusDaySolidIcon className="text-success" icon={SIconCircleCheck} />
       </span>
     );
 
   if (status === 'canceled')
     return (
       <span className={` ${className}`}>
-        <StatusDaySolidIcon className="text-cancel" icon={SIconCircleX} />
+        <StatusDaySolidIcon className="text-danger" icon={SIconCircleX} />
       </span>
     );
 

--- a/src/modules/tracking/presentation/ui/components/CurrentWeekStatus.tsx
+++ b/src/modules/tracking/presentation/ui/components/CurrentWeekStatus.tsx
@@ -77,7 +77,7 @@ function StatusDay({ status, className }: { status: StatusDayType; className?: s
   // default return if status === "next"
   return (
     <span className={`${className}`}>
-      <StatusDayIcon className="text-default/25" icon={IconCircleOutline} />
+      <StatusDayIcon className="text-fg-default/25" icon={IconCircleOutline} />
     </span>
   );
 }
@@ -96,7 +96,9 @@ export function CurrentWeekStatus({ className = '' }: { className?: string }) {
           const className = getStatusTextColorClass(status);
           return (
             <div key={day} className="flex flex-col justify-center" title={title}>
-              <span className={`text-center text-sm font-black ${className || 'text-default/75'}`}>
+              <span
+                className={`text-center text-sm font-black ${className || 'text-fg-default/75'}`}
+              >
                 {dayName}
               </span>
               <StatusDay status={status} />

--- a/src/modules/tracking/presentation/ui/components/CurrentWeekStatus.tsx
+++ b/src/modules/tracking/presentation/ui/components/CurrentWeekStatus.tsx
@@ -56,21 +56,21 @@ function StatusDay({ status, className }: { status: StatusDayType; className?: s
   if (status === 'completed')
     return (
       <span className={` ${className}`}>
-        <StatusDaySolidIcon className="fg-complete" icon={SIconCircleCheck} />
+        <StatusDaySolidIcon className="text-complete" icon={SIconCircleCheck} />
       </span>
     );
 
   if (status === 'canceled')
     return (
       <span className={` ${className}`}>
-        <StatusDaySolidIcon className="fg-cancel" icon={SIconCircleX} />
+        <StatusDaySolidIcon className="text-cancel" icon={SIconCircleX} />
       </span>
     );
 
   if (status === 'current')
     return (
       <span className={` ${className}`}>
-        <StatusDayIcon className="fg-accent" icon={IconCircleOutline} />
+        <StatusDayIcon className="text-accent" icon={IconCircleOutline} />
       </span>
     );
 

--- a/src/modules/tracking/presentation/ui/components/SessionsDetails.tsx
+++ b/src/modules/tracking/presentation/ui/components/SessionsDetails.tsx
@@ -8,7 +8,7 @@ export function SessionsDetails({ className }: { className?: string }) {
   const [prevDate, nextDate] = getPrevAndNextDate(selectedDate);
 
   return (
-    <main className={`bg-middle/20 flex h-86 flex-1 flex-col gap-4 rounded p-8 ${className}`}>
+    <main className={`bg-base/20 flex h-86 flex-1 flex-col gap-4 rounded p-8 ${className}`}>
       <header className="font-funnel-display text-center text-2xl font-light">Details</header>
       <div className="mx-auto flex w-full max-w-5xl items-center justify-between gap-4">
         <TrackingDay date={prevDate} />

--- a/src/modules/tracking/presentation/ui/components/SessionsDetails.tsx
+++ b/src/modules/tracking/presentation/ui/components/SessionsDetails.tsx
@@ -8,7 +8,7 @@ export function SessionsDetails({ className }: { className?: string }) {
   const [prevDate, nextDate] = getPrevAndNextDate(selectedDate);
 
   return (
-    <main className={`bg-base/20 flex h-86 flex-1 flex-col gap-4 rounded p-8 ${className}`}>
+    <main className={`bg-fill-base/20 flex h-86 flex-1 flex-col gap-4 rounded p-8 ${className}`}>
       <header className="font-funnel-display text-center text-2xl font-light">Details</header>
       <div className="mx-auto flex w-full max-w-5xl items-center justify-between gap-4">
         <TrackingDay date={prevDate} />

--- a/src/modules/tracking/presentation/ui/components/SessionsHistory.tsx
+++ b/src/modules/tracking/presentation/ui/components/SessionsHistory.tsx
@@ -74,7 +74,7 @@ export function SessionsHistory({ className }: { className?: string }) {
           </section>
           <section className="flex flex-col gap-4">
             <header className="flex items-center gap-2">
-              <IconCalendarClock className="text-muted" strokeWidth="1.5" />
+              <IconCalendarClock className="text-fg-subtle" strokeWidth="1.5" />
               <MonthDateSelector />
               <YearDateSelector />
             </header>

--- a/src/modules/tracking/presentation/ui/components/SessionsHistory.tsx
+++ b/src/modules/tracking/presentation/ui/components/SessionsHistory.tsx
@@ -74,7 +74,7 @@ export function SessionsHistory({ className }: { className?: string }) {
           </section>
           <section className="flex flex-col gap-4">
             <header className="flex items-center gap-2">
-              <IconCalendarClock className="fg-muted" strokeWidth="1.5" />
+              <IconCalendarClock className="text-muted" strokeWidth="1.5" />
               <MonthDateSelector />
               <YearDateSelector />
             </header>

--- a/src/modules/tracking/presentation/ui/components/SessionsHistory.tsx
+++ b/src/modules/tracking/presentation/ui/components/SessionsHistory.tsx
@@ -78,7 +78,7 @@ export function SessionsHistory({ className }: { className?: string }) {
               <MonthDateSelector />
               <YearDateSelector />
             </header>
-            <SubtleCard className="border-subtle/10 rounded-lg border">
+            <SubtleCard className="border-bd-default rounded-lg border">
               <SessionDetails session={session} />
             </SubtleCard>
           </section>

--- a/src/modules/tracking/presentation/ui/components/TrackingDay.tsx
+++ b/src/modules/tracking/presentation/ui/components/TrackingDay.tsx
@@ -79,9 +79,9 @@ export function TrackingDay({
       className={`group group border-subtle/20 relative flex w-full flex-col rounded-md border transition-colors hover:border-zinc-900 ${main ? 'min-h-54' : 'min-h-48'} ${className} ${dayTypeClass}`}
     >
       <header
-        className={`flex items-center justify-between bg-zinc-900/80 ${main ? 'h-10 px-4 text-base' : 'h-8 px-2 text-sm'} group-hover:text-strong rounded-t transition-colors`}
+        className={`flex items-center justify-between bg-zinc-900/80 ${main ? 'h-10 px-4 text-base' : 'h-8 px-2 text-sm'} group-hover:text-fg-strong rounded-t transition-colors`}
       >
-        <span className="text-strong flex-1 cursor-pointer overflow-hidden pr-2 font-medium text-ellipsis whitespace-nowrap hover:text-current/50">
+        <span className="text-fg-strong flex-1 cursor-pointer overflow-hidden pr-2 font-medium text-ellipsis whitespace-nowrap hover:text-current/50">
           {session.name}
         </span>
         <aside className="flex items-center gap-1">

--- a/src/modules/tracking/presentation/ui/components/TrackingDay.tsx
+++ b/src/modules/tracking/presentation/ui/components/TrackingDay.tsx
@@ -44,7 +44,7 @@ function DefaultStatusIcon({ Icon }: { Icon: IconTypes }) {
 function WeekDayTooltip({ date }: { date: Date }) {
   const dayOfWeek = DAYS[(date.getDay() + 1) as DayWeeksType].shortName;
   return (
-    <div className="bg-sec after:bg-base absolute bottom-[calc(100%+0.75rem)] left-2 hidden h-fit w-fit rounded-full px-4 group-hover:block after:absolute after:inset-0 after:top-auto after:-bottom-1 after:z-0 after:mx-auto after:size-2 after:rotate-45">
+    <div className="bg-sec after:bg-fill-base absolute bottom-[calc(100%+0.75rem)] left-2 hidden h-fit w-fit rounded-full px-4 group-hover:block after:absolute after:inset-0 after:top-auto after:-bottom-1 after:z-0 after:mx-auto after:size-2 after:rotate-45">
       <span className="block w-fit py-1.5 text-xs leading-none font-medium text-zinc-400">
         {dayOfWeek}
       </span>

--- a/src/modules/tracking/presentation/ui/components/TrackingDay.tsx
+++ b/src/modules/tracking/presentation/ui/components/TrackingDay.tsx
@@ -44,7 +44,7 @@ function DefaultStatusIcon({ Icon }: { Icon: IconTypes }) {
 function WeekDayTooltip({ date }: { date: Date }) {
   const dayOfWeek = DAYS[(date.getDay() + 1) as DayWeeksType].shortName;
   return (
-    <div className="bg-sec after:bg-middle absolute bottom-[calc(100%+0.75rem)] left-2 hidden h-fit w-fit rounded-full px-4 group-hover:block after:absolute after:inset-0 after:top-auto after:-bottom-1 after:z-0 after:mx-auto after:size-2 after:rotate-45">
+    <div className="bg-sec after:bg-base absolute bottom-[calc(100%+0.75rem)] left-2 hidden h-fit w-fit rounded-full px-4 group-hover:block after:absolute after:inset-0 after:top-auto after:-bottom-1 after:z-0 after:mx-auto after:size-2 after:rotate-45">
       <span className="block w-fit py-1.5 text-xs leading-none font-medium text-zinc-400">
         {dayOfWeek}
       </span>
@@ -79,9 +79,9 @@ export function TrackingDay({
       className={`group group border-subtle/20 relative flex w-full flex-col rounded-md border transition-colors hover:border-zinc-900 ${main ? 'min-h-54' : 'min-h-48'} ${className} ${dayTypeClass}`}
     >
       <header
-        className={`flex items-center justify-between bg-zinc-900/80 ${main ? 'h-10 px-4 text-base' : 'h-8 px-2 text-sm'} group-hover:fg-strong rounded-t transition-colors`}
+        className={`flex items-center justify-between bg-zinc-900/80 ${main ? 'h-10 px-4 text-base' : 'h-8 px-2 text-sm'} group-hover:text-strong rounded-t transition-colors`}
       >
-        <span className="fg-strong flex-1 cursor-pointer overflow-hidden pr-2 font-medium text-ellipsis whitespace-nowrap hover:text-current/50">
+        <span className="text-strong flex-1 cursor-pointer overflow-hidden pr-2 font-medium text-ellipsis whitespace-nowrap hover:text-current/50">
           {session.name}
         </span>
         <aside className="flex items-center gap-1">

--- a/src/modules/tracking/presentation/ui/components/TrackingDay.tsx
+++ b/src/modules/tracking/presentation/ui/components/TrackingDay.tsx
@@ -76,7 +76,7 @@ export function TrackingDay({
 
   return (
     <article
-      className={`group group border-subtle/20 relative flex w-full flex-col rounded-md border transition-colors hover:border-zinc-900 ${main ? 'min-h-54' : 'min-h-48'} ${className} ${dayTypeClass}`}
+      className={`group group border-bd-default relative flex w-full flex-col rounded-md border transition-colors hover:border-zinc-900 ${main ? 'min-h-54' : 'min-h-48'} ${className} ${dayTypeClass}`}
     >
       <header
         className={`flex items-center justify-between bg-zinc-900/80 ${main ? 'h-10 px-4 text-base' : 'h-8 px-2 text-sm'} group-hover:text-fg-strong rounded-t transition-colors`}

--- a/src/modules/user/presentation/ui/components/UserInfo.tsx
+++ b/src/modules/user/presentation/ui/components/UserInfo.tsx
@@ -14,7 +14,7 @@ export async function UserInfo({ className = '' }: { className?: string }) {
           <UserAvatar src={user?.image} size={36} />
         </figure>
         <header className={`hidden leading-normal lg:block`}>
-          <h4 className="fg-strong h-5 text-left text-base font-normal">{user.name}</h4>
+          <h4 className="text-strong h-5 text-left text-base font-normal">{user.name}</h4>
           <p className="overflow-y-clip text-sm font-light">{user.email}</p>
         </header>
       </main>

--- a/src/modules/user/presentation/ui/components/UserInfo.tsx
+++ b/src/modules/user/presentation/ui/components/UserInfo.tsx
@@ -14,7 +14,7 @@ export async function UserInfo({ className = '' }: { className?: string }) {
           <UserAvatar src={user?.image} size={36} />
         </figure>
         <header className={`hidden leading-normal lg:block`}>
-          <h4 className="text-strong h-5 text-left text-base font-normal">{user.name}</h4>
+          <h4 className="text-fg-strong h-5 text-left text-base font-normal">{user.name}</h4>
           <p className="overflow-y-clip text-sm font-light">{user.email}</p>
         </header>
       </main>

--- a/src/modules/user/presentation/ui/components/UserLogout.tsx
+++ b/src/modules/user/presentation/ui/components/UserLogout.tsx
@@ -4,7 +4,7 @@ import { UserAvatar } from './UserAvatar';
 export function UserLogout({ src }: { src?: string | null }) {
   return (
     <div className="flex items-center gap-4">
-      <picture className="bg-subtle/50 grid aspect-square size-8 place-items-center overflow-hidden rounded-full">
+      <picture className="grid aspect-square size-8 place-items-center overflow-hidden rounded-full">
         <UserAvatar src={src} />
       </picture>
       <LogOutButton />

--- a/src/presentation/globals/components/AppLogo.tsx
+++ b/src/presentation/globals/components/AppLogo.tsx
@@ -8,7 +8,7 @@ export function Imagotype({
   return (
     <div className={`flex gap-2 font-bold tracking-tight ${className}`}>
       <Logo size={isotypeSize} />
-      <span className="font-funnel-display text-strong hidden text-2xl lg:block">AtlasWay</span>
+      <span className="font-funnel-display text-fg-strong hidden text-2xl lg:block">AtlasWay</span>
     </div>
   );
 }

--- a/src/presentation/globals/components/AppLogo.tsx
+++ b/src/presentation/globals/components/AppLogo.tsx
@@ -8,7 +8,7 @@ export function Imagotype({
   return (
     <div className={`flex gap-2 font-bold tracking-tight ${className}`}>
       <Logo size={isotypeSize} />
-      <span className="font-funnel-display fg-strong hidden text-2xl lg:block">AtlasWay</span>
+      <span className="font-funnel-display text-strong hidden text-2xl lg:block">AtlasWay</span>
     </div>
   );
 }

--- a/src/presentation/globals/components/DraggableBadge.tsx
+++ b/src/presentation/globals/components/DraggableBadge.tsx
@@ -16,7 +16,7 @@ export function DraggableBadge(props: Props) {
       className={twMerge(
         `flex h-8 w-fit items-center justify-center gap-1 border`,
         'text-strong cursor-grab rounded-lg py-1 pl-1 text-sm',
-        'bg-base shadow-back light:shadow-black/5 border-bd-default shadow-lg',
+        'bg-fill-base shadow-back light:shadow-black/5 border-bd-default shadow-lg',
         className ?? ''
       )}
     >

--- a/src/presentation/globals/components/DraggableBadge.tsx
+++ b/src/presentation/globals/components/DraggableBadge.tsx
@@ -15,7 +15,7 @@ export function DraggableBadge(props: Props) {
       {...restProps}
       className={twMerge(
         `flex h-8 w-fit items-center justify-center gap-1 border`,
-        'text-strong cursor-grab rounded-lg py-1 pl-1 text-sm',
+        'text-fg-strong cursor-grab rounded-lg py-1 pl-1 text-sm',
         'bg-fill-base shadow-back light:shadow-black/5 border-bd-default shadow-lg',
         className ?? ''
       )}

--- a/src/presentation/globals/components/DraggableBadge.tsx
+++ b/src/presentation/globals/components/DraggableBadge.tsx
@@ -15,8 +15,8 @@ export function DraggableBadge(props: Props) {
       {...restProps}
       className={twMerge(
         `flex h-8 w-fit items-center justify-center gap-1 border`,
-        'fg-strong cursor-grab rounded-lg py-1 pl-1 text-sm',
-        'bg-middle shadow-back light:shadow-black/5 border-bd-default shadow-lg',
+        'text-strong cursor-grab rounded-lg py-1 pl-1 text-sm',
+        'bg-base shadow-back light:shadow-black/5 border-bd-default shadow-lg',
         className ?? ''
       )}
     >

--- a/src/presentation/globals/components/DraggableBadge.tsx
+++ b/src/presentation/globals/components/DraggableBadge.tsx
@@ -24,12 +24,11 @@ export function DraggableBadge(props: Props) {
       <span className="w-15 truncate">{children}</span>
       {onRemove && (
         <Button
-          variantConfig={{ type: 'square', size: 'xs', color: 'simple' }}
+          variant={{ type: 'icon', size: 'xs', color: 'simple' }}
           aria-label="Remove item"
+          Icon={IconXMark}
           onClick={onRemove}
-        >
-          <IconXMark className="size-5" />
-        </Button>
+        />
       )}
     </div>
   );

--- a/src/presentation/globals/components/DropdownList.tsx
+++ b/src/presentation/globals/components/DropdownList.tsx
@@ -31,7 +31,7 @@ export function DropdownList({
 
   return (
     <select
-      className={`bg-back border ${className} appearance:[base-select]`}
+      className={`bg-fill-back border ${className} appearance:[base-select]`}
       onChange={handleChange}
       value={selectedOption}
     >
@@ -41,7 +41,7 @@ export function DropdownList({
         </option>
       )}
       {values.map((value) => (
-        <option key={value.value} value={value.value} className="bg-back">
+        <option key={value.value} value={value.value} className="bg-fill-back">
           {value.label}
         </option>
       ))}

--- a/src/presentation/globals/components/modal/CloseButton.tsx
+++ b/src/presentation/globals/components/modal/CloseButton.tsx
@@ -17,7 +17,7 @@ export default function CloseButton({
   return (
     <Button
       type="button"
-      variantConfig={{
+      variant={{
         color: 'simple',
       }}
       className={className}

--- a/src/presentation/globals/components/modal/Modal.tsx
+++ b/src/presentation/globals/components/modal/Modal.tsx
@@ -21,7 +21,7 @@ export function Modal({
 
   return (
     <div className={`fixed inset-0 z-50 m-auto flex items-center justify-center ${className}`}>
-      <div ref={ref} className="bg-middle z-50 rounded-2xl shadow-lg">
+      <div ref={ref} className="bg-base z-50 rounded-2xl shadow-lg">
         {children}
       </div>
       <div className="fixed inset-0 z-0 bg-black/30 select-none"></div>

--- a/src/presentation/globals/components/modal/Modal.tsx
+++ b/src/presentation/globals/components/modal/Modal.tsx
@@ -21,7 +21,7 @@ export function Modal({
 
   return (
     <div className={`fixed inset-0 z-50 m-auto flex items-center justify-center ${className}`}>
-      <div ref={ref} className="bg-base z-50 rounded-2xl shadow-lg">
+      <div ref={ref} className="bg-fill-base z-50 rounded-2xl shadow-lg">
         {children}
       </div>
       <div className="fixed inset-0 z-0 bg-black/30 select-none"></div>

--- a/src/presentation/globals/components/table/TableHeader.tsx
+++ b/src/presentation/globals/components/table/TableHeader.tsx
@@ -4,7 +4,7 @@ type Props = {
 export function TableHeader({ children }: Props) {
   return (
     <thead className="h-10 divide-y">
-      <tr className="text-muted text-sm font-light md:text-base">{children}</tr>
+      <tr className="text-fg-subtle text-sm font-light md:text-base">{children}</tr>
     </thead>
   );
 }

--- a/src/presentation/globals/components/table/TableHeader.tsx
+++ b/src/presentation/globals/components/table/TableHeader.tsx
@@ -4,7 +4,7 @@ type Props = {
 export function TableHeader({ children }: Props) {
   return (
     <thead className="h-10 divide-y">
-      <tr className="fg-muted text-sm font-light md:text-base">{children}</tr>
+      <tr className="text-muted text-sm font-light md:text-base">{children}</tr>
     </thead>
   );
 }

--- a/src/presentation/globals/components/table/TableWrapper.tsx
+++ b/src/presentation/globals/components/table/TableWrapper.tsx
@@ -4,7 +4,7 @@ type Props = {
 
 export function TableWrapper({ children }: Props) {
   return (
-    <div className="bg-middle border-bd-default rounded-xl border">
+    <div className="bg-base border-bd-default rounded-xl border">
       <table className="w-full table-fixed">{children}</table>
     </div>
   );

--- a/src/presentation/globals/components/table/TableWrapper.tsx
+++ b/src/presentation/globals/components/table/TableWrapper.tsx
@@ -4,7 +4,7 @@ type Props = {
 
 export function TableWrapper({ children }: Props) {
   return (
-    <div className="bg-base border-bd-default rounded-xl border">
+    <div className="bg-fill-base border-bd-default rounded-xl border">
       <table className="w-full table-fixed">{children}</table>
     </div>
   );

--- a/src/presentation/globals/components/variants/icon.variants.ts
+++ b/src/presentation/globals/components/variants/icon.variants.ts
@@ -9,4 +9,8 @@ export const iconVariant = tv({
       lg: 'size-6 stroke-2',
     },
   },
+
+  defaultVariants: {
+    button: 'md',
+  },
 });

--- a/src/presentation/globals/components/variants/icon.variants.ts
+++ b/src/presentation/globals/components/variants/icon.variants.ts
@@ -1,0 +1,12 @@
+import { tv } from 'tailwind-variants';
+
+export const iconVariant = tv({
+  variants: {
+    button: {
+      xs: 'size-5 stroke-2',
+      sm: 'size-5 stroke-2',
+      md: 'size-6 stroke-2',
+      lg: 'size-6 stroke-2',
+    },
+  },
+});

--- a/src/presentation/globals/constants/classes.ts
+++ b/src/presentation/globals/constants/classes.ts
@@ -1,6 +1,6 @@
 export const STATUS_TEXT_COLORS = {
-  completed: 'text-complete font-medium',
-  canceled: 'text-cancel font-medium',
+  completed: 'text-success font-medium',
+  canceled: 'text-danger font-medium',
   pending: 'text-fg-default',
 };
 

--- a/src/presentation/globals/constants/classes.ts
+++ b/src/presentation/globals/constants/classes.ts
@@ -1,7 +1,7 @@
 export const STATUS_TEXT_COLORS = {
   completed: 'text-complete font-medium',
   canceled: 'text-cancel font-medium',
-  pending: 'text-default',
+  pending: 'text-fg-default',
 };
 
 export const WITH_STATUS_GRID_COLS_CLASS = {

--- a/src/presentation/globals/constants/classes.ts
+++ b/src/presentation/globals/constants/classes.ts
@@ -1,7 +1,7 @@
 export const STATUS_TEXT_COLORS = {
-  completed: 'fg-complete font-medium',
-  canceled: 'fg-cancel font-medium',
-  pending: 'fg-default',
+  completed: 'text-complete font-medium',
+  canceled: 'text-cancel font-medium',
+  pending: 'text-default',
 };
 
 export const WITH_STATUS_GRID_COLS_CLASS = {

--- a/src/presentation/modules/button/button.config.ts
+++ b/src/presentation/modules/button/button.config.ts
@@ -6,13 +6,6 @@ export const buttonVariant = tv({
   variants: {
     color: {
       primary: 'bg-primary fg-strong-dark hover:bg-primary/90',
-      primaryDeluxe: twMerge(
-        'fg-strong-dark to-primary from-secondary from-10%',
-        'bg-primary shadow-[0px_0px_30px_0px_var(--color-primary)]/80 hover:shadow-[0px_0px_30px_0px_var(--color-primary)]/50',
-        'hover:bg-amber-900',
-        'relative before:absolute before:-inset-0.5 before:-z-1 before:rounded-[calc(var(--rounding)+2px)]',
-        'before:to-primary before:from-primary before:via-accent light:before:via-white before:bg-linear-10'
-      ),
       subtle: 'bg-subtle/20 fg-default hover:bg-subtle/30',
       simple: twMerge(
         'fg-default hover:fg-muted hover:bg-bd-muted/50 border border-transparent bg-transparent',

--- a/src/presentation/modules/button/button.config.ts
+++ b/src/presentation/modules/button/button.config.ts
@@ -2,13 +2,13 @@ import { twMerge } from 'tailwind-merge';
 import { tv, type VariantProps } from 'tailwind-variants';
 
 export const buttonVariant = tv({
-  base: 'flex w-fit cursor-pointer items-center gap-2 rounded-(--rounding) py-0.5 whitespace-nowrap transition-colors [--rounding:10px] disabled:cursor-not-allowed disabled:opacity-50',
+  base: 'text-strong flex w-fit cursor-pointer items-center gap-2 rounded-full py-0.5 whitespace-nowrap transition-colors [--rounding:10px] disabled:cursor-not-allowed disabled:opacity-50',
   variants: {
     color: {
-      primary: 'bg-primary fg-strong-dark hover:bg-primary/90',
-      subtle: 'bg-subtle/20 fg-default hover:bg-subtle/30',
+      primary: 'bg-primary text-strong-dark hover:bg-primary/90',
+      subtle: 'bg-subtle/20 hover:text-muted',
       simple: twMerge(
-        'fg-default hover:fg-muted hover:bg-bd-muted/50 border border-transparent bg-transparent',
+        'hover:text-muted hover:bg-bd-muted/50 border border-transparent bg-transparent',
         'light:hover:bg-black/3'
       ),
     },
@@ -17,8 +17,8 @@ export const buttonVariant = tv({
       square: 'aspect-square',
     },
     size: {
-      xs: 'h-8 px-4 text-sm [--rounding:8px]',
-      sm: 'h-9 px-5 text-sm [--rounding:8px]',
+      xs: 'h-8 px-4 text-sm',
+      sm: 'h-9 px-5 text-sm',
       md: 'h-10 px-5 text-base',
       lg: 'h-11 px-6 text-base',
     },

--- a/src/presentation/modules/button/button.config.ts
+++ b/src/presentation/modules/button/button.config.ts
@@ -2,13 +2,13 @@ import { twMerge } from 'tailwind-merge';
 import { tv, type VariantProps } from 'tailwind-variants';
 
 export const buttonVariant = tv({
-  base: 'text-strong flex w-fit cursor-pointer items-center gap-2 rounded-full py-0.5 whitespace-nowrap transition-colors [--rounding:10px] disabled:cursor-not-allowed disabled:opacity-50',
+  base: 'text-fg-strong flex w-fit cursor-pointer items-center gap-2 rounded-full py-0.5 whitespace-nowrap transition-colors [--rounding:10px] disabled:cursor-not-allowed disabled:opacity-50',
   variants: {
     color: {
-      primary: 'bg-primary text-strong-dark hover:bg-primary/90',
-      subtle: 'bg-subtle/20 hover:text-muted',
+      primary: 'bg-primary text-fg-strong-dark hover:bg-primary/90',
+      subtle: 'bg-subtle/20 hover:text-fg-subtle',
       simple: twMerge(
-        'hover:text-muted hover:bg-bd-muted/50 border border-transparent bg-transparent',
+        'hover:text-fg-subtle hover:bg-bd-muted/50 border border-transparent bg-transparent',
         'light:hover:bg-black/3'
       ),
     },

--- a/src/presentation/modules/button/button.config.ts
+++ b/src/presentation/modules/button/button.config.ts
@@ -1,17 +1,13 @@
-import { twMerge } from 'tailwind-merge';
 import { tv, type VariantProps } from 'tailwind-variants';
 
 export const buttonVariant = tv({
-  base: 'text-fg-strong flex w-fit cursor-pointer items-center gap-2 rounded-full py-0.5 whitespace-nowrap transition-colors [--rounding:10px] disabled:cursor-not-allowed disabled:opacity-50',
+  base: 'flex w-fit cursor-pointer items-center gap-2 rounded-full py-0.5 whitespace-nowrap transition-colors [--rounding:10px] disabled:cursor-not-allowed disabled:opacity-50',
   variants: {
     color: {
       primary: 'bg-primary text-fg-strong-dark hover:bg-primary/90',
-      subtle: 'bg-fill-top hover:text-fg-subtle',
-      outline: 'hover:text-fg-subtle hover:bg-fill-top ring-bd-strong ring-1',
-      simple: twMerge(
-        'hover:text-fg-subtle hover:bg-bd-muted/50 border border-transparent bg-transparent',
-        'light:hover:bg-black/3'
-      ),
+      subtle: 'text-fg-strong bg-fill-top hover:text-fg-subtle',
+      outline: 'text-fg-strong hover:text-fg-subtle hover:bg-fill-top ring-bd-strong ring-1',
+      simple: 'text-fg-strong hover:text-fg-subtle',
     },
     type: {
       text: true,

--- a/src/presentation/modules/button/button.config.ts
+++ b/src/presentation/modules/button/button.config.ts
@@ -6,7 +6,7 @@ export const buttonVariant = tv({
   variants: {
     color: {
       primary: 'bg-primary text-fg-strong-dark hover:bg-primary/90',
-      subtle: 'bg-subtle/20 hover:text-fg-subtle',
+      subtle: 'bg-fill-top hover:text-fg-subtle',
       simple: twMerge(
         'hover:text-fg-subtle hover:bg-bd-muted/50 border border-transparent bg-transparent',
         'light:hover:bg-black/3'

--- a/src/presentation/modules/button/button.config.ts
+++ b/src/presentation/modules/button/button.config.ts
@@ -1,13 +1,15 @@
 import { tv, type VariantProps } from 'tailwind-variants';
 
 export const buttonVariant = tv({
-  base: 'flex w-fit cursor-pointer items-center gap-2 rounded-full py-0.5 font-medium whitespace-nowrap transition-colors [--rounding:10px] disabled:cursor-not-allowed disabled:opacity-50',
+  base: 'flex w-fit cursor-pointer items-center gap-2 rounded-full py-0.5 font-medium whitespace-nowrap transition-colors disabled:cursor-not-allowed disabled:opacity-50',
   variants: {
     color: {
-      primary: 'bg-primary text-fg-strong-dark hover:bg-primary/90',
+      primary: 'bg-primary text-fg-strong-dark hover:bg-primary/90 bg-linear-45',
       subtle: 'text-fg-strong bg-fill-top hover:text-fg-subtle',
       outline: 'text-fg-strong hover:text-fg-subtle hover:bg-fill-top ring-bd-strong ring-1',
       simple: 'text-fg-strong hover:text-fg-subtle',
+      muted: 'text-fg-muted hover:text-fg-default',
+      danger: 'text-danger bg-danger-fill hover:text-danger/80 hover:bg-danger-fill/50',
     },
     type: {
       text: true,

--- a/src/presentation/modules/button/button.config.ts
+++ b/src/presentation/modules/button/button.config.ts
@@ -7,14 +7,17 @@ export const buttonVariant = tv({
     color: {
       primary: 'bg-primary text-fg-strong-dark hover:bg-primary/90',
       subtle: 'bg-fill-top hover:text-fg-subtle',
+      outline: 'hover:text-fg-subtle hover:bg-fill-top ring-bd-strong ring-1',
       simple: twMerge(
         'hover:text-fg-subtle hover:bg-bd-muted/50 border border-transparent bg-transparent',
         'light:hover:bg-black/3'
       ),
     },
     type: {
-      normal: true,
+      text: true,
+      icon: 'aspect-square',
       square: 'aspect-square',
+      iconText: 'gap',
     },
     size: {
       xs: 'h-8 px-4 text-sm',
@@ -22,15 +25,22 @@ export const buttonVariant = tv({
       md: 'h-10 px-5 text-base',
       lg: 'h-11 px-6 text-base',
     },
+    disabled: {
+      true: 'cursor-not-allowed opacity-50',
+    },
   },
   compoundVariants: [
     {
       type: 'square',
       class: 'justify-center p-0',
     },
+    {
+      type: 'icon',
+      class: 'justify-center p-0',
+    },
   ],
   defaultVariants: {
-    type: 'normal',
+    type: 'text',
     size: 'md',
   },
 });

--- a/src/presentation/modules/button/button.config.ts
+++ b/src/presentation/modules/button/button.config.ts
@@ -1,7 +1,7 @@
 import { tv, type VariantProps } from 'tailwind-variants';
 
 export const buttonVariant = tv({
-  base: 'flex w-fit cursor-pointer items-center gap-2 rounded-full py-0.5 whitespace-nowrap transition-colors [--rounding:10px] disabled:cursor-not-allowed disabled:opacity-50',
+  base: 'flex w-fit cursor-pointer items-center gap-2 rounded-full py-0.5 font-medium whitespace-nowrap transition-colors [--rounding:10px] disabled:cursor-not-allowed disabled:opacity-50',
   variants: {
     color: {
       primary: 'bg-primary text-fg-strong-dark hover:bg-primary/90',

--- a/src/presentation/modules/button/button.types.d.ts
+++ b/src/presentation/modules/button/button.types.d.ts
@@ -1,6 +1,6 @@
+import type { NonEmptyString } from '@/shared/shared.types';
 import type { IconTypes } from '@/presentation/globals/presentation.types';
 import type { ButtonVariantProps } from '@/presentation/modules/button/button.config';
-import type { NonEmptyString } from '@/shared/shared.types';
 
 export type VariantButtonType<T> = T & PossibleButtonVariantProps;
 
@@ -11,7 +11,17 @@ type PossibleButtonVariantProps =
         color?: ButtonVariantProps['color'];
         type?: undefined;
       };
-      variantConfig?: ButtonVariantProps;
+      className?: string;
+      Icon?: never;
+      children: React.ReactNode;
+      'aria-label'?: NonEmptyString<string>;
+    }
+  | {
+      variant?: {
+        size?: ButtonVariantProps['size'];
+        color?: ButtonVariantProps['color'];
+        type?: 'square';
+      };
       className?: string;
       Icon?: never;
       children: React.ReactNode;
@@ -23,7 +33,6 @@ type PossibleButtonVariantProps =
         color?: ButtonVariantProps['color'];
         type?: 'icon';
       };
-      variantConfig?: ButtonVariantProps;
       className?: string;
       Icon: IconTypes;
       children?: never;
@@ -35,7 +44,6 @@ type PossibleButtonVariantProps =
         color?: ButtonVariantProps['color'];
         type?: 'iconText';
       };
-      variantConfig?: ButtonVariantProps;
       className?: string;
       Icon: IconTypes;
       children: React.ReactNode;
@@ -47,7 +55,6 @@ type PossibleButtonVariantProps =
         color?: ButtonVariantProps['color'];
         type?: 'text';
       };
-      variantConfig?: ButtonVariantProps;
       className?: string;
       Icon?: never;
       children: React.ReactNode;

--- a/src/presentation/modules/button/button.types.d.ts
+++ b/src/presentation/modules/button/button.types.d.ts
@@ -1,6 +1,55 @@
+import type { IconTypes } from '@/presentation/globals/presentation.types';
 import type { ButtonVariantProps } from '@/presentation/modules/button/button.config';
+import type { NonEmptyString } from '@/shared/shared.types';
 
-export type VariantButtonType<T> = {
-  variantConfig?: ButtonVariantProps;
-  className?: string;
-} & T;
+export type VariantButtonType<T> = T & PossibleButtonVariantProps;
+
+type PossibleButtonVariantProps =
+  | {
+      variant?: {
+        size?: ButtonVariantProps['size'];
+        size?: ButtonVariantProps['color'];
+        type?: undefined;
+      };
+      variantConfig?: ButtonVariantProps;
+      className?: string;
+      Icon?: never;
+      children: React.ReactNode;
+      'aria-label'?: NonEmptyString<string>;
+    }
+  | {
+      variant?: {
+        size?: ButtonVariantProps['size'];
+        size?: ButtonVariantProps['color'];
+        type?: 'icon';
+      };
+      variantConfig?: ButtonVariantProps;
+      className?: string;
+      Icon: IconTypes;
+      children?: never;
+      'aria-label': NonEmptyString<string>;
+    }
+  | {
+      variant?: {
+        size?: ButtonVariantProps['size'];
+        size?: ButtonVariantProps['color'];
+        type?: 'iconText';
+      };
+      variantConfig?: ButtonVariantProps;
+      className?: string;
+      Icon: IconTypes;
+      children: React.ReactNode;
+      'aria-label'?: NonEmptyString<string>;
+    }
+  | {
+      variant?: {
+        size?: ButtonVariantProps['size'];
+        size?: ButtonVariantProps['color'];
+        type?: 'text';
+      };
+      variantConfig?: ButtonVariantProps;
+      className?: string;
+      Icon?: never;
+      children: React.ReactNode;
+      'aria-label'?: NonEmptyString<string>;
+    };

--- a/src/presentation/modules/button/button.types.d.ts
+++ b/src/presentation/modules/button/button.types.d.ts
@@ -8,7 +8,7 @@ type PossibleButtonVariantProps =
   | {
       variant?: {
         size?: ButtonVariantProps['size'];
-        size?: ButtonVariantProps['color'];
+        color?: ButtonVariantProps['color'];
         type?: undefined;
       };
       variantConfig?: ButtonVariantProps;
@@ -20,7 +20,7 @@ type PossibleButtonVariantProps =
   | {
       variant?: {
         size?: ButtonVariantProps['size'];
-        size?: ButtonVariantProps['color'];
+        color?: ButtonVariantProps['color'];
         type?: 'icon';
       };
       variantConfig?: ButtonVariantProps;
@@ -32,7 +32,7 @@ type PossibleButtonVariantProps =
   | {
       variant?: {
         size?: ButtonVariantProps['size'];
-        size?: ButtonVariantProps['color'];
+        color?: ButtonVariantProps['color'];
         type?: 'iconText';
       };
       variantConfig?: ButtonVariantProps;
@@ -44,7 +44,7 @@ type PossibleButtonVariantProps =
   | {
       variant?: {
         size?: ButtonVariantProps['size'];
-        size?: ButtonVariantProps['color'];
+        color?: ButtonVariantProps['color'];
         type?: 'text';
       };
       variantConfig?: ButtonVariantProps;

--- a/src/presentation/modules/button/components/Button.test.tsx
+++ b/src/presentation/modules/button/components/Button.test.tsx
@@ -30,7 +30,7 @@ describe('<Button />', () => {
     describe('should apply class based on variantConfig color', () => {
       const cases = [
         { color: 'primary', expectedClass: 'bg-primary' },
-        { color: 'simple', expectedClass: 'fg-default' },
+        { color: 'simple', expectedClass: 'text-default' },
         { color: 'subtle', expectedClass: 'bg-subtle/20' },
       ];
 

--- a/src/presentation/modules/button/components/Button.test.tsx
+++ b/src/presentation/modules/button/components/Button.test.tsx
@@ -30,7 +30,7 @@ describe('<Button />', () => {
     describe('should apply class based on variantConfig color', () => {
       const cases = [
         { color: 'primary', expectedClass: 'bg-primary' },
-        { color: 'simple', expectedClass: 'text-default' },
+        { color: 'simple', expectedClass: 'text-fg-default' },
         { color: 'subtle', expectedClass: 'bg-subtle/20' },
       ];
 

--- a/src/presentation/modules/button/components/Button.test.tsx
+++ b/src/presentation/modules/button/components/Button.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 import { Button } from '@/presentation/modules/button/components/Button';
+import { IconRocket } from '@/presentation/globals/components/icons/outline/IconRocket';
 
 describe('<Button />', () => {
   describe('Basic Rendering', () => {
@@ -22,8 +23,8 @@ describe('<Button />', () => {
       expect(screen.getByRole('button')).toBeDisabled();
     });
 
-    it('should apply p-0 class based on square variantConfig type', () => {
-      render(<Button variantConfig={{ type: 'square' }}>Click</Button>);
+    it('should apply p-0 class based on icon variantConfig type', () => {
+      render(<Button variant={{ type: 'icon' }} aria-label="Click" Icon={IconRocket}></Button>);
       expect(screen.getByRole('button')).toHaveClass('p-0');
     });
 
@@ -38,9 +39,7 @@ describe('<Button />', () => {
         'should apply $expectedClass when color is $color',
         ({ color, expectedClass }) => {
           render(
-            <Button variantConfig={{ color: color as 'simple' | 'primary' | 'subtle' }}>
-              Click
-            </Button>
+            <Button variant={{ color: color as 'simple' | 'primary' | 'subtle' }}>Click</Button>
           );
           expect(screen.getByRole('button')).toHaveClass(expectedClass);
         }
@@ -57,9 +56,7 @@ describe('<Button />', () => {
       test.each(cases)(
         'should apply $expectedClass when size is $size',
         ({ size, expectedClass }) => {
-          render(
-            <Button variantConfig={{ size: size as 'xs' | 'sm' | 'md' | 'lg' }}>Click</Button>
-          );
+          render(<Button variant={{ size: size as 'xs' | 'sm' | 'md' | 'lg' }}>Click</Button>);
           expect(screen.getByRole('button')).toHaveClass(expectedClass);
         }
       );
@@ -84,11 +81,7 @@ describe('<Button />', () => {
     });
 
     it('should be identifiable via aria-label when provided', async () => {
-      render(
-        <Button variantConfig={{ type: 'square' }} aria-label="Create">
-          +
-        </Button>
-      );
+      render(<Button variant={{ type: 'icon' }} aria-label="Create" Icon={IconRocket}></Button>);
       const button = screen.getByRole('button', { name: /create/i });
       expect(button).toBeInTheDocument();
     });

--- a/src/presentation/modules/button/components/Button.test.tsx
+++ b/src/presentation/modules/button/components/Button.test.tsx
@@ -30,8 +30,8 @@ describe('<Button />', () => {
     describe('should apply class based on variantConfig color', () => {
       const cases = [
         { color: 'primary', expectedClass: 'bg-primary' },
-        { color: 'simple', expectedClass: 'text-fg-default' },
-        { color: 'subtle', expectedClass: 'bg-subtle/20' },
+        { color: 'simple', expectedClass: 'hover:text-fg-subtle' },
+        { color: 'subtle', expectedClass: 'bg-fill-top' },
       ];
 
       test.each(cases)(

--- a/src/presentation/modules/button/components/Button.tsx
+++ b/src/presentation/modules/button/components/Button.tsx
@@ -6,9 +6,9 @@ import type { VariantButtonType } from '@/presentation/modules/button/button.typ
 type Props = VariantButtonType<ButtonElementProps>;
 
 export function Button(props: Props) {
-  const { children, Icon, variantConfig, className, type, ...restProps } = props;
+  const { children, Icon, variant, className, type, ...restProps } = props;
 
-  const variantClassNames = buttonVariant({ ...variantConfig, disabled: props.disabled });
+  const variantClassNames = buttonVariant({ ...variant, disabled: props.disabled });
   return (
     <button
       type={type ?? 'button'}

--- a/src/presentation/modules/button/components/Button.tsx
+++ b/src/presentation/modules/button/components/Button.tsx
@@ -3,12 +3,20 @@ import { buttonVariant } from '@/presentation/modules/button/button.config';
 import type { ButtonElementProps } from '@/presentation/globals/presentation.types';
 import type { VariantButtonType } from '@/presentation/modules/button/button.types';
 
-export function Button({
-  variantConfig,
-  className,
-  type = 'button',
-  ...props
-}: VariantButtonType<ButtonElementProps>) {
-  const variantClassNames = buttonVariant(variantConfig);
-  return <button type={type} className={twMerge(variantClassNames, className)} {...props}></button>;
+type Props = VariantButtonType<ButtonElementProps>;
+
+export function Button(props: Props) {
+  const { children, Icon, variantConfig, className, type, ...restProps } = props;
+
+  const variantClassNames = buttonVariant({ ...variantConfig, disabled: props.disabled });
+  return (
+    <button
+      type={type ?? 'button'}
+      className={twMerge(variantClassNames, className)}
+      {...restProps}
+    >
+      {Icon && <Icon />}
+      {children}
+    </button>
+  );
 }

--- a/src/presentation/modules/button/components/Button.tsx
+++ b/src/presentation/modules/button/components/Button.tsx
@@ -2,6 +2,7 @@ import { twMerge } from 'tailwind-merge';
 import { buttonVariant } from '@/presentation/modules/button/button.config';
 import type { ButtonElementProps } from '@/presentation/globals/presentation.types';
 import type { VariantButtonType } from '@/presentation/modules/button/button.types';
+import { iconVariant } from '@/presentation/globals/components/variants/icon.variants';
 
 type Props = VariantButtonType<ButtonElementProps>;
 
@@ -9,13 +10,14 @@ export function Button(props: Props) {
   const { children, Icon, variant, className, type, ...restProps } = props;
 
   const variantClassNames = buttonVariant({ ...variant, disabled: props.disabled });
+  const iconClassNames = iconVariant({ button: variant?.size });
   return (
     <button
       type={type ?? 'button'}
       className={twMerge(variantClassNames, className)}
       {...restProps}
     >
-      {Icon && <Icon />}
+      {Icon && <Icon className={iconClassNames} />}
       {children}
     </button>
   );

--- a/src/presentation/modules/button/components/Link.test.tsx
+++ b/src/presentation/modules/button/components/Link.test.tsx
@@ -36,7 +36,7 @@ describe('<Link />', () => {
     describe('should apply class based on variantConfig color', () => {
       const cases = [
         { color: 'primary', expectedClass: 'bg-primary' },
-        { color: 'simple', expectedClass: 'fg-default' },
+        { color: 'simple', expectedClass: 'text-default' },
         { color: 'subtle', expectedClass: 'bg-subtle/20' },
       ];
 

--- a/src/presentation/modules/button/components/Link.test.tsx
+++ b/src/presentation/modules/button/components/Link.test.tsx
@@ -36,7 +36,7 @@ describe('<Link />', () => {
     describe('should apply class based on variantConfig color', () => {
       const cases = [
         { color: 'primary', expectedClass: 'bg-primary' },
-        { color: 'simple', expectedClass: 'text-default' },
+        { color: 'simple', expectedClass: 'text-fg-default' },
         { color: 'subtle', expectedClass: 'bg-subtle/20' },
       ];
 

--- a/src/presentation/modules/button/components/Link.test.tsx
+++ b/src/presentation/modules/button/components/Link.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 import { Link } from '@/presentation/modules/button/components/Link';
+import { IconRocket } from '@/presentation/globals/components/icons/outline/IconRocket';
 
 describe('<Link />', () => {
   const href = '/dashboard';
@@ -26,9 +27,7 @@ describe('<Link />', () => {
 
     it('should apply p-0 class based on square variantConfig type', () => {
       render(
-        <Link href={href} variantConfig={{ type: 'square' }}>
-          Click
-        </Link>
+        <Link href={href} variant={{ type: 'icon' }} aria-label="Click" Icon={IconRocket}></Link>
       );
       expect(screen.getByRole('link')).toHaveClass('p-0');
     });
@@ -44,7 +43,7 @@ describe('<Link />', () => {
         'should apply $expectedClass when color is $color',
         ({ color, expectedClass }) => {
           render(
-            <Link href={href} variantConfig={{ color: color as 'simple' | 'primary' | 'subtle' }}>
+            <Link href={href} variant={{ color: color as 'simple' | 'primary' | 'subtle' }}>
               Click
             </Link>
           );
@@ -65,7 +64,7 @@ describe('<Link />', () => {
         'should apply $expectedClass when size is $size',
         ({ size, expectedClass }) => {
           render(
-            <Link href={href} variantConfig={{ size: size as 'xs' | 'sm' | 'md' | 'lg' }}>
+            <Link href={href} variant={{ size: size as 'xs' | 'sm' | 'md' | 'lg' }}>
               Click
             </Link>
           );
@@ -85,9 +84,7 @@ describe('<Link />', () => {
 
     it('should be identifiable via aria-label when provided', async () => {
       render(
-        <Link href={href} variantConfig={{ type: 'square' }} aria-label="Routines">
-          +
-        </Link>
+        <Link href={href} variant={{ type: 'icon' }} aria-label="Routines" Icon={IconRocket}></Link>
       );
       const anchor = screen.getByRole('link', { name: /routines/i });
       expect(anchor).toBeInTheDocument();

--- a/src/presentation/modules/button/components/Link.test.tsx
+++ b/src/presentation/modules/button/components/Link.test.tsx
@@ -36,8 +36,8 @@ describe('<Link />', () => {
     describe('should apply class based on variantConfig color', () => {
       const cases = [
         { color: 'primary', expectedClass: 'bg-primary' },
-        { color: 'simple', expectedClass: 'text-fg-default' },
-        { color: 'subtle', expectedClass: 'bg-subtle/20' },
+        { color: 'simple', expectedClass: 'hover:text-fg-subtle' },
+        { color: 'subtle', expectedClass: 'bg-fill-top' },
       ];
 
       test.each(cases)(

--- a/src/presentation/modules/button/components/Link.tsx
+++ b/src/presentation/modules/button/components/Link.tsx
@@ -1,16 +1,17 @@
 import NextLink from 'next/link';
 import { twMerge } from 'tailwind-merge';
 import { buttonVariant } from '@/presentation/modules/button/button.config';
-import type { ComponentProps } from 'react';
 import type { VariantButtonType } from '@/presentation/modules/button/button.types';
 
-type LinkProps = ComponentProps<typeof NextLink>;
+type LinkProps = React.ComponentProps<typeof NextLink>;
 
-export function Link({ variantConfig, className, ...props }: VariantButtonType<LinkProps>) {
-  const { children, ...rest } = props;
+export function Link(props: VariantButtonType<LinkProps>) {
+  const { children, Icon, variantConfig, className, ...restProps } = props;
+
   const variantClassNames = buttonVariant(variantConfig);
   return (
-    <NextLink className={twMerge(variantClassNames, className)} {...rest}>
+    <NextLink className={twMerge(variantClassNames, className)} {...restProps}>
+      {Icon && <Icon />}
       {children}
     </NextLink>
   );

--- a/src/presentation/modules/button/components/Link.tsx
+++ b/src/presentation/modules/button/components/Link.tsx
@@ -6,9 +6,9 @@ import type { VariantButtonType } from '@/presentation/modules/button/button.typ
 type LinkProps = React.ComponentProps<typeof NextLink>;
 
 export function Link(props: VariantButtonType<LinkProps>) {
-  const { children, Icon, variantConfig, className, ...restProps } = props;
+  const { children, Icon, variant, className, ...restProps } = props;
 
-  const variantClassNames = buttonVariant(variantConfig);
+  const variantClassNames = buttonVariant(variant);
   return (
     <NextLink className={twMerge(variantClassNames, className)} {...restProps}>
       {Icon && <Icon />}

--- a/src/presentation/modules/calendar/components/ArrowButton.tsx
+++ b/src/presentation/modules/calendar/components/ArrowButton.tsx
@@ -11,7 +11,7 @@ export function ArrowButton({
     <button
       type="button"
       onClick={onClick}
-      className={`border-bd-default hover:text-strong hover:border-subtle/80 grid aspect-square h-full cursor-pointer place-content-center border transition-colors ${className}`}
+      className={`border-bd-default hover:text-fg-strong hover:border-subtle/80 grid aspect-square h-full cursor-pointer place-content-center border transition-colors ${className}`}
     >
       {children}
     </button>

--- a/src/presentation/modules/calendar/components/ArrowButton.tsx
+++ b/src/presentation/modules/calendar/components/ArrowButton.tsx
@@ -11,7 +11,7 @@ export function ArrowButton({
     <button
       type="button"
       onClick={onClick}
-      className={`border-bd-default hover:fg-strong hover:border-subtle/80 grid aspect-square h-full cursor-pointer place-content-center border transition-colors ${className}`}
+      className={`border-bd-default hover:text-strong hover:border-subtle/80 grid aspect-square h-full cursor-pointer place-content-center border transition-colors ${className}`}
     >
       {children}
     </button>

--- a/src/presentation/modules/calendar/components/ArrowButton.tsx
+++ b/src/presentation/modules/calendar/components/ArrowButton.tsx
@@ -11,7 +11,7 @@ export function ArrowButton({
     <button
       type="button"
       onClick={onClick}
-      className={`border-bd-default hover:text-fg-strong hover:border-subtle/80 grid aspect-square h-full cursor-pointer place-content-center border transition-colors ${className}`}
+      className={`border-bd-default hover:text-fg-strong hover:border-bd-default grid aspect-square h-full cursor-pointer place-content-center border transition-colors ${className}`}
     >
       {children}
     </button>

--- a/src/presentation/modules/calendar/components/CalendarDay.tsx
+++ b/src/presentation/modules/calendar/components/CalendarDay.tsx
@@ -43,7 +43,7 @@ function CalendarDayCompleted({ day, isSelected = false, onClick }: CalendarDayT
   return (
     <CalendarDayItem
       onClick={onClick}
-      className={isSelected ? 'fg-strong bg-green-600' : 'bg-green-600/50'}
+      className={isSelected ? 'text-strong bg-green-600' : 'bg-green-600/50'}
     >
       {day}
     </CalendarDayItem>
@@ -54,7 +54,7 @@ function CalendarDayCanceled({ day, isSelected = false, onClick }: CalendarDayTy
   return (
     <CalendarDayItem
       onClick={onClick}
-      className={isSelected ? 'fg-strong bg-red-600' : 'bg-red-600/50'}
+      className={isSelected ? 'text-strong bg-red-600' : 'bg-red-600/50'}
     >
       {day}
     </CalendarDayItem>
@@ -71,7 +71,7 @@ function CalendarDayCurrent({
   return (
     <CalendarDayItem
       onClick={onClick}
-      className={`${isSelected ? 'bg-strong fg-strong-light light:fg-strong-dark' : 'bg-subtle/20'}`}
+      className={`${isSelected ? 'bg-strong text-strong-light light:text-strong-dark' : 'bg-subtle/20'}`}
     >
       <IconBarbellOff className="size-4.5" strokeWidth={isSelected ? '2' : '1.5'} />
     </CalendarDayItem>
@@ -80,7 +80,7 @@ function CalendarDayCurrent({
 
 function CalendarDayNormalSelected({ day, onClick }: CalendarDayTypeProps) {
   return (
-    <CalendarDayItem onClick={onClick} className="bg-strong fg-full-black light:fg-strong-dark">
+    <CalendarDayItem onClick={onClick} className="bg-strong text-full-black light:text-strong-dark">
       {day}
     </CalendarDayItem>
   );
@@ -90,7 +90,7 @@ function CalendarDayNextTraining({ day, onClick }: CalendarDayTypeProps) {
   return (
     <CalendarDayItem
       onClick={onClick}
-      className={`fg-strong outline-bd-default outline-1 outline-offset-1`}
+      className={`text-strong outline-bd-default outline-1 outline-offset-1`}
     >
       {day}
     </CalendarDayItem>

--- a/src/presentation/modules/calendar/components/CalendarDay.tsx
+++ b/src/presentation/modules/calendar/components/CalendarDay.tsx
@@ -43,7 +43,7 @@ function CalendarDayCompleted({ day, isSelected = false, onClick }: CalendarDayT
   return (
     <CalendarDayItem
       onClick={onClick}
-      className={isSelected ? 'text-strong bg-green-600' : 'bg-green-600/50'}
+      className={isSelected ? 'text-fg-strong bg-green-600' : 'bg-green-600/50'}
     >
       {day}
     </CalendarDayItem>
@@ -54,7 +54,7 @@ function CalendarDayCanceled({ day, isSelected = false, onClick }: CalendarDayTy
   return (
     <CalendarDayItem
       onClick={onClick}
-      className={isSelected ? 'text-strong bg-red-600' : 'bg-red-600/50'}
+      className={isSelected ? 'text-fg-strong bg-red-600' : 'bg-red-600/50'}
     >
       {day}
     </CalendarDayItem>
@@ -71,7 +71,7 @@ function CalendarDayCurrent({
   return (
     <CalendarDayItem
       onClick={onClick}
-      className={`${isSelected ? 'bg-strong text-strong-light light:text-strong-dark' : 'bg-subtle/20'}`}
+      className={`${isSelected ? 'bg-strong text-fg-strong-light light:text-fg-strong-dark' : 'bg-subtle/20'}`}
     >
       <IconBarbellOff className="size-4.5" strokeWidth={isSelected ? '2' : '1.5'} />
     </CalendarDayItem>
@@ -80,7 +80,10 @@ function CalendarDayCurrent({
 
 function CalendarDayNormalSelected({ day, onClick }: CalendarDayTypeProps) {
   return (
-    <CalendarDayItem onClick={onClick} className="bg-strong text-full-black light:text-strong-dark">
+    <CalendarDayItem
+      onClick={onClick}
+      className="bg-strong text-full-black light:text-fg-strong-dark"
+    >
       {day}
     </CalendarDayItem>
   );
@@ -90,7 +93,7 @@ function CalendarDayNextTraining({ day, onClick }: CalendarDayTypeProps) {
   return (
     <CalendarDayItem
       onClick={onClick}
-      className={`text-strong outline-bd-default outline-1 outline-offset-1`}
+      className={`text-fg-strong outline-bd-default outline-1 outline-offset-1`}
     >
       {day}
     </CalendarDayItem>

--- a/src/presentation/modules/calendar/components/CalendarDay.tsx
+++ b/src/presentation/modules/calendar/components/CalendarDay.tsx
@@ -82,7 +82,7 @@ function CalendarDayNormalSelected({ day, onClick }: CalendarDayTypeProps) {
   return (
     <CalendarDayItem
       onClick={onClick}
-      className="bg-fg-strong text-full-black light:text-fg-strong-dark"
+      className="bg-fg-strong text-fg-strong-light light:text-fg-strong-dark"
     >
       {day}
     </CalendarDayItem>

--- a/src/presentation/modules/calendar/components/CalendarDay.tsx
+++ b/src/presentation/modules/calendar/components/CalendarDay.tsx
@@ -71,7 +71,7 @@ function CalendarDayCurrent({
   return (
     <CalendarDayItem
       onClick={onClick}
-      className={`${isSelected ? 'bg-strong text-fg-strong-light light:text-fg-strong-dark' : 'bg-subtle/20'}`}
+      className={`${isSelected ? 'bg-fg-strong text-fg-strong-light light:text-fg-strong-dark' : 'bg-fill-top'}`}
     >
       <IconBarbellOff className="size-4.5" strokeWidth={isSelected ? '2' : '1.5'} />
     </CalendarDayItem>
@@ -82,7 +82,7 @@ function CalendarDayNormalSelected({ day, onClick }: CalendarDayTypeProps) {
   return (
     <CalendarDayItem
       onClick={onClick}
-      className="bg-strong text-full-black light:text-fg-strong-dark"
+      className="bg-fg-strong text-full-black light:text-fg-strong-dark"
     >
       {day}
     </CalendarDayItem>

--- a/src/presentation/modules/calendar/components/CalendarDay.tsx
+++ b/src/presentation/modules/calendar/components/CalendarDay.tsx
@@ -18,10 +18,10 @@ function CalendarDayItem({
   return (
     <Button
       type="button"
-      variantConfig={{
-        type: 'square',
+      variant={{
         color: 'simple',
         size: 'xs',
+        type: 'square',
       }}
       onClick={onClick}
       className="flex w-full cursor-pointer justify-center hover:bg-transparent"

--- a/src/presentation/modules/calendar/components/DateDropdrownList.tsx
+++ b/src/presentation/modules/calendar/components/DateDropdrownList.tsx
@@ -13,7 +13,7 @@ export function DateDropdownlist({
   return (
     <DropdownList
       values={values}
-      className={`rounded-0 text-default/50 px-2 py-1 text-xs font-light ${styles.select} ${className} outline-none!`}
+      className={`rounded-0 text-fg-default/50 px-2 py-1 text-xs font-light ${styles.select} ${className} outline-none!`}
       selectedValue={selectedValue}
       onChange={onChange}
     />

--- a/src/presentation/modules/calendar/components/DateSelector.tsx
+++ b/src/presentation/modules/calendar/components/DateSelector.tsx
@@ -16,7 +16,7 @@ function ArrowButton({
     <button
       type="button"
       onClick={onClick}
-      className={`hover:fg-strong grid size-6 cursor-pointer place-content-center rounded-full transition-colors ${className} `}
+      className={`hover:text-strong grid size-6 cursor-pointer place-content-center rounded-full transition-colors ${className} `}
     >
       {children}
     </button>
@@ -41,7 +41,7 @@ function DateController({
       <ArrowButton onClick={onPreviousClick} className="text-default/25">
         <IconArrowUp className="-mb-1.5 size-8" strokeWidth="2" />
       </ArrowButton>
-      <span className="fg-strong text-3xl font-bold">{children}</span>
+      <span className="text-strong text-3xl font-bold">{children}</span>
       <ArrowButton onClick={onNextClick} className="text-default/25">
         <IconArrowUp className="size-8 rotate-180" strokeWidth="2" />
       </ArrowButton>
@@ -65,7 +65,7 @@ export function DateSelector({ className = '' }: { className?: string }) {
     <section
       className={`border-bd-default flex w-full flex-1 flex-col items-center justify-center gap-4 rounded-xl border p-6 ${className}`}
     >
-      <header className="font-funnel-display fg-strong text-4xl font-medium">
+      <header className="font-funnel-display text-strong text-4xl font-medium">
         <h2>Friday, July 5</h2>
       </header>
       <main className="flex gap-4">

--- a/src/presentation/modules/calendar/components/DateSelector.tsx
+++ b/src/presentation/modules/calendar/components/DateSelector.tsx
@@ -16,7 +16,7 @@ function ArrowButton({
     <button
       type="button"
       onClick={onClick}
-      className={`hover:text-strong grid size-6 cursor-pointer place-content-center rounded-full transition-colors ${className} `}
+      className={`hover:text-fg-strong grid size-6 cursor-pointer place-content-center rounded-full transition-colors ${className} `}
     >
       {children}
     </button>
@@ -38,11 +38,11 @@ function DateController({
 }: DateControllerProps) {
   return (
     <section className={`flex flex-col items-center justify-between gap-2 ${className}`}>
-      <ArrowButton onClick={onPreviousClick} className="text-default/25">
+      <ArrowButton onClick={onPreviousClick} className="text-fg-default/25">
         <IconArrowUp className="-mb-1.5 size-8" strokeWidth="2" />
       </ArrowButton>
-      <span className="text-strong text-3xl font-bold">{children}</span>
-      <ArrowButton onClick={onNextClick} className="text-default/25">
+      <span className="text-fg-strong text-3xl font-bold">{children}</span>
+      <ArrowButton onClick={onNextClick} className="text-fg-default/25">
         <IconArrowUp className="size-8 rotate-180" strokeWidth="2" />
       </ArrowButton>
     </section>
@@ -65,7 +65,7 @@ export function DateSelector({ className = '' }: { className?: string }) {
     <section
       className={`border-bd-default flex w-full flex-1 flex-col items-center justify-center gap-4 rounded-xl border p-6 ${className}`}
     >
-      <header className="font-funnel-display text-strong text-4xl font-medium">
+      <header className="font-funnel-display text-fg-strong text-4xl font-medium">
         <h2>Friday, July 5</h2>
       </header>
       <main className="flex gap-4">

--- a/src/presentation/modules/card/card.config.ts
+++ b/src/presentation/modules/card/card.config.ts
@@ -16,10 +16,10 @@ export const cardVariant = tv({
       dashboard: 'flex flex-col gap-6 p-8 tracking-tight shadow-xl shadow-black/2',
     },
     color: {
-      default: 'before:bg-middle',
-      disabled: 'before:bg-middle border-bd-default opacity-50',
-      main: 'from-secondary to-primary fg-strong-dark before:from-accent bg-linear-45 bg-radial-[100%_100%_at_25%_25%] before:absolute before:inset-0 before:rounded-xl before:bg-radial-[200%_150%_at_200%_0%] before:to-transparent after:border-transparent',
-      special: 'bg-accent fg-strong-dark border-accent',
+      default: 'before:bg-base',
+      disabled: 'before:bg-base border-bd-default opacity-50',
+      main: 'bg-primary text-strong-dark before:from-accent bg-linear-45 bg-radial-[100%_100%_at_25%_25%] before:absolute before:inset-0 before:rounded-xl before:bg-radial-[200%_150%_at_200%_0%] before:to-transparent after:border-transparent',
+      special: 'bg-accent text-strong-dark border-accent',
     },
     width: {
       xs: 'w-40',

--- a/src/presentation/modules/card/card.config.ts
+++ b/src/presentation/modules/card/card.config.ts
@@ -18,8 +18,8 @@ export const cardVariant = tv({
     color: {
       default: 'before:bg-fill-base',
       disabled: 'before:bg-fill-base border-bd-default opacity-50',
-      main: 'bg-primary text-strong-dark before:from-accent bg-linear-45 bg-radial-[100%_100%_at_25%_25%] before:absolute before:inset-0 before:rounded-xl before:bg-radial-[200%_150%_at_200%_0%] before:to-transparent after:border-transparent',
-      special: 'bg-accent text-strong-dark border-accent',
+      main: 'bg-primary text-fg-strong-dark before:from-accent bg-linear-45 bg-radial-[100%_100%_at_25%_25%] before:absolute before:inset-0 before:rounded-xl before:bg-radial-[200%_150%_at_200%_0%] before:to-transparent after:border-transparent',
+      special: 'bg-accent text-fg-strong-dark border-accent',
     },
     width: {
       xs: 'w-40',

--- a/src/presentation/modules/card/card.config.ts
+++ b/src/presentation/modules/card/card.config.ts
@@ -16,8 +16,8 @@ export const cardVariant = tv({
       dashboard: 'flex flex-col gap-6 p-8 tracking-tight shadow-xl shadow-black/2',
     },
     color: {
-      default: 'before:bg-base',
-      disabled: 'before:bg-base border-bd-default opacity-50',
+      default: 'before:bg-fill-base',
+      disabled: 'before:bg-fill-base border-bd-default opacity-50',
       main: 'bg-primary text-strong-dark before:from-accent bg-linear-45 bg-radial-[100%_100%_at_25%_25%] before:absolute before:inset-0 before:rounded-xl before:bg-radial-[200%_150%_at_200%_0%] before:to-transparent after:border-transparent',
       special: 'bg-accent text-strong-dark border-accent',
     },

--- a/src/presentation/modules/card/components/CardButton.tsx
+++ b/src/presentation/modules/card/components/CardButton.tsx
@@ -10,7 +10,7 @@ export function CardButton({ children, className }: Props) {
   return (
     <Button
       type="button"
-      variantConfig={{
+      variant={{
         color: 'simple',
       }}
       className={twMerge('ml-auto flex items-center gap-1', className)}

--- a/src/presentation/modules/card/components/CardTag.tsx
+++ b/src/presentation/modules/card/components/CardTag.tsx
@@ -16,7 +16,7 @@ export function CardTag({ tag, className }: Props) {
   const { value, selected } = tag;
   const selectedClassName = selected
     ? 'bg-accent text-strong-light light:text-strong-dark'
-    : 'bg-front text-strong';
+    : 'bg-fill-middle text-strong';
   return (
     <div
       className={twMerge(

--- a/src/presentation/modules/card/components/CardTag.tsx
+++ b/src/presentation/modules/card/components/CardTag.tsx
@@ -15,8 +15,8 @@ type Props = {
 export function CardTag({ tag, className }: Props) {
   const { value, selected } = tag;
   const selectedClassName = selected
-    ? 'bg-accent text-strong-light light:text-strong-dark'
-    : 'bg-fill-middle text-strong';
+    ? 'bg-accent text-fg-strong-light light:text-fg-strong-dark'
+    : 'bg-fill-middle text-fg-strong';
   return (
     <div
       className={twMerge(

--- a/src/presentation/modules/card/components/CardTag.tsx
+++ b/src/presentation/modules/card/components/CardTag.tsx
@@ -15,8 +15,8 @@ type Props = {
 export function CardTag({ tag, className }: Props) {
   const { value, selected } = tag;
   const selectedClassName = selected
-    ? 'bg-accent fg-strong-light light:fg-strong-dark'
-    : 'bg-front fg-strong';
+    ? 'bg-accent text-strong-light light:text-strong-dark'
+    : 'bg-front text-strong';
   return (
     <div
       className={twMerge(

--- a/src/presentation/modules/card/components/CardTitle.tsx
+++ b/src/presentation/modules/card/components/CardTitle.tsx
@@ -13,13 +13,13 @@ export function CardTitle({
   return (
     <h3
       className={twMerge(
-        'font-funnel-display text-strong truncate overflow-hidden text-xl',
+        'font-funnel-display text-fg-strong truncate overflow-hidden text-xl',
         Icon ? 'flex w-full items-center gap-4' : '',
         className
       )}
     >
       {Icon && (
-        <div className="bg-fill-middle text-muted grid aspect-square size-9 place-content-center rounded-xl">
+        <div className="bg-fill-middle text-fg-subtle grid aspect-square size-9 place-content-center rounded-xl">
           <Icon strokeWidth="1.5" className="size-6" />
         </div>
       )}

--- a/src/presentation/modules/card/components/CardTitle.tsx
+++ b/src/presentation/modules/card/components/CardTitle.tsx
@@ -13,13 +13,13 @@ export function CardTitle({
   return (
     <h3
       className={twMerge(
-        'font-funnel-display fg-strong truncate overflow-hidden text-xl',
+        'font-funnel-display text-strong truncate overflow-hidden text-xl',
         Icon ? 'flex w-full items-center gap-4' : '',
         className
       )}
     >
       {Icon && (
-        <div className="bg-front fg-muted grid aspect-square size-9 place-content-center rounded-xl">
+        <div className="bg-front text-muted grid aspect-square size-9 place-content-center rounded-xl">
           <Icon strokeWidth="1.5" className="size-6" />
         </div>
       )}

--- a/src/presentation/modules/card/components/CardTitle.tsx
+++ b/src/presentation/modules/card/components/CardTitle.tsx
@@ -19,7 +19,7 @@ export function CardTitle({
       )}
     >
       {Icon && (
-        <div className="bg-front text-muted grid aspect-square size-9 place-content-center rounded-xl">
+        <div className="bg-fill-middle text-muted grid aspect-square size-9 place-content-center rounded-xl">
           <Icon strokeWidth="1.5" className="size-6" />
         </div>
       )}

--- a/src/presentation/modules/card/components/SubtleCard.tsx
+++ b/src/presentation/modules/card/components/SubtleCard.tsx
@@ -5,5 +5,5 @@ export function SubtleCard({
   className?: string;
   children: React.ReactNode;
 }) {
-  return <article className={`bg-subtle/5 rounded p-4 ${className}`}>{children}</article>;
+  return <article className={`bg-fill-middle rounded p-4 ${className}`}>{children}</article>;
 }

--- a/src/presentation/modules/dashboard/components/Header.tsx
+++ b/src/presentation/modules/dashboard/components/Header.tsx
@@ -7,7 +7,7 @@ export function Header({ className = '' }: { className?: string }) {
   return (
     <header className="h-(--header-height) w-full">
       <main
-        className={`bg-back border-bd-muted font-funnel-display fixed top-0 left-0 z-10 grid h-(--header-height) w-full grid-cols-[auto_auto_auto] gap-4 border-b pr-4 md:grid-cols-[1fr_auto_1fr] ${className}`}
+        className={`bg-fill-back border-bd-muted font-funnel-display fixed top-0 left-0 z-10 grid h-(--header-height) w-full grid-cols-[auto_auto_auto] gap-4 border-b pr-4 md:grid-cols-[1fr_auto_1fr] ${className}`}
       >
         <section className="flex h-full items-center gap-2">
           <main className="border-bd-muted flex h-full w-(--sidebar-width) items-center justify-between gap-0 border-r lg:pl-4">

--- a/src/presentation/modules/dashboard/components/Section.tsx
+++ b/src/presentation/modules/dashboard/components/Section.tsx
@@ -13,7 +13,7 @@ export function Section({
     <section className={`${className}`}>
       {title && (
         <header className="mb-2">
-          <h3 className="fg-strong flex items-center gap-4 text-2xl font-semibold">
+          <h3 className="text-strong flex items-center gap-4 text-2xl font-semibold">
             <span className="block w-fit">{title}</span>
             <span className="bg-front block h-0.5 w-full flex-1 mask-r-from-0 mask-r-to-150%"></span>
           </h3>

--- a/src/presentation/modules/dashboard/components/Section.tsx
+++ b/src/presentation/modules/dashboard/components/Section.tsx
@@ -15,7 +15,7 @@ export function Section({
         <header className="mb-2">
           <h3 className="text-strong flex items-center gap-4 text-2xl font-semibold">
             <span className="block w-fit">{title}</span>
-            <span className="bg-front block h-0.5 w-full flex-1 mask-r-from-0 mask-r-to-150%"></span>
+            <span className="bg-fill-middle block h-0.5 w-full flex-1 mask-r-from-0 mask-r-to-150%"></span>
           </h3>
           {description && <p>{description}</p>}
         </header>

--- a/src/presentation/modules/dashboard/components/Section.tsx
+++ b/src/presentation/modules/dashboard/components/Section.tsx
@@ -13,7 +13,7 @@ export function Section({
     <section className={`${className}`}>
       {title && (
         <header className="mb-2">
-          <h3 className="text-strong flex items-center gap-4 text-2xl font-semibold">
+          <h3 className="text-fg-strong flex items-center gap-4 text-2xl font-semibold">
             <span className="block w-fit">{title}</span>
             <span className="bg-fill-middle block h-0.5 w-full flex-1 mask-r-from-0 mask-r-to-150%"></span>
           </h3>

--- a/src/presentation/modules/dashboard/components/home/BestExercises.tsx
+++ b/src/presentation/modules/dashboard/components/home/BestExercises.tsx
@@ -9,7 +9,7 @@ export function BestExercises({ className = '' }: { className?: string }) {
       <main>
         <table className="w-full text-left">
           <thead>
-            <tr className="fg-strong *:px-1">
+            <tr className="text-strong *:px-1">
               <th>Top</th>
               <th>Exercise</th>
               <th>Progress</th>
@@ -19,22 +19,22 @@ export function BestExercises({ className = '' }: { className?: string }) {
             <tr className="font-light *:px-1 *:py-0.5 *:leading-none">
               <td>1</td>
               <td>Biceps Curl</td>
-              <td className="fg-accent">10% improvement</td>
+              <td className="text-accent">10% improvement</td>
             </tr>
             <tr className="font-light *:px-1 *:py-0.5 *:leading-none">
               <td>2</td>
               <td>Bulgarians</td>
-              <td className="fg-accent">7% improvement</td>
+              <td className="text-accent">7% improvement</td>
             </tr>
             <tr className="font-light *:px-1 *:py-0.5 *:leading-none">
               <td>3</td>
               <td>Dips</td>
-              <td className="fg-accent">5% improvement</td>
+              <td className="text-accent">5% improvement</td>
             </tr>
             <tr className="font-light *:px-1 *:py-0.5 *:leading-none">
               <td>4</td>
               <td>Pull Ups</td>
-              <td className="fg-accent">2% improvement</td>
+              <td className="text-accent">2% improvement</td>
             </tr>
           </tbody>
         </table>

--- a/src/presentation/modules/dashboard/components/home/BestExercises.tsx
+++ b/src/presentation/modules/dashboard/components/home/BestExercises.tsx
@@ -9,7 +9,7 @@ export function BestExercises({ className = '' }: { className?: string }) {
       <main>
         <table className="w-full text-left">
           <thead>
-            <tr className="text-strong *:px-1">
+            <tr className="text-fg-strong *:px-1">
               <th>Top</th>
               <th>Exercise</th>
               <th>Progress</th>

--- a/src/presentation/modules/dashboard/components/home/Calendar.tsx
+++ b/src/presentation/modules/dashboard/components/home/Calendar.tsx
@@ -8,9 +8,9 @@ function CalendarHeader({ className = '' }: { className?: string }) {
   return (
     <header className={` ${className}`}>
       <ul className="font-funnel-display grid grid-cols-[1fr_auto_1fr] font-light">
-        <li className="text-default/50">July</li>
-        <li className="text-strong text-xl">August 2024</li>
-        <li className="text-default/50 text-right">September</li>
+        <li className="text-fg-default/50">July</li>
+        <li className="text-fg-strong text-xl">August 2024</li>
+        <li className="text-fg-default/50 text-right">September</li>
       </ul>
     </header>
   );
@@ -21,7 +21,7 @@ function CalendarCurrentWeek({ className }: { className?: string }) {
     <ul
       className={`flex items-end justify-around gap-2 text-sm leading-[1.2] *:w-full *:rounded-lg *:px-3 *:py-1 ${className}`}
     >
-      <li className="bg-subtle/5 text-default/70 flex flex-col items-center gap-2 text-xs font-normal">
+      <li className="bg-subtle/5 text-fg-default/70 flex flex-col items-center gap-2 text-xs font-normal">
         <main>
           <header>Thu</header>
           <footer>07</footer>
@@ -57,7 +57,7 @@ function CalendarCurrentWeek({ className }: { className?: string }) {
           <IconBarbell className="mx-auto size-5" />
         </footer>
       </li>
-      <li className="bg-subtle/5 text-default/70 flex flex-col items-center gap-2 text-xs font-normal">
+      <li className="bg-subtle/5 text-fg-default/70 flex flex-col items-center gap-2 text-xs font-normal">
         <main>
           <header>Mon</header>
           <footer>11</footer>
@@ -73,7 +73,7 @@ function CalendarCurrentWeek({ className }: { className?: string }) {
 function CalendarNextWeek({ className }: { className?: string }) {
   return (
     <ul
-      className={`text-default/50 *:bg-subtle/5 flex items-end justify-around gap-2 text-xs *:flex *:w-full *:flex-col *:items-center *:gap-1 *:rounded-lg *:px-3 *:py-1 ${className} `}
+      className={`text-fg-default/50 *:bg-subtle/5 flex items-end justify-around gap-2 text-xs *:flex *:w-full *:flex-col *:items-center *:gap-1 *:rounded-lg *:px-3 *:py-1 ${className} `}
     >
       <li>
         <main>Tue 12</main>

--- a/src/presentation/modules/dashboard/components/home/Calendar.tsx
+++ b/src/presentation/modules/dashboard/components/home/Calendar.tsx
@@ -9,7 +9,7 @@ function CalendarHeader({ className = '' }: { className?: string }) {
     <header className={` ${className}`}>
       <ul className="font-funnel-display grid grid-cols-[1fr_auto_1fr] font-light">
         <li className="text-default/50">July</li>
-        <li className="fg-strong text-xl">August 2024</li>
+        <li className="text-strong text-xl">August 2024</li>
         <li className="text-default/50 text-right">September</li>
       </ul>
     </header>
@@ -39,7 +39,7 @@ function CalendarCurrentWeek({ className }: { className?: string }) {
           <IconCircleCheck className="mx-auto size-5" />
         </footer>
       </li>
-      <li className="bg-subtle/10 fg-accent flex flex-col items-center gap-2 text-xl leading-[1.2] font-medium">
+      <li className="bg-subtle/10 text-accent flex flex-col items-center gap-2 text-xl leading-[1.2] font-medium">
         <main>
           <header>Sat</header>
           <footer>09</footer>

--- a/src/presentation/modules/dashboard/components/home/Calendar.tsx
+++ b/src/presentation/modules/dashboard/components/home/Calendar.tsx
@@ -21,7 +21,7 @@ function CalendarCurrentWeek({ className }: { className?: string }) {
     <ul
       className={`flex items-end justify-around gap-2 text-sm leading-[1.2] *:w-full *:rounded-lg *:px-3 *:py-1 ${className}`}
     >
-      <li className="bg-subtle/5 text-fg-default/70 flex flex-col items-center gap-2 text-xs font-normal">
+      <li className="bg-fill-middle text-fg-default/70 flex flex-col items-center gap-2 text-xs font-normal">
         <main>
           <header>Thu</header>
           <footer>07</footer>
@@ -30,7 +30,7 @@ function CalendarCurrentWeek({ className }: { className?: string }) {
           <IconCircleCheck className="mx-auto size-5" />
         </footer>
       </li>
-      <li className="bg-subtle/10 flex flex-col items-center gap-2">
+      <li className="bg-fill-middle flex flex-col items-center gap-2">
         <main>
           <header>Fri</header>
           <footer>08</footer>
@@ -39,7 +39,7 @@ function CalendarCurrentWeek({ className }: { className?: string }) {
           <IconCircleCheck className="mx-auto size-5" />
         </footer>
       </li>
-      <li className="bg-subtle/10 text-accent flex flex-col items-center gap-2 text-xl leading-[1.2] font-medium">
+      <li className="bg-fill-middle text-accent flex flex-col items-center gap-2 text-xl leading-[1.2] font-medium">
         <main>
           <header>Sat</header>
           <footer>09</footer>
@@ -48,7 +48,7 @@ function CalendarCurrentWeek({ className }: { className?: string }) {
           <IconAlarm className="mx-auto size-5" />
         </footer>
       </li>
-      <li className="bg-subtle/10 flex flex-col items-center gap-2">
+      <li className="bg-fill-middle flex flex-col items-center gap-2">
         <main>
           <header>Sun</header>
           <footer>10</footer>
@@ -57,7 +57,7 @@ function CalendarCurrentWeek({ className }: { className?: string }) {
           <IconBarbell className="mx-auto size-5" />
         </footer>
       </li>
-      <li className="bg-subtle/5 text-fg-default/70 flex flex-col items-center gap-2 text-xs font-normal">
+      <li className="bg-fill-middle text-fg-default/70 flex flex-col items-center gap-2 text-xs font-normal">
         <main>
           <header>Mon</header>
           <footer>11</footer>
@@ -73,7 +73,7 @@ function CalendarCurrentWeek({ className }: { className?: string }) {
 function CalendarNextWeek({ className }: { className?: string }) {
   return (
     <ul
-      className={`text-fg-default/50 *:bg-subtle/5 flex items-end justify-around gap-2 text-xs *:flex *:w-full *:flex-col *:items-center *:gap-1 *:rounded-lg *:px-3 *:py-1 ${className} `}
+      className={`text-fg-default/50 *:bg-fill-middle flex items-end justify-around gap-2 text-xs *:flex *:w-full *:flex-col *:items-center *:gap-1 *:rounded-lg *:px-3 *:py-1 ${className} `}
     >
       <li>
         <main>Tue 12</main>

--- a/src/presentation/modules/dashboard/components/home/LastSession.tsx
+++ b/src/presentation/modules/dashboard/components/home/LastSession.tsx
@@ -10,7 +10,7 @@ export function LastSession({ className = '' }: { className?: string }) {
       <main className="flex flex-col gap-4">
         <header className="flex items-center">
           <h4 className="text-complete inline text-xl leading-none font-bold">Push Day</h4>
-          <span className="bg-fill-middle text-default/70 ml-2 inline rounded-full px-3 py-1 text-sm font-light">
+          <span className="bg-fill-middle text-fg-default/70 ml-2 inline rounded-full px-3 py-1 text-sm font-light">
             Yesterday
           </span>
         </header>
@@ -22,7 +22,7 @@ export function LastSession({ className = '' }: { className?: string }) {
                 <span className="leading-none">Push Ups</span>
               </main>
               <aside>
-                <span className="text-default/50 text-sm font-light">+1 Reps</span>
+                <span className="text-fg-default/50 text-sm font-light">+1 Reps</span>
               </aside>
             </li>
 
@@ -32,7 +32,7 @@ export function LastSession({ className = '' }: { className?: string }) {
                 <span className="leading-none">Lateral Raises</span>
               </main>
               <aside>
-                <span className="text-default/50 text-sm font-light">+1 Reps</span>
+                <span className="text-fg-default/50 text-sm font-light">+1 Reps</span>
               </aside>
             </li>
 
@@ -42,7 +42,7 @@ export function LastSession({ className = '' }: { className?: string }) {
                 <span className="leading-none">Abs</span>
               </main>
               <aside>
-                <span className="text-default/50 text-sm font-light">+1 Reps</span>
+                <span className="text-fg-default/50 text-sm font-light">+1 Reps</span>
               </aside>
             </li>
 
@@ -52,7 +52,7 @@ export function LastSession({ className = '' }: { className?: string }) {
                 <span className="leading-none">Dips</span>
               </main>
               <aside>
-                <span className="text-default/50 text-sm font-light">+1 Reps</span>
+                <span className="text-fg-default/50 text-sm font-light">+1 Reps</span>
               </aside>
             </li>
           </ul>

--- a/src/presentation/modules/dashboard/components/home/LastSession.tsx
+++ b/src/presentation/modules/dashboard/components/home/LastSession.tsx
@@ -10,7 +10,7 @@ export function LastSession({ className = '' }: { className?: string }) {
       <main className="flex flex-col gap-4">
         <header className="flex items-center">
           <h4 className="text-complete inline text-xl leading-none font-bold">Push Day</h4>
-          <span className="bg-front text-default/70 ml-2 inline rounded-full px-3 py-1 text-sm font-light">
+          <span className="bg-fill-middle text-default/70 ml-2 inline rounded-full px-3 py-1 text-sm font-light">
             Yesterday
           </span>
         </header>

--- a/src/presentation/modules/dashboard/components/home/LastSession.tsx
+++ b/src/presentation/modules/dashboard/components/home/LastSession.tsx
@@ -9,7 +9,7 @@ export function LastSession({ className = '' }: { className?: string }) {
       <CardTitle Icon={IconPlayerTrackPrev} title="Last Sessions" />
       <main className="flex flex-col gap-4">
         <header className="flex items-center">
-          <h4 className="text-complete inline text-xl leading-none font-bold">Push Day</h4>
+          <h4 className="text-success inline text-xl leading-none font-bold">Push Day</h4>
           <span className="bg-fill-middle text-fg-default/70 ml-2 inline rounded-full px-3 py-1 text-sm font-light">
             Yesterday
           </span>
@@ -18,7 +18,7 @@ export function LastSession({ className = '' }: { className?: string }) {
           <ul className="font-sm font-light">
             <li className="flex items-center justify-between gap-2">
               <main className="*:inline">
-                <SIconCircleCheck className="text-complete mr-1 size-6" />
+                <SIconCircleCheck className="text-success mr-1 size-6" />
                 <span className="leading-none">Push Ups</span>
               </main>
               <aside>
@@ -28,7 +28,7 @@ export function LastSession({ className = '' }: { className?: string }) {
 
             <li className="flex items-center justify-between gap-2">
               <main className="*:inline">
-                <SIconCircleCheck className="text-complete mr-1 size-6" />
+                <SIconCircleCheck className="text-success mr-1 size-6" />
                 <span className="leading-none">Lateral Raises</span>
               </main>
               <aside>
@@ -38,7 +38,7 @@ export function LastSession({ className = '' }: { className?: string }) {
 
             <li className="flex items-center justify-between gap-2">
               <main className="*:inline">
-                <SIconCircleCheck className="text-complete mr-1 size-6" />
+                <SIconCircleCheck className="text-success mr-1 size-6" />
                 <span className="leading-none">Abs</span>
               </main>
               <aside>
@@ -48,7 +48,7 @@ export function LastSession({ className = '' }: { className?: string }) {
 
             <li className="flex items-center justify-between gap-2">
               <main className="*:inline">
-                <SIconCircleCheck className="text-complete mr-1 size-6" />
+                <SIconCircleCheck className="text-success mr-1 size-6" />
                 <span className="leading-none">Dips</span>
               </main>
               <aside>

--- a/src/presentation/modules/dashboard/components/home/LastSession.tsx
+++ b/src/presentation/modules/dashboard/components/home/LastSession.tsx
@@ -9,7 +9,7 @@ export function LastSession({ className = '' }: { className?: string }) {
       <CardTitle Icon={IconPlayerTrackPrev} title="Last Sessions" />
       <main className="flex flex-col gap-4">
         <header className="flex items-center">
-          <h4 className="fg-complete inline text-xl leading-none font-bold">Push Day</h4>
+          <h4 className="text-complete inline text-xl leading-none font-bold">Push Day</h4>
           <span className="bg-front text-default/70 ml-2 inline rounded-full px-3 py-1 text-sm font-light">
             Yesterday
           </span>
@@ -18,7 +18,7 @@ export function LastSession({ className = '' }: { className?: string }) {
           <ul className="font-sm font-light">
             <li className="flex items-center justify-between gap-2">
               <main className="*:inline">
-                <SIconCircleCheck className="fg-complete mr-1 size-6" />
+                <SIconCircleCheck className="text-complete mr-1 size-6" />
                 <span className="leading-none">Push Ups</span>
               </main>
               <aside>
@@ -28,7 +28,7 @@ export function LastSession({ className = '' }: { className?: string }) {
 
             <li className="flex items-center justify-between gap-2">
               <main className="*:inline">
-                <SIconCircleCheck className="fg-complete mr-1 size-6" />
+                <SIconCircleCheck className="text-complete mr-1 size-6" />
                 <span className="leading-none">Lateral Raises</span>
               </main>
               <aside>
@@ -38,7 +38,7 @@ export function LastSession({ className = '' }: { className?: string }) {
 
             <li className="flex items-center justify-between gap-2">
               <main className="*:inline">
-                <SIconCircleCheck className="fg-complete mr-1 size-6" />
+                <SIconCircleCheck className="text-complete mr-1 size-6" />
                 <span className="leading-none">Abs</span>
               </main>
               <aside>
@@ -48,7 +48,7 @@ export function LastSession({ className = '' }: { className?: string }) {
 
             <li className="flex items-center justify-between gap-2">
               <main className="*:inline">
-                <SIconCircleCheck className="fg-complete mr-1 size-6" />
+                <SIconCircleCheck className="text-complete mr-1 size-6" />
                 <span className="leading-none">Dips</span>
               </main>
               <aside>

--- a/src/presentation/modules/dashboard/components/home/MainCard.tsx
+++ b/src/presentation/modules/dashboard/components/home/MainCard.tsx
@@ -9,7 +9,7 @@ export function MainCard({ className = '' }: { className?: string }) {
     <Card color="main" className={`relative flex flex-col gap-4 ${className}`}>
       <header className="relative z-1">
         <h3 className="font-funnel-display max-w-100 text-2xl tracking-tight">
-          Start achieving your goals with <span className="fg-accent">AtlasWay</span>
+          Start achieving your goals with <span className="text-accent">AtlasWay</span>
         </h3>
       </header>
       <main className="relative z-1 flex max-w-140 flex-1 flex-col">

--- a/src/presentation/modules/dashboard/components/home/NotificationsList.tsx
+++ b/src/presentation/modules/dashboard/components/home/NotificationsList.tsx
@@ -13,7 +13,7 @@ function NotificationListItem({
   date: string;
   notseen?: boolean;
 }) {
-  const notSeenClassName = notseen ? 'font-medium bg-subtle/10 fg-strong' : '';
+  const notSeenClassName = notseen ? 'font-medium bg-subtle/10 text-strong' : '';
   return (
     <li
       className={`outline-subtle/10 flex items-center justify-between gap-2 px-3 py-2 outline-1 ${notSeenClassName} ${className}`}

--- a/src/presentation/modules/dashboard/components/home/NotificationsList.tsx
+++ b/src/presentation/modules/dashboard/components/home/NotificationsList.tsx
@@ -13,13 +13,13 @@ function NotificationListItem({
   date: string;
   notseen?: boolean;
 }) {
-  const notSeenClassName = notseen ? 'font-medium bg-subtle/10 text-strong' : '';
+  const notSeenClassName = notseen ? 'font-medium bg-subtle/10 text-fg-strong' : '';
   return (
     <li
       className={`outline-subtle/10 flex items-center justify-between gap-2 px-3 py-2 outline-1 ${notSeenClassName} ${className}`}
     >
       <main>{notification}</main>
-      <aside className={`${notseen ? 'text-default/80' : 'text-default/50'}`}>{date}</aside>
+      <aside className={`${notseen ? 'text-fg-default/80' : 'text-fg-default/50'}`}>{date}</aside>
     </li>
   );
 }

--- a/src/presentation/modules/dashboard/components/home/NotificationsList.tsx
+++ b/src/presentation/modules/dashboard/components/home/NotificationsList.tsx
@@ -13,10 +13,10 @@ function NotificationListItem({
   date: string;
   notseen?: boolean;
 }) {
-  const notSeenClassName = notseen ? 'font-medium bg-subtle/10 text-fg-strong' : '';
+  const notSeenClassName = notseen ? 'font-medium bg-fill-middle text-fg-strong' : '';
   return (
     <li
-      className={`outline-subtle/10 flex items-center justify-between gap-2 px-3 py-2 outline-1 ${notSeenClassName} ${className}`}
+      className={`outline-bd-default/10 flex items-center justify-between gap-2 px-3 py-2 outline-1 ${notSeenClassName} ${className}`}
     >
       <main>{notification}</main>
       <aside className={`${notseen ? 'text-fg-default/80' : 'text-fg-default/50'}`}>{date}</aside>

--- a/src/presentation/modules/dashboard/components/home/RoutinesList.tsx
+++ b/src/presentation/modules/dashboard/components/home/RoutinesList.tsx
@@ -12,9 +12,9 @@ export function RoutinesList({ className = '' }: { className?: string }) {
         <ul className="flex flex-col gap-2">
           <li className="flex flex-col gap-1">
             <header className="">
-              <h4 className="text-strong text-base">1. Push, Pull, Legs</h4>
+              <h4 className="text-fg-strong text-base">1. Push, Pull, Legs</h4>
             </header>
-            <ul className="text-default/70 flex flex-col gap-1 text-sm *:leading-none">
+            <ul className="text-fg-default/70 flex flex-col gap-1 text-sm *:leading-none">
               <li className="flex items-center gap-2">
                 <IconAlarm className="size-4" strokeWidth="1.5" />
                 <span className="font-light">3 Sessions</span>
@@ -27,9 +27,9 @@ export function RoutinesList({ className = '' }: { className?: string }) {
           </li>
           <li className="flex flex-col gap-1">
             <header className="">
-              <h4 className="text-strong text-base">2. Full Body</h4>
+              <h4 className="text-fg-strong text-base">2. Full Body</h4>
             </header>
-            <ul className="text-default/70 flex flex-col gap-1 text-sm *:leading-none">
+            <ul className="text-fg-default/70 flex flex-col gap-1 text-sm *:leading-none">
               <li className="flex items-center gap-2">
                 <IconAlarm className="size-4" strokeWidth="1.5" />
                 <span className="font-light">1 Session</span>

--- a/src/presentation/modules/dashboard/components/home/RoutinesList.tsx
+++ b/src/presentation/modules/dashboard/components/home/RoutinesList.tsx
@@ -12,7 +12,7 @@ export function RoutinesList({ className = '' }: { className?: string }) {
         <ul className="flex flex-col gap-2">
           <li className="flex flex-col gap-1">
             <header className="">
-              <h4 className="fg-strong text-base">1. Push, Pull, Legs</h4>
+              <h4 className="text-strong text-base">1. Push, Pull, Legs</h4>
             </header>
             <ul className="text-default/70 flex flex-col gap-1 text-sm *:leading-none">
               <li className="flex items-center gap-2">
@@ -27,7 +27,7 @@ export function RoutinesList({ className = '' }: { className?: string }) {
           </li>
           <li className="flex flex-col gap-1">
             <header className="">
-              <h4 className="fg-strong text-base">2. Full Body</h4>
+              <h4 className="text-strong text-base">2. Full Body</h4>
             </header>
             <ul className="text-default/70 flex flex-col gap-1 text-sm *:leading-none">
               <li className="flex items-center gap-2">

--- a/src/presentation/modules/dashboard/components/home/SimpleTable.tsx
+++ b/src/presentation/modules/dashboard/components/home/SimpleTable.tsx
@@ -1,8 +1,8 @@
 function SimpleTableRow({ row }: { row: { key: number; name: string } }) {
   return (
     <>
-      <li className="fg-muted border-bd-strong border-t">{row.key + 1}</li>
-      <li className="fg-muted border-bd-strong border-t">{row.name}</li>
+      <li className="text-muted border-bd-strong border-t">{row.key + 1}</li>
+      <li className="text-muted border-bd-strong border-t">{row.name}</li>
     </>
   );
 }
@@ -16,8 +16,8 @@ export function SimpleTable({
 }) {
   return (
     <ul className="grid grid-cols-[1.5rem_1fr] text-sm font-light *:py-0.5">
-      <li className="fg-default font-medium">{header.key}</li>
-      <li className="fg-default font-medium">{header.name}</li>
+      <li className="text-default font-medium">{header.key}</li>
+      <li className="text-default font-medium">{header.name}</li>
       {values.map((value) => (
         <SimpleTableRow key={value.key} row={value} />
       ))}

--- a/src/presentation/modules/dashboard/components/home/SimpleTable.tsx
+++ b/src/presentation/modules/dashboard/components/home/SimpleTable.tsx
@@ -1,8 +1,8 @@
 function SimpleTableRow({ row }: { row: { key: number; name: string } }) {
   return (
     <>
-      <li className="text-muted border-bd-strong border-t">{row.key + 1}</li>
-      <li className="text-muted border-bd-strong border-t">{row.name}</li>
+      <li className="text-fg-subtle border-bd-strong border-t">{row.key + 1}</li>
+      <li className="text-fg-subtle border-bd-strong border-t">{row.name}</li>
     </>
   );
 }
@@ -16,8 +16,8 @@ export function SimpleTable({
 }) {
   return (
     <ul className="grid grid-cols-[1.5rem_1fr] text-sm font-light *:py-0.5">
-      <li className="text-default font-medium">{header.key}</li>
-      <li className="text-default font-medium">{header.name}</li>
+      <li className="text-fg-default font-medium">{header.key}</li>
+      <li className="text-fg-default font-medium">{header.name}</li>
       {values.map((value) => (
         <SimpleTableRow key={value.key} row={value} />
       ))}

--- a/src/presentation/modules/dashboard/components/home/TotalSessionsDone.tsx
+++ b/src/presentation/modules/dashboard/components/home/TotalSessionsDone.tsx
@@ -10,7 +10,7 @@ export function TotalSessionsDone({ className = '' }: { className?: string }) {
         <span className="font-funnel-display text-accent text-8xl font-medium tracking-tighter">
           120
         </span>
-        <span className="text-default/50 text-base leading-none font-light">Sessions</span>
+        <span className="text-fg-default/50 text-base leading-none font-light">Sessions</span>
       </main>
     </Card>
   );

--- a/src/presentation/modules/dashboard/components/home/TotalSessionsDone.tsx
+++ b/src/presentation/modules/dashboard/components/home/TotalSessionsDone.tsx
@@ -7,7 +7,7 @@ export function TotalSessionsDone({ className = '' }: { className?: string }) {
     <Card className={`flex flex-col gap-0 ${className}`}>
       <CardTitle Icon={IconTrophy} title="Total Sessions Done" className="text-center" />
       <main className="flex flex-1 flex-col items-center justify-center gap-0">
-        <span className="font-funnel-display fg-accent text-8xl font-medium tracking-tighter">
+        <span className="font-funnel-display text-accent text-8xl font-medium tracking-tighter">
           120
         </span>
         <span className="text-default/50 text-base leading-none font-light">Sessions</span>

--- a/src/presentation/modules/dashboard/components/page/PageHeader.tsx
+++ b/src/presentation/modules/dashboard/components/page/PageHeader.tsx
@@ -10,7 +10,7 @@ export function PageHeader({
   title: string;
 }) {
   return (
-    <header className={`fg-strong flex w-full items-start pt-4 ${className}`}>
+    <header className={`text-strong flex w-full items-start pt-4 ${className}`}>
       <div className="w-full space-y-1">
         <h1 className="font-funnel-display text-2xl leading-none font-bold">{title}</h1>
         {description && <p className="text-default/70 text-base font-light">{description}</p>}

--- a/src/presentation/modules/dashboard/components/page/PageHeader.tsx
+++ b/src/presentation/modules/dashboard/components/page/PageHeader.tsx
@@ -10,10 +10,10 @@ export function PageHeader({
   title: string;
 }) {
   return (
-    <header className={`text-strong flex w-full items-start pt-4 ${className}`}>
+    <header className={`text-fg-strong flex w-full items-start pt-4 ${className}`}>
       <div className="w-full space-y-1">
         <h1 className="font-funnel-display text-2xl leading-none font-bold">{title}</h1>
-        {description && <p className="text-default/70 text-base font-light">{description}</p>}
+        {description && <p className="text-fg-default/70 text-base font-light">{description}</p>}
       </div>
       <aside>{children}</aside>
     </header>

--- a/src/presentation/modules/form/components/Box.tsx
+++ b/src/presentation/modules/form/components/Box.tsx
@@ -6,7 +6,7 @@ type BoxProps = {
 export function Box({ className, children }: BoxProps) {
   return (
     <div
-      className={`bg-back hover:outline-bd-default w-full rounded-lg p-2 hover:outline-1 ${className}`}
+      className={`bg-fill-back hover:outline-bd-default w-full rounded-lg p-2 hover:outline-1 ${className}`}
     >
       {children}
     </div>

--- a/src/presentation/modules/form/components/ErrorMessage.tsx
+++ b/src/presentation/modules/form/components/ErrorMessage.tsx
@@ -1,4 +1,4 @@
 export function ErrorMessage({ message }: { message?: string }) {
   if (!message) return null;
-  return <p className="text-cancel leading-tight font-medium">{message}</p>;
+  return <p className="text-danger leading-tight font-medium">{message}</p>;
 }

--- a/src/presentation/modules/form/components/ErrorMessage.tsx
+++ b/src/presentation/modules/form/components/ErrorMessage.tsx
@@ -1,4 +1,4 @@
 export function ErrorMessage({ message }: { message?: string }) {
   if (!message) return null;
-  return <p className="fg-cancel leading-tight font-medium">{message}</p>;
+  return <p className="text-cancel leading-tight font-medium">{message}</p>;
 }

--- a/src/presentation/modules/form/components/FormFieldSection.tsx
+++ b/src/presentation/modules/form/components/FormFieldSection.tsx
@@ -9,7 +9,7 @@ type Props = {
 export function FormFieldSection({ Icon, children, title, className }: Props) {
   return (
     <section className="space-y-2" aria-label={title}>
-      <h5 className="fg-default border-b-bd-muted flex h-10 items-center gap-2 border-b">
+      <h5 className="text-default border-b-bd-muted flex h-10 items-center gap-2 border-b">
         {Icon && <Icon strokeWidth="1" />}
         <span className="truncate text-lg font-normal">{title}</span>
       </h5>

--- a/src/presentation/modules/form/components/FormFieldSection.tsx
+++ b/src/presentation/modules/form/components/FormFieldSection.tsx
@@ -9,7 +9,7 @@ type Props = {
 export function FormFieldSection({ Icon, children, title, className }: Props) {
   return (
     <section className="space-y-2" aria-label={title}>
-      <h5 className="text-default border-b-bd-muted flex h-10 items-center gap-2 border-b">
+      <h5 className="text-fg-default border-b-bd-muted flex h-10 items-center gap-2 border-b">
         {Icon && <Icon strokeWidth="1" />}
         <span className="truncate text-lg font-normal">{title}</span>
       </h5>

--- a/src/presentation/modules/form/components/MultipleSelectBox.tsx
+++ b/src/presentation/modules/form/components/MultipleSelectBox.tsx
@@ -76,7 +76,7 @@ export function MultipleSelectBox<TForm extends FieldValues, TName extends Field
   return (
     <>
       <div className="flex flex-col gap-2">
-        <header className="text-strong font-medium">{label}</header>
+        <header className="text-fg-strong font-medium">{label}</header>
         <Box className="flex h-48 gap-1">
           <main className="scrollbar-y flex flex-1 flex-wrap content-start gap-2 pb-4">
             {fields.map((field, index) => (

--- a/src/presentation/modules/form/components/MultipleSelectBox.tsx
+++ b/src/presentation/modules/form/components/MultipleSelectBox.tsx
@@ -21,7 +21,7 @@ function SelectedOptions({ option, onCrossClick }: SelectedOption) {
     onCrossClick?.(option.value);
   };
   return (
-    <div className="bg-base border-bd-muted flex w-fit max-w-36 items-center gap-0.5 rounded-lg border px-1 py-1 pl-3 hover:border-transparent">
+    <div className="bg-fill-base border-bd-muted flex w-fit max-w-36 items-center gap-0.5 rounded-lg border px-1 py-1 pl-3 hover:border-transparent">
       <span className="truncate">{option.label}</span>
       {onCrossClick && (
         <Button

--- a/src/presentation/modules/form/components/MultipleSelectBox.tsx
+++ b/src/presentation/modules/form/components/MultipleSelectBox.tsx
@@ -21,7 +21,7 @@ function SelectedOptions({ option, onCrossClick }: SelectedOption) {
     onCrossClick?.(option.value);
   };
   return (
-    <div className="bg-middle border-bd-muted flex w-fit max-w-36 items-center gap-0.5 rounded-lg border px-1 py-1 pl-3 hover:border-transparent">
+    <div className="bg-base border-bd-muted flex w-fit max-w-36 items-center gap-0.5 rounded-lg border px-1 py-1 pl-3 hover:border-transparent">
       <span className="truncate">{option.label}</span>
       {onCrossClick && (
         <Button
@@ -76,7 +76,7 @@ export function MultipleSelectBox<TForm extends FieldValues, TName extends Field
   return (
     <>
       <div className="flex flex-col gap-2">
-        <header className="fg-strong font-medium">{label}</header>
+        <header className="text-strong font-medium">{label}</header>
         <Box className="flex h-48 gap-1">
           <main className="scrollbar-y flex flex-1 flex-wrap content-start gap-2 pb-4">
             {fields.map((field, index) => (

--- a/src/presentation/modules/form/components/MultipleSelectBox.tsx
+++ b/src/presentation/modules/form/components/MultipleSelectBox.tsx
@@ -25,13 +25,13 @@ function SelectedOptions({ option, onCrossClick }: SelectedOption) {
       <span className="truncate">{option.label}</span>
       {onCrossClick && (
         <Button
-          variantConfig={{ size: 'xs', type: 'square' }}
+          variant={{ size: 'xs', type: 'icon' }}
           type="button"
           onClick={handleClick}
-          className="cursor-pointer transition-opacity hover:opacity-50"
-        >
-          <IconXMark className="size-5" strokeWidth="1" />
-        </Button>
+          className="transition-opacity hover:opacity-50"
+          Icon={IconXMark}
+          aria-label="Remove option selected"
+        />
       )}
     </div>
   );
@@ -90,18 +90,16 @@ export function MultipleSelectBox<TForm extends FieldValues, TName extends Field
           <aside className="flex flex-col items-center justify-between gap-2">
             <Button
               onClick={openSelection}
-              variantConfig={{ type: 'square', color: 'subtle' }}
+              variant={{ type: 'icon', color: 'subtle' }}
+              Icon={IconCirclePlus}
               aria-label="Add new element"
-            >
-              <IconCirclePlus strokeWidth="1" />
-            </Button>
+            />
             <Button
               onClick={clearAllItems}
-              variantConfig={{ type: 'square', color: 'subtle' }}
+              variant={{ type: 'icon', color: 'subtle' }}
               aria-label="Clear all elements"
-            >
-              <IconTrash strokeWidth="1" />
-            </Button>
+              Icon={IconTrash}
+            />
           </aside>
         </Box>
         <ErrorMessage message={error} />

--- a/src/presentation/modules/form/components/Radiobutton.tsx
+++ b/src/presentation/modules/form/components/Radiobutton.tsx
@@ -42,7 +42,7 @@ export function Radiobutton({
       <div
         className={twMerge(
           'outline-focus flex h-10 items-center gap-2 rounded px-2 py-1 transition-colors peer-focus:outline-2',
-          checked ? '' : 'text-default/50',
+          checked ? '' : 'text-fg-default/50',
           className
         )}
       >

--- a/src/presentation/modules/form/components/SelectBox.tsx
+++ b/src/presentation/modules/form/components/SelectBox.tsx
@@ -44,7 +44,7 @@ export function SelectBox({
     <>
       <div
         ref={ref}
-        className="bg-base border-subtle/20 fixed inset-0 z-10 m-auto flex size-fit w-160 flex-col gap-2 rounded-lg border p-6"
+        className="bg-fill-base border-subtle/20 fixed inset-0 z-10 m-auto flex size-fit w-160 flex-col gap-2 rounded-lg border p-6"
       >
         <header className="flex items-center justify-between gap-2">
           <h5 className="text-strong truncate text-xl font-medium">{title}</h5>
@@ -53,7 +53,7 @@ export function SelectBox({
           </Button>
         </header>
         <div>
-          <label className="hover:outline-bd-default bg-back mb-2 flex w-full items-center gap-2 rounded-lg px-4 py-2 text-base font-light hover:outline-1">
+          <label className="hover:outline-bd-default bg-fill-back mb-2 flex w-full items-center gap-2 rounded-lg px-4 py-2 text-base font-light hover:outline-1">
             <IconSearch className="text-muted size-5" strokeWidth="2" />
             <input
               type="search"

--- a/src/presentation/modules/form/components/SelectBox.tsx
+++ b/src/presentation/modules/form/components/SelectBox.tsx
@@ -44,17 +44,17 @@ export function SelectBox({
     <>
       <div
         ref={ref}
-        className="bg-middle border-subtle/20 fixed inset-0 z-10 m-auto flex size-fit w-160 flex-col gap-2 rounded-lg border p-6"
+        className="bg-base border-subtle/20 fixed inset-0 z-10 m-auto flex size-fit w-160 flex-col gap-2 rounded-lg border p-6"
       >
         <header className="flex items-center justify-between gap-2">
-          <h5 className="fg-strong truncate text-xl font-medium">{title}</h5>
+          <h5 className="text-strong truncate text-xl font-medium">{title}</h5>
           <Button variantConfig={{ color: 'simple', type: 'square' }} onClick={onClose}>
             <IconXMark />
           </Button>
         </header>
         <div>
           <label className="hover:outline-bd-default bg-back mb-2 flex w-full items-center gap-2 rounded-lg px-4 py-2 text-base font-light hover:outline-1">
-            <IconSearch className="fg-muted size-5" strokeWidth="2" />
+            <IconSearch className="text-muted size-5" strokeWidth="2" />
             <input
               type="search"
               className="w-full appearance-none outline-none"

--- a/src/presentation/modules/form/components/SelectBox.tsx
+++ b/src/presentation/modules/form/components/SelectBox.tsx
@@ -47,14 +47,14 @@ export function SelectBox({
         className="bg-fill-base border-subtle/20 fixed inset-0 z-10 m-auto flex size-fit w-160 flex-col gap-2 rounded-lg border p-6"
       >
         <header className="flex items-center justify-between gap-2">
-          <h5 className="text-strong truncate text-xl font-medium">{title}</h5>
+          <h5 className="text-fg-strong truncate text-xl font-medium">{title}</h5>
           <Button variantConfig={{ color: 'simple', type: 'square' }} onClick={onClose}>
             <IconXMark />
           </Button>
         </header>
         <div>
           <label className="hover:outline-bd-default bg-fill-back mb-2 flex w-full items-center gap-2 rounded-lg px-4 py-2 text-base font-light hover:outline-1">
-            <IconSearch className="text-muted size-5" strokeWidth="2" />
+            <IconSearch className="text-fg-subtle size-5" strokeWidth="2" />
             <input
               type="search"
               className="w-full appearance-none outline-none"

--- a/src/presentation/modules/form/components/SelectBox.tsx
+++ b/src/presentation/modules/form/components/SelectBox.tsx
@@ -48,9 +48,12 @@ export function SelectBox({
       >
         <header className="flex items-center justify-between gap-2">
           <h5 className="text-fg-strong truncate text-xl font-medium">{title}</h5>
-          <Button variantConfig={{ color: 'simple', type: 'square' }} onClick={onClose}>
-            <IconXMark />
-          </Button>
+          <Button
+            onClick={onClose}
+            variant={{ color: 'simple', type: 'icon' }}
+            Icon={IconXMark}
+            aria-label="Close selection"
+          />
         </header>
         <div>
           <label className="hover:outline-bd-default bg-fill-back mb-2 flex w-full items-center gap-2 rounded-lg px-4 py-2 text-base font-light hover:outline-1">
@@ -77,7 +80,7 @@ export function SelectBox({
         <footer className="mt-4 flex justify-end">
           <Button
             type="button"
-            variantConfig={{
+            variant={{
               color: 'simple',
             }}
             onClick={handleClose}
@@ -86,7 +89,7 @@ export function SelectBox({
           </Button>
           <Button
             type="button"
-            variantConfig={{
+            variant={{
               color: 'primary',
             }}
             onClick={handleAddOptions}

--- a/src/presentation/modules/form/components/SelectBox.tsx
+++ b/src/presentation/modules/form/components/SelectBox.tsx
@@ -44,7 +44,7 @@ export function SelectBox({
     <>
       <div
         ref={ref}
-        className="bg-fill-base border-subtle/20 fixed inset-0 z-10 m-auto flex size-fit w-160 flex-col gap-2 rounded-lg border p-6"
+        className="bg-fill-base border-bd-default fixed inset-0 z-10 m-auto flex size-fit w-160 flex-col gap-2 rounded-lg border p-6"
       >
         <header className="flex items-center justify-between gap-2">
           <h5 className="text-fg-strong truncate text-xl font-medium">{title}</h5>

--- a/src/presentation/modules/form/components/SelectBoxOption.test.tsx
+++ b/src/presentation/modules/form/components/SelectBoxOption.test.tsx
@@ -74,7 +74,7 @@ describe('<SelectBoxOption />', () => {
 
     it('Should be highlighted when isSelected prop is "true"', async () => {
       render(<SelectBoxOption onSelect={() => {}} option={options[0]} isSelected />);
-      expect(screen.getByText(options[0].label)).toHaveClass('border-complete');
+      expect(screen.getByText(options[0].label)).toHaveClass('border-success');
     });
 
     it('Should not be highlighted when isSelected prop is not provided or as "false"', () => {

--- a/src/presentation/modules/form/components/SelectBoxOption.test.tsx
+++ b/src/presentation/modules/form/components/SelectBoxOption.test.tsx
@@ -79,7 +79,7 @@ describe('<SelectBoxOption />', () => {
 
     it('Should not be highlighted when isSelected prop is not provided or as "false"', () => {
       render(<SelectBoxOption onSelect={() => {}} option={options[0]} />);
-      expect(screen.getByText(options[0].label)).toHaveClass('border-subtle/20');
+      expect(screen.getByText(options[0].label)).toHaveClass('border-bd-default');
     });
   });
 });

--- a/src/presentation/modules/form/components/SelectBoxOption.tsx
+++ b/src/presentation/modules/form/components/SelectBoxOption.tsx
@@ -11,7 +11,7 @@ export function SelectBoxOption({
   onSelect: (value: SelectOption['value']) => void;
 }) {
   const isActiveClass = isSelected
-    ? 'border-complete fg-complete font-medium light:fg-green-700 light:border-green-600'
+    ? 'border-complete text-complete font-medium light:text-green-700 light:border-green-600'
     : 'border-subtle/20';
   return (
     <label className="relative">
@@ -24,7 +24,7 @@ export function SelectBoxOption({
       />
       <div
         className={twMerge(
-          'outline-focus bg-middle hover:border-complete hover:fg-complete light:hover:fg-green-900 w-fit cursor-pointer rounded-lg border px-3 py-1 text-sm peer-focus:outline-2',
+          'outline-focus bg-base hover:border-complete hover:text-complete light:hover:text-green-900 w-fit cursor-pointer rounded-lg border px-3 py-1 text-sm peer-focus:outline-2',
           isActiveClass
         )}
       >

--- a/src/presentation/modules/form/components/SelectBoxOption.tsx
+++ b/src/presentation/modules/form/components/SelectBoxOption.tsx
@@ -11,7 +11,7 @@ export function SelectBoxOption({
   onSelect: (value: SelectOption['value']) => void;
 }) {
   const isActiveClass = isSelected
-    ? 'border-complete text-complete font-medium light:text-green-700 light:border-green-600'
+    ? 'border-success text-success font-medium light:text-green-700 light:border-green-600'
     : 'border-subtle/20';
   return (
     <label className="relative">
@@ -24,7 +24,7 @@ export function SelectBoxOption({
       />
       <div
         className={twMerge(
-          'outline-focus bg-fill-base hover:border-complete hover:text-complete light:hover:text-green-900 w-fit cursor-pointer rounded-lg border px-3 py-1 text-sm peer-focus:outline-2',
+          'outline-focus bg-fill-base hover:border-success hover:text-success light:hover:text-green-900 w-fit cursor-pointer rounded-lg border px-3 py-1 text-sm peer-focus:outline-2',
           isActiveClass
         )}
       >

--- a/src/presentation/modules/form/components/SelectBoxOption.tsx
+++ b/src/presentation/modules/form/components/SelectBoxOption.tsx
@@ -24,7 +24,7 @@ export function SelectBoxOption({
       />
       <div
         className={twMerge(
-          'outline-focus bg-base hover:border-complete hover:text-complete light:hover:text-green-900 w-fit cursor-pointer rounded-lg border px-3 py-1 text-sm peer-focus:outline-2',
+          'outline-focus bg-fill-base hover:border-complete hover:text-complete light:hover:text-green-900 w-fit cursor-pointer rounded-lg border px-3 py-1 text-sm peer-focus:outline-2',
           isActiveClass
         )}
       >

--- a/src/presentation/modules/form/components/SelectBoxOption.tsx
+++ b/src/presentation/modules/form/components/SelectBoxOption.tsx
@@ -12,7 +12,7 @@ export function SelectBoxOption({
 }) {
   const isActiveClass = isSelected
     ? 'border-success text-success font-medium light:text-green-700 light:border-green-600'
-    : 'border-subtle/20';
+    : 'border-bd-default';
   return (
     <label className="relative">
       <input

--- a/src/presentation/modules/form/components/SortableInputItem.tsx
+++ b/src/presentation/modules/form/components/SortableInputItem.tsx
@@ -21,7 +21,7 @@ export function SortableInputItem({ item, index, onRemoveOption }: Props) {
 
   return (
     <div
-      className="bg-middle flex min-h-10 w-full items-center gap-2 rounded-lg py-1 pr-3 pl-1"
+      className="bg-base flex min-h-10 w-full items-center gap-2 rounded-lg py-1 pr-3 pl-1"
       ref={ref}
       data-testid="sortable-item"
     >

--- a/src/presentation/modules/form/components/SortableInputItem.tsx
+++ b/src/presentation/modules/form/components/SortableInputItem.tsx
@@ -21,7 +21,7 @@ export function SortableInputItem({ item, index, onRemoveOption }: Props) {
 
   return (
     <div
-      className="bg-base flex min-h-10 w-full items-center gap-2 rounded-lg py-1 pr-3 pl-1"
+      className="bg-fill-base flex min-h-10 w-full items-center gap-2 rounded-lg py-1 pr-3 pl-1"
       ref={ref}
       data-testid="sortable-item"
     >

--- a/src/presentation/modules/form/components/SortableInputItem.tsx
+++ b/src/presentation/modules/form/components/SortableInputItem.tsx
@@ -27,23 +27,21 @@ export function SortableInputItem({ item, index, onRemoveOption }: Props) {
     >
       <div className="flex w-full items-center">
         <Button
-          variantConfig={{ type: 'square', color: 'simple' }}
           className="cursor-grab"
           ref={handleRef}
+          variant={{ type: 'icon', color: 'simple' }}
+          Icon={IconGripVertical}
           aria-label="Drag item"
-        >
-          <IconGripVertical className="size-5" />
-        </Button>
+        />
         <span className="px-2 text-sm">{index + 1}</span>
         <div>{item.label}</div>
       </div>
       <Button
-        variantConfig={{ type: 'square', color: 'simple' }}
+        variant={{ type: 'icon', color: 'simple' }}
+        Icon={IconTrash}
         onClick={handleRemoveOption}
         aria-label="Remove item"
-      >
-        <IconTrash className="size-5" />
-      </Button>
+      />
     </div>
   );
 }

--- a/src/presentation/modules/form/components/SortableInputItems.tsx
+++ b/src/presentation/modules/form/components/SortableInputItems.tsx
@@ -68,7 +68,7 @@ export function SortableInputItems<TForm extends FieldValues, TName extends Fiel
           sortField(initialIndex, index);
         }}
       >
-        <main className="bg-back min-h-16 space-y-2 rounded-lg p-2">
+        <main className="bg-fill-back min-h-16 space-y-2 rounded-lg p-2">
           {fields.map((field, index) => (
             <SortableInputItem
               key={field.fieldId}

--- a/src/presentation/modules/form/components/SortableInputItems.tsx
+++ b/src/presentation/modules/form/components/SortableInputItems.tsx
@@ -81,7 +81,7 @@ export function SortableInputItems<TForm extends FieldValues, TName extends Fiel
       </DragDropProvider>
       <footer className="flex items-center justify-between">
         <Button
-          variantConfig={{ color: 'simple' }}
+          variant={{ color: 'simple' }}
           type="button"
           onClick={openSelection}
           className="pr-3 pl-2"
@@ -90,7 +90,7 @@ export function SortableInputItems<TForm extends FieldValues, TName extends Fiel
           {addButtonLabel ?? 'Add'}
         </Button>
         <Button
-          variantConfig={{ color: 'simple' }}
+          variant={{ color: 'simple' }}
           type="button"
           onClick={crearAllItems}
           className="pr-3 pl-2"

--- a/src/presentation/modules/form/components/fields/InputCheckBox.test.tsx
+++ b/src/presentation/modules/form/components/fields/InputCheckBox.test.tsx
@@ -8,33 +8,18 @@ describe('<InputCheckBox />', () => {
     it('should render correctly with minimum props', () => {
       render(<InputCheckBox />);
       expect(screen.getByRole('switch')).toBeInTheDocument();
-      expect(screen.getByText('Off')).toBeInTheDocument();
     });
   });
 
   describe('Integration with Props', () => {
     it('should be checked when active props is true', () => {
       render(<InputCheckBox active />);
-      expect(screen.getByRole('switch')).toBeInTheDocument();
-      expect(screen.getByText('On')).toBeInTheDocument();
+      expect(screen.getByRole('switch')).toBeChecked();
     });
 
     it('should not be checked when active props is false', () => {
       render(<InputCheckBox active={false} />);
-      expect(screen.getByRole('switch')).toBeInTheDocument();
-    });
-  });
-
-  describe('Internal State', () => {
-    it('should show "On" text when checkbox checked', async () => {
-      render(<InputCheckBox active />);
-      expect(screen.getByRole('switch')).toBeChecked();
-      expect(screen.getByText('On')).toBeInTheDocument();
-    });
-    it('should show "Off" text when checkbox not checked', async () => {
-      render(<InputCheckBox active={false} />);
       expect(screen.getByRole('switch')).not.toBeChecked();
-      expect(screen.getByText('Off')).toBeInTheDocument();
     });
   });
 
@@ -42,9 +27,9 @@ describe('<InputCheckBox />', () => {
     it('should update active state after clicking', async () => {
       const user = userEvent.setup();
       render(<InputCheckBox active={false} />);
-      expect(screen.getByText('Off')).toBeInTheDocument();
+      expect(screen.getByRole('switch')).not.toBeChecked();
       await user.click(screen.getByTestId('input-checkbox'));
-      expect(screen.getByText('On')).toBeInTheDocument();
+      expect(screen.getByRole('switch')).toBeChecked();
     });
   });
 

--- a/src/presentation/modules/form/components/fields/InputCheckBox.tsx
+++ b/src/presentation/modules/form/components/fields/InputCheckBox.tsx
@@ -43,12 +43,12 @@ export function InputCheckBox(props: Props) {
       <div
         data-testid="input-checkbox"
         onClick={() => setActive((prev) => !prev)}
-        className="bg-back grid h-10 w-16 cursor-pointer place-items-center rounded-md p-1 peer-focus-visible:outline"
+        className="bg-fill-back grid h-10 w-16 cursor-pointer place-items-center rounded-md p-1 peer-focus-visible:outline"
       >
         <span
           className={twMerge(
             'flex h-full w-full items-center justify-center rounded px-2 py-1 transition-colors',
-            active ? 'bg-primary text-strong-dark' : 'bg-base'
+            active ? 'bg-primary text-strong-dark' : 'bg-fill-base'
           )}
         >
           {active ? 'On' : 'Off'}

--- a/src/presentation/modules/form/components/fields/InputCheckBox.tsx
+++ b/src/presentation/modules/form/components/fields/InputCheckBox.tsx
@@ -48,7 +48,7 @@ export function InputCheckBox(props: Props) {
         <span
           className={twMerge(
             'flex h-full w-full items-center justify-center rounded px-2 py-1 transition-colors',
-            active ? 'bg-primary fg-strong-dark' : 'bg-middle'
+            active ? 'bg-primary text-strong-dark' : 'bg-base'
           )}
         >
           {active ? 'On' : 'Off'}

--- a/src/presentation/modules/form/components/fields/InputCheckBox.tsx
+++ b/src/presentation/modules/form/components/fields/InputCheckBox.tsx
@@ -48,7 +48,7 @@ export function InputCheckBox(props: Props) {
         <span
           className={twMerge(
             'flex h-full w-full items-center justify-center rounded px-2 py-1 transition-colors',
-            active ? 'bg-primary text-strong-dark' : 'bg-fill-base'
+            active ? 'bg-primary text-fg-strong-dark' : 'bg-fill-base'
           )}
         >
           {active ? 'On' : 'Off'}

--- a/src/presentation/modules/form/components/fields/InputCheckBox.tsx
+++ b/src/presentation/modules/form/components/fields/InputCheckBox.tsx
@@ -43,16 +43,22 @@ export function InputCheckBox(props: Props) {
       <div
         data-testid="input-checkbox"
         onClick={() => setActive((prev) => !prev)}
-        className="bg-fill-back grid h-10 w-16 cursor-pointer place-items-center rounded-md p-1 peer-focus-visible:outline"
+        className="ring-bd-strong grid h-8 w-16 cursor-pointer place-items-center rounded-full ring peer-focus-visible:outline"
       >
-        <span
+        <div
           className={twMerge(
-            'flex h-full w-full items-center justify-center rounded px-2 py-1 transition-colors',
+            'relative flex h-full w-full items-center justify-center rounded-full py-1 transition-colors',
             active ? 'bg-primary text-fg-strong-dark' : 'bg-fill-base'
           )}
         >
-          {active ? 'On' : 'Off'}
-        </span>
+          <div
+            className={twMerge(
+              'ring-bd-strong absolute inset-0 top-0 my-auto block size-8 rounded-full bg-white ring transition-[left]',
+              'before:absolute before:inset-0 before:m-auto before:size-6 before:rounded-full before:bg-linear-275 before:from-white before:to-zinc-200',
+              active ? 'left-8' : 'left-0'
+            )}
+          />
+        </div>
       </div>
     </>
   );

--- a/src/presentation/modules/form/components/fields/Label.tsx
+++ b/src/presentation/modules/form/components/fields/Label.tsx
@@ -11,7 +11,7 @@ export function Label({
 }) {
   return (
     <label htmlFor={htmlFor} className={`flex flex-col gap-2 ${className}`}>
-      <span className="fg-strong pl-0.5 font-medium whitespace-nowrap">{title}</span>
+      <span className="text-strong pl-0.5 font-medium whitespace-nowrap">{title}</span>
       {children}
     </label>
   );

--- a/src/presentation/modules/form/components/fields/Label.tsx
+++ b/src/presentation/modules/form/components/fields/Label.tsx
@@ -11,7 +11,7 @@ export function Label({
 }) {
   return (
     <label htmlFor={htmlFor} className={`flex flex-col gap-2 ${className}`}>
-      <span className="text-strong pl-0.5 font-medium whitespace-nowrap">{title}</span>
+      <span className="text-fg-strong pl-0.5 font-medium whitespace-nowrap">{title}</span>
       {children}
     </label>
   );

--- a/src/presentation/modules/form/components/fields/LabelGroup.tsx
+++ b/src/presentation/modules/form/components/fields/LabelGroup.tsx
@@ -9,7 +9,7 @@ export function LabelGroup({
 }) {
   return (
     <div className={`flex flex-col gap-2 ${className}`}>
-      <span className="text-strong font-medium whitespace-nowrap">{title}</span>
+      <span className="text-fg-strong font-medium whitespace-nowrap">{title}</span>
       {children}
     </div>
   );

--- a/src/presentation/modules/form/components/fields/LabelGroup.tsx
+++ b/src/presentation/modules/form/components/fields/LabelGroup.tsx
@@ -9,7 +9,7 @@ export function LabelGroup({
 }) {
   return (
     <div className={`flex flex-col gap-2 ${className}`}>
-      <span className="fg-strong font-medium whitespace-nowrap">{title}</span>
+      <span className="text-strong font-medium whitespace-nowrap">{title}</span>
       {children}
     </div>
   );

--- a/src/presentation/modules/form/components/fields/Select.tsx
+++ b/src/presentation/modules/form/components/fields/Select.tsx
@@ -61,7 +61,7 @@ export function Select({
           <option
             key={option.value}
             value={option.value}
-            className="bg-middle focus:bg-back hover:bg-back"
+            className="bg-base focus:bg-back hover:bg-back"
           >
             {option.label}
           </option>

--- a/src/presentation/modules/form/components/fields/Select.tsx
+++ b/src/presentation/modules/form/components/fields/Select.tsx
@@ -61,7 +61,7 @@ export function Select({
           <option
             key={option.value}
             value={option.value}
-            className="bg-base focus:bg-back hover:bg-back"
+            className="bg-fill-base focus:bg-fill-back hover:bg-fill-back"
           >
             {option.label}
           </option>

--- a/src/presentation/modules/form/components/modal-form/ModalForm.tsx
+++ b/src/presentation/modules/form/components/modal-form/ModalForm.tsx
@@ -27,7 +27,9 @@ export function ModalForm<T extends ZodSchema<any, any>>({
   return (
     <div className={`flex w-160 flex-col gap-4 ${className}`}>
       <header className="border-bd-muted flex h-16 items-center justify-between border-b p-8">
-        <h3 className="font-funnel-display text-strong truncate text-2xl font-medium">{title}</h3>
+        <h3 className="font-funnel-display text-fg-strong truncate text-2xl font-medium">
+          {title}
+        </h3>
         <aside>
           <Button
             type="button"

--- a/src/presentation/modules/form/components/modal-form/ModalForm.tsx
+++ b/src/presentation/modules/form/components/modal-form/ModalForm.tsx
@@ -26,8 +26,8 @@ export function ModalForm<T extends ZodSchema<any, any>>({
 
   return (
     <div className={`flex w-160 flex-col gap-4 ${className}`}>
-      <header className="border-bd-muted flex h-10 items-center justify-between border-b p-8 text-xl">
-        <h3 className="font-funnel-display fg-strong truncate text-2xl font-medium">{title}</h3>
+      <header className="border-bd-muted flex h-16 items-center justify-between border-b p-8">
+        <h3 className="font-funnel-display text-strong truncate text-2xl font-medium">{title}</h3>
         <aside>
           <Button
             type="button"

--- a/src/presentation/modules/form/components/modal-form/ModalForm.tsx
+++ b/src/presentation/modules/form/components/modal-form/ModalForm.tsx
@@ -33,14 +33,14 @@ export function ModalForm<T extends ZodSchema<any, any>>({
         <aside>
           <Button
             type="button"
-            variantConfig={{
+            variant={{
               color: 'simple',
-              type: 'square',
+              type: 'icon',
             }}
             onClick={onClose}
-          >
-            <IconXMark />
-          </Button>
+            Icon={IconXMark}
+            aria-label="Close modal"
+          />
         </aside>
       </header>
       <FormProvider {...methods}>

--- a/src/presentation/modules/form/components/modal-form/ModalFormButtons.tsx
+++ b/src/presentation/modules/form/components/modal-form/ModalFormButtons.tsx
@@ -15,7 +15,7 @@ export function ModalFormButtons({ onClose }: { onClose?: () => void }) {
     <footer className="mt-2 flex justify-end">
       <Button
         type="button"
-        variantConfig={{
+        variant={{
           color: 'simple',
         }}
         onClick={handleClose}
@@ -24,7 +24,7 @@ export function ModalFormButtons({ onClose }: { onClose?: () => void }) {
       </Button>
       <Button
         type="submit"
-        variantConfig={{
+        variant={{
           color: 'primary',
         }}
         className={isSubmitting ? 'cursor-not-allowed opacity-50' : ''}

--- a/src/presentation/modules/form/components/modal-form/ModalFormHeader.tsx
+++ b/src/presentation/modules/form/components/modal-form/ModalFormHeader.tsx
@@ -4,7 +4,7 @@ type ModalFormProps = {
 };
 export function ModalFormHeader({ title, className = '' }: ModalFormProps) {
   return (
-    <header className={`font-funnel-display text-strong text-2xl font-medium ${className}`}>
+    <header className={`font-funnel-display text-fg-strong text-2xl font-medium ${className}`}>
       {title}
     </header>
   );

--- a/src/presentation/modules/form/components/modal-form/ModalFormHeader.tsx
+++ b/src/presentation/modules/form/components/modal-form/ModalFormHeader.tsx
@@ -4,7 +4,7 @@ type ModalFormProps = {
 };
 export function ModalFormHeader({ title, className = '' }: ModalFormProps) {
   return (
-    <header className={`font-funnel-display fg-strong text-2xl font-medium ${className}`}>
+    <header className={`font-funnel-display text-strong text-2xl font-medium ${className}`}>
       {title}
     </header>
   );

--- a/src/presentation/modules/form/components/tooltip/TooltipSelect.tsx
+++ b/src/presentation/modules/form/components/tooltip/TooltipSelect.tsx
@@ -41,7 +41,7 @@ export function TooltipSelect({
 
   return (
     <div className="fixed inset-0 grid size-full place-items-center bg-black/50">
-      <div ref={tooltipRef} className="bg-middle w-90 space-y-4 rounded-2xl border border-white/5">
+      <div ref={tooltipRef} className="bg-base w-90 space-y-4 rounded-2xl border border-white/5">
         <header className="flex items-center justify-between gap-2 pl-4">
           <h5>{title}</h5>
           <Button onClick={onClose} variantConfig={{ type: 'square', color: 'simple' }}>

--- a/src/presentation/modules/form/components/tooltip/TooltipSelect.tsx
+++ b/src/presentation/modules/form/components/tooltip/TooltipSelect.tsx
@@ -41,7 +41,10 @@ export function TooltipSelect({
 
   return (
     <div className="fixed inset-0 grid size-full place-items-center bg-black/50">
-      <div ref={tooltipRef} className="bg-base w-90 space-y-4 rounded-2xl border border-white/5">
+      <div
+        ref={tooltipRef}
+        className="bg-fill-base w-90 space-y-4 rounded-2xl border border-white/5"
+      >
         <header className="flex items-center justify-between gap-2 pl-4">
           <h5>{title}</h5>
           <Button onClick={onClose} variantConfig={{ type: 'square', color: 'simple' }}>

--- a/src/presentation/modules/form/components/tooltip/TooltipSelect.tsx
+++ b/src/presentation/modules/form/components/tooltip/TooltipSelect.tsx
@@ -47,19 +47,22 @@ export function TooltipSelect({
       >
         <header className="flex items-center justify-between gap-2 pl-4">
           <h5>{title}</h5>
-          <Button onClick={onClose} variantConfig={{ type: 'square', color: 'simple' }}>
-            <IconXMark />
-          </Button>
+          <Button
+            onClick={onClose}
+            variant={{ type: 'icon', color: 'simple' }}
+            Icon={IconXMark}
+            aria-label="Close tooltip"
+          />
         </header>
         <main className="space-y-4 px-4 pb-4">
           <LabelGroup title={label}>
             <Select ref={selectRef} multiple={false} options={selectOptions} />
           </LabelGroup>
           <footer className="flex items-center justify-end gap-2">
-            <Button variantConfig={{ color: 'simple', size: 'sm' }} onClick={onClose}>
+            <Button variant={{ color: 'simple', size: 'sm' }} onClick={onClose}>
               Cancel
             </Button>
-            <Button variantConfig={{ color: 'primary', size: 'sm' }} onClick={handleSelectOption}>
+            <Button variant={{ color: 'primary', size: 'sm' }} onClick={handleSelectOption}>
               Done
             </Button>
           </footer>

--- a/src/presentation/modules/form/constants/classes.ts
+++ b/src/presentation/modules/form/constants/classes.ts
@@ -1,3 +1,3 @@
 export const InputClasses =
-  'w-full bg-back px-3 py-2 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed focus:outline focus:outline-strong/50';
+  'w-full bg-fill-back px-3 py-2 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed focus:outline focus:outline-strong/50';
 export const TextAreaClasses = `${InputClasses} [resize:none] [vertical-align:top]`;

--- a/src/presentation/modules/landing/components/Advantages.tsx
+++ b/src/presentation/modules/landing/components/Advantages.tsx
@@ -8,7 +8,7 @@ export function Advantages({ className = '' }: { className?: string }) {
   return (
     <section className={`mx-auto my-16 w-full max-w-5xl ${className}`}>
       <header>
-        <h2 className="font-funnel-display text-strong text-4xl font-bold">Why AtlasWay?</h2>
+        <h2 className="font-funnel-display text-fg-strong text-4xl font-bold">Why AtlasWay?</h2>
       </header>
 
       <main>

--- a/src/presentation/modules/landing/components/Advantages.tsx
+++ b/src/presentation/modules/landing/components/Advantages.tsx
@@ -8,7 +8,7 @@ export function Advantages({ className = '' }: { className?: string }) {
   return (
     <section className={`mx-auto my-16 w-full max-w-5xl ${className}`}>
       <header>
-        <h2 className="font-funnel-display fg-strong text-4xl font-bold">Why AtlasWay?</h2>
+        <h2 className="font-funnel-display text-strong text-4xl font-bold">Why AtlasWay?</h2>
       </header>
 
       <main>

--- a/src/presentation/modules/landing/components/BentoGrid.tsx
+++ b/src/presentation/modules/landing/components/BentoGrid.tsx
@@ -12,7 +12,7 @@ import { IconTrendingUp } from '@/presentation/globals/components/icons/outline/
 export function BentoGrid({ className = '' }: { className?: string }) {
   return (
     <section className={`mx-auto my-16 flex w-full max-w-5xl flex-col gap-8 ${className}`}>
-      <h2 className="font-funnel-display fg-strong text-4xl font-bold">Explore Our Features</h2>
+      <h2 className="font-funnel-display text-strong text-4xl font-bold">Explore Our Features</h2>
       <main className="xs:grid-cols-2 grid grid-cols-1 gap-2 md:grid-cols-4">
         <StartYourJourney />
 

--- a/src/presentation/modules/landing/components/BentoGrid.tsx
+++ b/src/presentation/modules/landing/components/BentoGrid.tsx
@@ -12,7 +12,9 @@ import { IconTrendingUp } from '@/presentation/globals/components/icons/outline/
 export function BentoGrid({ className = '' }: { className?: string }) {
   return (
     <section className={`mx-auto my-16 flex w-full max-w-5xl flex-col gap-8 ${className}`}>
-      <h2 className="font-funnel-display text-strong text-4xl font-bold">Explore Our Features</h2>
+      <h2 className="font-funnel-display text-fg-strong text-4xl font-bold">
+        Explore Our Features
+      </h2>
       <main className="xs:grid-cols-2 grid grid-cols-1 gap-2 md:grid-cols-4">
         <StartYourJourney />
 

--- a/src/presentation/modules/landing/components/Footer.tsx
+++ b/src/presentation/modules/landing/components/Footer.tsx
@@ -1,6 +1,6 @@
 export function Footer({ className = '' }: { className?: string }) {
   return (
-    <footer className={`bg-base mt-16 flex h-48 w-full items-center ${className}`}>
+    <footer className={`bg-fill-base mt-16 flex h-48 w-full items-center ${className}`}>
       <main className="text-strong mx-auto flex max-w-5xl flex-col items-center justify-between gap-2 md:flex-row md:gap-16">
         <aside>
           <h5 className="text-2xl">

--- a/src/presentation/modules/landing/components/Footer.tsx
+++ b/src/presentation/modules/landing/components/Footer.tsx
@@ -1,7 +1,7 @@
 export function Footer({ className = '' }: { className?: string }) {
   return (
-    <footer className={`bg-middle mt-16 flex h-48 w-full items-center ${className}`}>
-      <main className="fg-strong mx-auto flex max-w-5xl flex-col items-center justify-between gap-2 md:flex-row md:gap-16">
+    <footer className={`bg-base mt-16 flex h-48 w-full items-center ${className}`}>
+      <main className="text-strong mx-auto flex max-w-5xl flex-col items-center justify-between gap-2 md:flex-row md:gap-16">
         <aside>
           <h5 className="text-2xl">
             <strong className="font-funnel-display">AtlasWay</strong> &copy;{' '}

--- a/src/presentation/modules/landing/components/Footer.tsx
+++ b/src/presentation/modules/landing/components/Footer.tsx
@@ -1,7 +1,7 @@
 export function Footer({ className = '' }: { className?: string }) {
   return (
     <footer className={`bg-fill-base mt-16 flex h-48 w-full items-center ${className}`}>
-      <main className="text-strong mx-auto flex max-w-5xl flex-col items-center justify-between gap-2 md:flex-row md:gap-16">
+      <main className="text-fg-strong mx-auto flex max-w-5xl flex-col items-center justify-between gap-2 md:flex-row md:gap-16">
         <aside>
           <h5 className="text-2xl">
             <strong className="font-funnel-display">AtlasWay</strong> &copy;{' '}

--- a/src/presentation/modules/landing/components/Header.tsx
+++ b/src/presentation/modules/landing/components/Header.tsx
@@ -7,7 +7,7 @@ import { HeaderNav } from '@/presentation/modules/nav/components/HeaderNav';
 export function Header({ className = '' }: { className?: string }) {
   return (
     <header className={`h-14 ${className}`}>
-      <main className="bg-back border-bd-muted fixed z-10 h-14 w-full border-b">
+      <main className="bg-fill-back border-bd-muted fixed z-10 h-14 w-full border-b">
         <div className="top-0 left-0 mx-auto flex h-14 w-full max-w-5xl items-center justify-between gap-1 px-4 md:gap-4 md:px-4 lg:px-0">
           <div className="flex w-full flex-row items-center justify-start gap-2 md:grid md:grid-cols-[1fr_auto_1fr] md:justify-between md:gap-0">
             <aside className="w-fit">

--- a/src/presentation/modules/landing/components/Hero.tsx
+++ b/src/presentation/modules/landing/components/Hero.tsx
@@ -9,7 +9,7 @@ export async function Hero() {
     <section className="relative grid place-items-center py-16 md:min-h-160 xl:min-h-180">
       <main className="relative z-1 mx-auto flex w-full max-w-360 justify-center">
         <header className="flex flex-col items-center gap-4 text-center md:max-w-5xl md:gap-8 xl:max-w-7xl">
-          <h1 className="font-funnel-display text-strong animate-fade text-5xl leading-none font-bold tracking-tight text-pretty md:text-7xl xl:text-8xl">
+          <h1 className="font-funnel-display text-fg-strong animate-fade text-5xl leading-none font-bold tracking-tight text-pretty md:text-7xl xl:text-8xl">
             Track your <Highilight>planning</Highilight>, build your{' '}
             <Highilight>progress</Highilight> and achieve your <Highilight>goals</Highilight>
           </h1>

--- a/src/presentation/modules/landing/components/Hero.tsx
+++ b/src/presentation/modules/landing/components/Hero.tsx
@@ -9,7 +9,7 @@ export async function Hero() {
     <section className="relative grid place-items-center py-16 md:min-h-160 xl:min-h-180">
       <main className="relative z-1 mx-auto flex w-full max-w-360 justify-center">
         <header className="flex flex-col items-center gap-4 text-center md:max-w-5xl md:gap-8 xl:max-w-7xl">
-          <h1 className="font-funnel-display fg-strong animate-fade text-5xl leading-none font-bold tracking-tight text-pretty md:text-7xl xl:text-8xl">
+          <h1 className="font-funnel-display text-strong animate-fade text-5xl leading-none font-bold tracking-tight text-pretty md:text-7xl xl:text-8xl">
             Track your <Highilight>planning</Highilight>, build your{' '}
             <Highilight>progress</Highilight> and achieve your <Highilight>goals</Highilight>
           </h1>

--- a/src/presentation/modules/landing/components/HeroFooter.tsx
+++ b/src/presentation/modules/landing/components/HeroFooter.tsx
@@ -25,7 +25,7 @@ export function HeroFooter({ className, logged }: Props) {
     >
       <Button
         onClick={handleClick}
-        variantConfig={{
+        variant={{
           color: 'primary',
           size: 'lg',
         }}

--- a/src/presentation/modules/landing/components/Try.tsx
+++ b/src/presentation/modules/landing/components/Try.tsx
@@ -3,7 +3,7 @@ import { Link } from '@/presentation/modules/button/components/Link';
 export function Try({ className = '' }: { className?: string }) {
   return (
     <section
-      className={`fg-strong mx-auto grid w-full max-w-5xl place-items-center gap-4 md:my-16 ${className}`}
+      className={`text-strong mx-auto grid w-full max-w-5xl place-items-center gap-4 md:my-16 ${className}`}
     >
       <h2 className="font-funnel-display text-2xl font-bold">Try for free</h2>
       <main className="flex w-fit items-center justify-center gap-4">

--- a/src/presentation/modules/landing/components/Try.tsx
+++ b/src/presentation/modules/landing/components/Try.tsx
@@ -3,7 +3,7 @@ import { Link } from '@/presentation/modules/button/components/Link';
 export function Try({ className = '' }: { className?: string }) {
   return (
     <section
-      className={`text-strong mx-auto grid w-full max-w-5xl place-items-center gap-4 md:my-16 ${className}`}
+      className={`text-fg-strong mx-auto grid w-full max-w-5xl place-items-center gap-4 md:my-16 ${className}`}
     >
       <h2 className="font-funnel-display text-2xl font-bold">Try for free</h2>
       <main className="flex w-fit items-center justify-center gap-4">

--- a/src/presentation/modules/landing/components/Try.tsx
+++ b/src/presentation/modules/landing/components/Try.tsx
@@ -9,7 +9,7 @@ export function Try({ className = '' }: { className?: string }) {
       <main className="flex w-fit items-center justify-center gap-4">
         <Link
           href="/dashboard"
-          variantConfig={{
+          variant={{
             color: 'primary',
             size: 'lg',
           }}

--- a/src/presentation/modules/landing/components/advantages/AdvantageItem.tsx
+++ b/src/presentation/modules/landing/components/advantages/AdvantageItem.tsx
@@ -11,11 +11,11 @@ export function AdvantageItem({
 }) {
   return (
     <li className="xs:flex-col flex list-disc flex-row gap-4 rounded-md p-4">
-      <div className="bg-accent fg-strong-light h-fit w-fit rounded-full p-2">
+      <div className="bg-accent text-strong-light h-fit w-fit rounded-full p-2">
         <Icon className="size-6" strokeWidth="1.5" />
       </div>
       <main className="xs:p-0 flex flex-1 flex-col gap-2 pt-1.5">
-        <h3 className="fg-strong text-xl font-medium">{tile}</h3>
+        <h3 className="text-strong text-xl font-medium">{tile}</h3>
         <p>{description}</p>
       </main>
     </li>

--- a/src/presentation/modules/landing/components/advantages/AdvantageItem.tsx
+++ b/src/presentation/modules/landing/components/advantages/AdvantageItem.tsx
@@ -11,11 +11,11 @@ export function AdvantageItem({
 }) {
   return (
     <li className="xs:flex-col flex list-disc flex-row gap-4 rounded-md p-4">
-      <div className="bg-accent text-strong-light h-fit w-fit rounded-full p-2">
+      <div className="bg-accent text-fg-strong-light h-fit w-fit rounded-full p-2">
         <Icon className="size-6" strokeWidth="1.5" />
       </div>
       <main className="xs:p-0 flex flex-1 flex-col gap-2 pt-1.5">
-        <h3 className="text-strong text-xl font-medium">{tile}</h3>
+        <h3 className="text-fg-strong text-xl font-medium">{tile}</h3>
         <p>{description}</p>
       </main>
     </li>

--- a/src/presentation/modules/landing/components/bentogrid/AtlasWayCard.tsx
+++ b/src/presentation/modules/landing/components/bentogrid/AtlasWayCard.tsx
@@ -8,9 +8,9 @@ export function AtlasWayCard({ className }: Props) {
   return (
     <BentoCard className={`p-4 md:col-span-2 md:row-span-3 ${className}`}>
       <main className="grid h-full place-content-center p-4 md:p-0">
-        <span className="fg-white xs:text-5xl font-funnel-display text-6xl font-extrabold tracking-tighter sm:text-7xl lg:text-8xl">
-          <span className="fg-strong">Atlas</span>
-          <span className="fg-primary">Way</span>
+        <span className="xs:text-5xl font-funnel-display text-6xl font-extrabold tracking-tighter text-white sm:text-7xl lg:text-8xl">
+          <span className="text-strong">Atlas</span>
+          <span className="text-primary">Way</span>
         </span>
       </main>
     </BentoCard>

--- a/src/presentation/modules/landing/components/bentogrid/AtlasWayCard.tsx
+++ b/src/presentation/modules/landing/components/bentogrid/AtlasWayCard.tsx
@@ -9,7 +9,7 @@ export function AtlasWayCard({ className }: Props) {
     <BentoCard className={`p-4 md:col-span-2 md:row-span-3 ${className}`}>
       <main className="grid h-full place-content-center p-4 md:p-0">
         <span className="xs:text-5xl font-funnel-display text-6xl font-extrabold tracking-tighter text-white sm:text-7xl lg:text-8xl">
-          <span className="text-strong">Atlas</span>
+          <span className="text-fg-strong">Atlas</span>
           <span className="text-primary">Way</span>
         </span>
       </main>

--- a/src/presentation/modules/landing/components/bentogrid/BentoCard.tsx
+++ b/src/presentation/modules/landing/components/bentogrid/BentoCard.tsx
@@ -6,7 +6,7 @@ type Props = {
 export function BentoCard({ className, children }: Props) {
   return (
     <article
-      className={`bg-middle light:shadow-[inset_0px_1px_1px_0px_white,5px_5px_20px_gray]/50 border-subtle/20 rounded-lg border shadow-[inset_0px_0.5px_0px_0px_var(--color-subtle),0px_5px_20px_black]/50 md:min-h-32 ${className}`}
+      className={`bg-base light:shadow-[inset_0px_1px_1px_0px_white,5px_5px_20px_gray]/50 border-subtle/20 rounded-lg border shadow-[inset_0px_0.5px_0px_0px_var(--color-subtle),0px_5px_20px_black]/50 md:min-h-32 ${className}`}
     >
       {children}
     </article>

--- a/src/presentation/modules/landing/components/bentogrid/BentoCard.tsx
+++ b/src/presentation/modules/landing/components/bentogrid/BentoCard.tsx
@@ -6,7 +6,7 @@ type Props = {
 export function BentoCard({ className, children }: Props) {
   return (
     <article
-      className={`bg-base light:shadow-[inset_0px_1px_1px_0px_white,5px_5px_20px_gray]/50 border-subtle/20 rounded-lg border shadow-[inset_0px_0.5px_0px_0px_var(--color-subtle),0px_5px_20px_black]/50 md:min-h-32 ${className}`}
+      className={`bg-fill-base light:shadow-[inset_0px_1px_1px_0px_white,5px_5px_20px_gray]/50 border-subtle/20 rounded-lg border shadow-[inset_0px_0.5px_0px_0px_var(--color-subtle),0px_5px_20px_black]/50 md:min-h-32 ${className}`}
     >
       {children}
     </article>

--- a/src/presentation/modules/landing/components/bentogrid/BentoCard.tsx
+++ b/src/presentation/modules/landing/components/bentogrid/BentoCard.tsx
@@ -6,7 +6,7 @@ type Props = {
 export function BentoCard({ className, children }: Props) {
   return (
     <article
-      className={`bg-fill-base light:shadow-[inset_0px_1px_1px_0px_white,5px_5px_20px_gray]/50 border-subtle/20 rounded-lg border shadow-[inset_0px_0.5px_0px_0px_var(--color-subtle),0px_5px_20px_black]/50 md:min-h-32 ${className}`}
+      className={`bg-fill-base light:shadow-[inset_0px_1px_1px_0px_white,5px_5px_20px_gray]/50 border-bd-default rounded-lg border shadow-[inset_0px_0.5px_0px_0px_var(--color-subtle),0px_5px_20px_black]/50 md:min-h-32 ${className}`}
     >
       {children}
     </article>

--- a/src/presentation/modules/landing/components/bentogrid/CreateYourOwnRoutines.tsx
+++ b/src/presentation/modules/landing/components/bentogrid/CreateYourOwnRoutines.tsx
@@ -8,7 +8,7 @@ export function CreateYourOwnRoutines({ className }: Props) {
   return (
     <BentoCard className={`p-2 md:row-span-2 md:p-0 ${className}`}>
       <main className="grid h-full place-content-center p-4 md:p-0">
-        <header className="font-funnel-display fg-accent max-w-45 text-center text-2xl leading-[1.1] font-bold">
+        <header className="font-funnel-display text-accent max-w-45 text-center text-2xl leading-[1.1] font-bold">
           Create Your Own Routines
         </header>
       </main>

--- a/src/presentation/modules/landing/components/bentogrid/DaysSelection.tsx
+++ b/src/presentation/modules/landing/components/bentogrid/DaysSelection.tsx
@@ -6,8 +6,8 @@ function Day({
   unselected?: boolean;
 }) {
   const className = !unselected
-    ? 'border-accent fg-accent light:border-black light:text-black'
-    : 'fg-default border-strong opacity-50 light:opacity-100 light:border-black/40 light:text-black';
+    ? 'border-accent text-accent light:border-black light:text-black'
+    : 'text-default border-strong opacity-50 light:opacity-100 light:border-black/40 light:text-black';
   return (
     <li className={`rounded-full border px-2 py-1 text-xs font-light ${className}`}>{children}</li>
   );

--- a/src/presentation/modules/landing/components/bentogrid/DaysSelection.tsx
+++ b/src/presentation/modules/landing/components/bentogrid/DaysSelection.tsx
@@ -7,7 +7,7 @@ function Day({
 }) {
   const className = !unselected
     ? 'border-accent text-accent light:border-black light:text-black'
-    : 'text-default border-strong opacity-50 light:opacity-100 light:border-black/40 light:text-black';
+    : 'text-fg-default border-strong opacity-50 light:opacity-100 light:border-black/40 light:text-black';
   return (
     <li className={`rounded-full border px-2 py-1 text-xs font-light ${className}`}>{children}</li>
   );

--- a/src/presentation/modules/landing/components/bentogrid/FlexibleRoutines.tsx
+++ b/src/presentation/modules/landing/components/bentogrid/FlexibleRoutines.tsx
@@ -9,13 +9,13 @@ export function FlexibleRoutines({ className }: Props) {
   return (
     <BentoCard className={`relative p-4 md:row-span-2 ${className}`}>
       <main>
-        <p className="xs:p-0 font-funnel-display text-strong max-w-48 pl-4 text-xl">
+        <p className="xs:p-0 font-funnel-display text-fg-strong max-w-48 pl-4 text-xl">
           Flexible routines to fit your lifestyle.
         </p>
       </main>
       <div className="absolute inset-0 z-0 overflow-hidden rounded-lg">
         <figure className="bg-primary absolute right-10 -bottom-21 h-32 w-fit rounded-full p-2">
-          <IconArrowsLeftRight className="text-strong size-6" strokeWidth="1.5" />
+          <IconArrowsLeftRight className="text-fg-strong size-6" strokeWidth="1.5" />
         </figure>
       </div>
     </BentoCard>

--- a/src/presentation/modules/landing/components/bentogrid/FlexibleRoutines.tsx
+++ b/src/presentation/modules/landing/components/bentogrid/FlexibleRoutines.tsx
@@ -9,13 +9,13 @@ export function FlexibleRoutines({ className }: Props) {
   return (
     <BentoCard className={`relative p-4 md:row-span-2 ${className}`}>
       <main>
-        <p className="xs:p-0 font-funnel-display fg-strong max-w-48 pl-4 text-xl">
+        <p className="xs:p-0 font-funnel-display text-strong max-w-48 pl-4 text-xl">
           Flexible routines to fit your lifestyle.
         </p>
       </main>
       <div className="absolute inset-0 z-0 overflow-hidden rounded-lg">
         <figure className="bg-primary absolute right-10 -bottom-21 h-32 w-fit rounded-full p-2">
-          <IconArrowsLeftRight className="fg-strong size-6" strokeWidth="1.5" />
+          <IconArrowsLeftRight className="text-strong size-6" strokeWidth="1.5" />
         </figure>
       </div>
     </BentoCard>

--- a/src/presentation/modules/landing/components/bentogrid/GetStartedCard.tsx
+++ b/src/presentation/modules/landing/components/bentogrid/GetStartedCard.tsx
@@ -14,7 +14,7 @@ export function GetStartedCard({ className }: Props) {
         variantConfig={{
           size: 'lg',
         }}
-        className="from-accent to-primary fg-strong-dark border-back outline-bd-default flex min-h-14 items-center gap-2 rounded-full border-4 bg-radial-[50%_50%_at_50%_0%] outline"
+        className="from-accent to-primary text-strong-dark border-back outline-bd-default flex min-h-14 items-center gap-2 rounded-full border-4 bg-radial-[50%_50%_at_50%_0%] outline"
       >
         <IconRocket className="-ml-2 size-7" strokeWidth="1.4" />
         <span className="text-lg whitespace-nowrap">Start Now</span>

--- a/src/presentation/modules/landing/components/bentogrid/GetStartedCard.tsx
+++ b/src/presentation/modules/landing/components/bentogrid/GetStartedCard.tsx
@@ -14,7 +14,7 @@ export function GetStartedCard({ className }: Props) {
         variantConfig={{
           size: 'lg',
         }}
-        className="from-accent to-primary text-strong-dark border-back outline-bd-default flex min-h-14 items-center gap-2 rounded-full border-4 bg-radial-[50%_50%_at_50%_0%] outline"
+        className="from-accent to-primary text-fg-strong-dark border-back outline-bd-default flex min-h-14 items-center gap-2 rounded-full border-4 bg-radial-[50%_50%_at_50%_0%] outline"
       >
         <IconRocket className="-ml-2 size-7" strokeWidth="1.4" />
         <span className="text-lg whitespace-nowrap">Start Now</span>

--- a/src/presentation/modules/landing/components/bentogrid/GetStartedCard.tsx
+++ b/src/presentation/modules/landing/components/bentogrid/GetStartedCard.tsx
@@ -11,7 +11,7 @@ export function GetStartedCard({ className }: Props) {
     <BentoCard className={`xs:grid hidden place-content-center md:row-span-2 ${className}`}>
       <Link
         href="/dashboard"
-        variantConfig={{
+        variant={{
           size: 'lg',
         }}
         className="from-accent to-primary text-fg-strong-dark border-back outline-bd-default flex min-h-14 items-center gap-2 rounded-full border-4 bg-radial-[50%_50%_at_50%_0%] outline"

--- a/src/presentation/modules/landing/components/bentogrid/IconHeaderCard.tsx
+++ b/src/presentation/modules/landing/components/bentogrid/IconHeaderCard.tsx
@@ -15,14 +15,14 @@ export function IconHeaderCard({ className, Icon, description, title }: Props) {
         <header className="grid flex-1 place-content-center">
           <figure className="bg-primary shadow-primary/50 rounded-full p-1.5 shadow-lg">
             <Icon
-              className="fg-strong size-6 mask-b-from-black mask-b-from-0% mask-b-to-black/40 mask-b-to-100% md:size-10"
+              className="text-strong size-6 mask-b-from-black mask-b-from-0% mask-b-to-black/40 mask-b-to-100% md:size-10"
               strokeWidth="1.5"
             />
           </figure>
         </header>
         <main className="text-center">
-          <header className="font-funnel-display fg-strong text-xl font-bold">{title}</header>
-          <p className="fg-default text-base leading-[1.3] md:text-lg">{description}</p>
+          <header className="font-funnel-display text-strong text-xl font-bold">{title}</header>
+          <p className="text-default text-base leading-[1.3] md:text-lg">{description}</p>
         </main>
       </main>
     </BentoCard>

--- a/src/presentation/modules/landing/components/bentogrid/IconHeaderCard.tsx
+++ b/src/presentation/modules/landing/components/bentogrid/IconHeaderCard.tsx
@@ -15,14 +15,14 @@ export function IconHeaderCard({ className, Icon, description, title }: Props) {
         <header className="grid flex-1 place-content-center">
           <figure className="bg-primary shadow-primary/50 rounded-full p-1.5 shadow-lg">
             <Icon
-              className="text-strong size-6 mask-b-from-black mask-b-from-0% mask-b-to-black/40 mask-b-to-100% md:size-10"
+              className="text-fg-strong size-6 mask-b-from-black mask-b-from-0% mask-b-to-black/40 mask-b-to-100% md:size-10"
               strokeWidth="1.5"
             />
           </figure>
         </header>
         <main className="text-center">
-          <header className="font-funnel-display text-strong text-xl font-bold">{title}</header>
-          <p className="text-default text-base leading-[1.3] md:text-lg">{description}</p>
+          <header className="font-funnel-display text-fg-strong text-xl font-bold">{title}</header>
+          <p className="text-fg-default text-base leading-[1.3] md:text-lg">{description}</p>
         </main>
       </main>
     </BentoCard>

--- a/src/presentation/modules/landing/components/bentogrid/IconsAnimation.tsx
+++ b/src/presentation/modules/landing/components/bentogrid/IconsAnimation.tsx
@@ -48,7 +48,7 @@ function IconContainer({
   return (
     <figure className={`absolute top-0 left-0 block ${className}`} style={style}>
       <Icon
-        className="text-strong animate-wiggle-more animate-infinite animate-duration-5000 size-8"
+        className="text-fg-strong animate-wiggle-more animate-infinite animate-duration-5000 size-8"
         strokeWidth="1"
       />
     </figure>

--- a/src/presentation/modules/landing/components/bentogrid/IconsAnimation.tsx
+++ b/src/presentation/modules/landing/components/bentogrid/IconsAnimation.tsx
@@ -48,7 +48,7 @@ function IconContainer({
   return (
     <figure className={`absolute top-0 left-0 block ${className}`} style={style}>
       <Icon
-        className="fg-strong animate-wiggle-more animate-infinite animate-duration-5000 size-8"
+        className="text-strong animate-wiggle-more animate-infinite animate-duration-5000 size-8"
         strokeWidth="1"
       />
     </figure>

--- a/src/presentation/modules/landing/components/bentogrid/ScheduleYourSessions.tsx
+++ b/src/presentation/modules/landing/components/bentogrid/ScheduleYourSessions.tsx
@@ -10,7 +10,7 @@ export function ScheduleYourSessions({ className }: Props) {
     <BentoCard
       className={`relative flex h-full flex-col gap-4 p-4 md:row-span-2 md:px-0 ${className}`}
     >
-      <main className="font-funnel-display fg-strong z-3 px-4 py-4 text-center text-2xl leading-none md:py-0 md:text-right">
+      <main className="font-funnel-display text-strong z-3 px-4 py-4 text-center text-2xl leading-none md:py-0 md:text-right">
         Schedule Your Sessions
       </main>
       <div className="absolute inset-0 h-full flex-1 overflow-hidden rounded-b-lg opacity-40">

--- a/src/presentation/modules/landing/components/bentogrid/ScheduleYourSessions.tsx
+++ b/src/presentation/modules/landing/components/bentogrid/ScheduleYourSessions.tsx
@@ -10,7 +10,7 @@ export function ScheduleYourSessions({ className }: Props) {
     <BentoCard
       className={`relative flex h-full flex-col gap-4 p-4 md:row-span-2 md:px-0 ${className}`}
     >
-      <main className="font-funnel-display text-strong z-3 px-4 py-4 text-center text-2xl leading-none md:py-0 md:text-right">
+      <main className="font-funnel-display text-fg-strong z-3 px-4 py-4 text-center text-2xl leading-none md:py-0 md:text-right">
         Schedule Your Sessions
       </main>
       <div className="absolute inset-0 h-full flex-1 overflow-hidden rounded-b-lg opacity-40">

--- a/src/presentation/modules/landing/components/bentogrid/StartYourJourney.tsx
+++ b/src/presentation/modules/landing/components/bentogrid/StartYourJourney.tsx
@@ -8,12 +8,12 @@ export function StartYourJourney({ className }: Props) {
   return (
     <BentoCard className={`p-4 md:row-span-2 ${className}`}>
       <main className="flex h-full flex-col gap-2 p-2 md:gap-4 md:p-0">
-        <header className="font-funnel-display text-strong flex-1 text-center text-2xl leading-none font-medium md:max-w-45 md:text-left">
+        <header className="font-funnel-display text-fg-strong flex-1 text-center text-2xl leading-none font-medium md:max-w-45 md:text-left">
           Start Your Journey Now
         </header>
         <footer className="text-center text-base leading-[1.2] font-light md:text-left">
           <p>Totally for free</p>
-          <p className="text-default text-sm">$0/month</p>
+          <p className="text-fg-default text-sm">$0/month</p>
         </footer>
       </main>
     </BentoCard>

--- a/src/presentation/modules/landing/components/bentogrid/StartYourJourney.tsx
+++ b/src/presentation/modules/landing/components/bentogrid/StartYourJourney.tsx
@@ -8,12 +8,12 @@ export function StartYourJourney({ className }: Props) {
   return (
     <BentoCard className={`p-4 md:row-span-2 ${className}`}>
       <main className="flex h-full flex-col gap-2 p-2 md:gap-4 md:p-0">
-        <header className="font-funnel-display fg-strong flex-1 text-center text-2xl leading-none font-medium md:max-w-45 md:text-left">
+        <header className="font-funnel-display text-strong flex-1 text-center text-2xl leading-none font-medium md:max-w-45 md:text-left">
           Start Your Journey Now
         </header>
         <footer className="text-center text-base leading-[1.2] font-light md:text-left">
           <p>Totally for free</p>
-          <p className="fg-default text-sm">$0/month</p>
+          <p className="text-default text-sm">$0/month</p>
         </footer>
       </main>
     </BentoCard>

--- a/src/presentation/modules/nav/components/HeaderNav.tsx
+++ b/src/presentation/modules/nav/components/HeaderNav.tsx
@@ -23,7 +23,7 @@ export function HeaderNav() {
           <IconMenu className="size-6" />
         </Button>
         <ul
-          className={`${hiddenClass(showing, 'button')} bg-middle fg-strong absolute top-10 -left-10 z-10 flex w-48 flex-col items-start gap-0 rounded-md py-2 text-left *:grid *:h-full *:w-full *:cursor-pointer *:place-items-start *:px-6 *:py-2 *:transition-colors *:hover:bg-sky-50/5 *:hover:text-current/50 md:relative md:top-auto md:left-auto md:flex md:w-full md:flex-row md:items-center md:gap-16 md:bg-transparent md:p-0 md:text-center *:md:w-fit *:md:place-items-center *:md:p-0 *:md:hover:bg-transparent`}
+          className={`${hiddenClass(showing, 'button')} bg-base text-strong absolute top-10 -left-10 z-10 flex w-48 flex-col items-start gap-0 rounded-md py-2 text-left *:grid *:h-full *:w-full *:cursor-pointer *:place-items-start *:px-6 *:py-2 *:transition-colors *:hover:bg-sky-50/5 *:hover:text-current/50 md:relative md:top-auto md:left-auto md:flex md:w-full md:flex-row md:items-center md:gap-16 md:bg-transparent md:p-0 md:text-center *:md:w-fit *:md:place-items-center *:md:p-0 *:md:hover:bg-transparent`}
         >
           <li>
             <Link href="/">Home</Link>

--- a/src/presentation/modules/nav/components/HeaderNav.tsx
+++ b/src/presentation/modules/nav/components/HeaderNav.tsx
@@ -23,7 +23,7 @@ export function HeaderNav() {
           <IconMenu className="size-6" />
         </Button>
         <ul
-          className={`${hiddenClass(showing, 'button')} bg-fill-base text-strong absolute top-10 -left-10 z-10 flex w-48 flex-col items-start gap-0 rounded-md py-2 text-left *:grid *:h-full *:w-full *:cursor-pointer *:place-items-start *:px-6 *:py-2 *:transition-colors *:hover:bg-sky-50/5 *:hover:text-current/50 md:relative md:top-auto md:left-auto md:flex md:w-full md:flex-row md:items-center md:gap-16 md:bg-transparent md:p-0 md:text-center *:md:w-fit *:md:place-items-center *:md:p-0 *:md:hover:bg-transparent`}
+          className={`${hiddenClass(showing, 'button')} bg-fill-base text-fg-strong absolute top-10 -left-10 z-10 flex w-48 flex-col items-start gap-0 rounded-md py-2 text-left *:grid *:h-full *:w-full *:cursor-pointer *:place-items-start *:px-6 *:py-2 *:transition-colors *:hover:bg-sky-50/5 *:hover:text-current/50 md:relative md:top-auto md:left-auto md:flex md:w-full md:flex-row md:items-center md:gap-16 md:bg-transparent md:p-0 md:text-center *:md:w-fit *:md:place-items-center *:md:p-0 *:md:hover:bg-transparent`}
         >
           <li>
             <Link href="/">Home</Link>

--- a/src/presentation/modules/nav/components/HeaderNav.tsx
+++ b/src/presentation/modules/nav/components/HeaderNav.tsx
@@ -23,7 +23,7 @@ export function HeaderNav() {
           <IconMenu className="size-6" />
         </Button>
         <ul
-          className={`${hiddenClass(showing, 'button')} bg-base text-strong absolute top-10 -left-10 z-10 flex w-48 flex-col items-start gap-0 rounded-md py-2 text-left *:grid *:h-full *:w-full *:cursor-pointer *:place-items-start *:px-6 *:py-2 *:transition-colors *:hover:bg-sky-50/5 *:hover:text-current/50 md:relative md:top-auto md:left-auto md:flex md:w-full md:flex-row md:items-center md:gap-16 md:bg-transparent md:p-0 md:text-center *:md:w-fit *:md:place-items-center *:md:p-0 *:md:hover:bg-transparent`}
+          className={`${hiddenClass(showing, 'button')} bg-fill-base text-strong absolute top-10 -left-10 z-10 flex w-48 flex-col items-start gap-0 rounded-md py-2 text-left *:grid *:h-full *:w-full *:cursor-pointer *:place-items-start *:px-6 *:py-2 *:transition-colors *:hover:bg-sky-50/5 *:hover:text-current/50 md:relative md:top-auto md:left-auto md:flex md:w-full md:flex-row md:items-center md:gap-16 md:bg-transparent md:p-0 md:text-center *:md:w-fit *:md:place-items-center *:md:p-0 *:md:hover:bg-transparent`}
         >
           <li>
             <Link href="/">Home</Link>
@@ -37,7 +37,10 @@ export function HeaderNav() {
         </ul>
       </nav>
       {showing && (
-        <div onClick={handleClickOut} className={`bg-back/80 fixed inset-0 z-1 md:hidden`}></div>
+        <div
+          onClick={handleClickOut}
+          className={`bg-fill-back/80 fixed inset-0 z-1 md:hidden`}
+        ></div>
       )}
     </div>
   );

--- a/src/presentation/modules/nav/components/HeaderNav.tsx
+++ b/src/presentation/modules/nav/components/HeaderNav.tsx
@@ -13,15 +13,15 @@ export function HeaderNav() {
       <nav className="relative text-lg font-medium">
         <Button
           type="button"
-          variantConfig={{
+          variant={{
             color: 'simple',
-            type: 'square',
+            type: 'icon',
           }}
           onClick={handleClick}
           className="md:hidden"
-        >
-          <IconMenu className="size-6" />
-        </Button>
+          aria-label="Open navigation items"
+          Icon={IconMenu}
+        />
         <ul
           className={`${hiddenClass(showing, 'button')} bg-fill-base text-fg-strong absolute top-10 -left-10 z-10 flex w-48 flex-col items-start gap-0 rounded-md py-2 text-left *:grid *:h-full *:w-full *:cursor-pointer *:place-items-start *:px-6 *:py-2 *:transition-colors *:hover:bg-sky-50/5 *:hover:text-current/50 md:relative md:top-auto md:left-auto md:flex md:w-full md:flex-row md:items-center md:gap-16 md:bg-transparent md:p-0 md:text-center *:md:w-fit *:md:place-items-center *:md:p-0 *:md:hover:bg-transparent`}
         >

--- a/src/presentation/modules/sidebar/components/SettingsTooltip.tsx
+++ b/src/presentation/modules/sidebar/components/SettingsTooltip.tsx
@@ -23,7 +23,7 @@ export function SettingsTooltip({ isOpen, onClose }: Props) {
     <>
       <div
         ref={ref}
-        className="bg-middle border-bd-default absolute bottom-full left-4 z-10 mb-4 ml-0 rounded-lg border p-2 shadow-lg shadow-black/30"
+        className="bg-base border-bd-default absolute bottom-full left-4 z-10 mb-4 ml-0 rounded-lg border p-2 shadow-lg shadow-black/30"
       >
         <header className="mb-2 px-2 text-base font-light">Settings</header>
         <ul>

--- a/src/presentation/modules/sidebar/components/SettingsTooltip.tsx
+++ b/src/presentation/modules/sidebar/components/SettingsTooltip.tsx
@@ -23,7 +23,7 @@ export function SettingsTooltip({ isOpen, onClose }: Props) {
     <>
       <div
         ref={ref}
-        className="bg-base border-bd-default absolute bottom-full left-4 z-10 mb-4 ml-0 rounded-lg border p-2 shadow-lg shadow-black/30"
+        className="bg-fill-base border-bd-default absolute bottom-full left-4 z-10 mb-4 ml-0 rounded-lg border p-2 shadow-lg shadow-black/30"
       >
         <header className="mb-2 px-2 text-base font-light">Settings</header>
         <ul>

--- a/src/presentation/modules/sidebar/components/SettingsTooltip.tsx
+++ b/src/presentation/modules/sidebar/components/SettingsTooltip.tsx
@@ -31,7 +31,7 @@ export function SettingsTooltip({ isOpen, onClose }: Props) {
             <ToggleTheme className="w-full pl-2">Theme</ToggleTheme>
           </li>
           <li className="flex items-center gap-0">
-            <Button variantConfig={{ color: 'simple' }} className="pl-2">
+            <Button variant={{ color: 'simple' }} className="pl-2">
               <IconLanguage strokeWidth="1.5" />
               Language
             </Button>

--- a/src/presentation/modules/sidebar/components/Sidebar.tsx
+++ b/src/presentation/modules/sidebar/components/Sidebar.tsx
@@ -16,7 +16,7 @@ export function Sidebar({ className = '' }: { className?: string }) {
   return (
     <aside className="w-(--sidebar-width)">
       <main
-        className={`bg-back border-bd-muted fixed top-(--header-height) left-0 z-10 flex h-(--sidebar-height) w-(--sidebar-width) flex-col gap-4 border-r shadow-2xl shadow-black/5 ${className}`}
+        className={`bg-fill-back border-bd-muted fixed top-(--header-height) left-0 z-10 flex h-(--sidebar-height) w-(--sidebar-width) flex-col gap-4 border-r shadow-2xl shadow-black/5 ${className}`}
       >
         <div className="flex-1 space-y-4 py-2 lg:p-2 lg:pt-4">
           <header>

--- a/src/presentation/modules/sidebar/components/SidebarFooter.tsx
+++ b/src/presentation/modules/sidebar/components/SidebarFooter.tsx
@@ -21,7 +21,7 @@ export function SidebarFooter({ className = '' }: { className?: string }) {
 
   return (
     <footer
-      className={`bg-base relative mx-1 mb-1 flex items-center rounded transition-colors lg:p-1 lg:pr-2 lg:pl-4 ${className}`}
+      className={`bg-fill-base relative mx-1 mb-1 flex items-center rounded transition-colors lg:p-1 lg:pr-2 lg:pl-4 ${className}`}
     >
       <div className="w-full">
         <div className="flex w-full items-center justify-center gap-1 lg:justify-between">

--- a/src/presentation/modules/sidebar/components/SidebarFooter.tsx
+++ b/src/presentation/modules/sidebar/components/SidebarFooter.tsx
@@ -21,7 +21,7 @@ export function SidebarFooter({ className = '' }: { className?: string }) {
 
   return (
     <footer
-      className={`bg-middle relative mx-1 mb-1 flex items-center rounded transition-colors lg:p-1 lg:pr-2 lg:pl-4 ${className}`}
+      className={`bg-base relative mx-1 mb-1 flex items-center rounded transition-colors lg:p-1 lg:pr-2 lg:pl-4 ${className}`}
     >
       <div className="w-full">
         <div className="flex w-full items-center justify-center gap-1 lg:justify-between">

--- a/src/presentation/modules/sidebar/components/SidebarFooter.tsx
+++ b/src/presentation/modules/sidebar/components/SidebarFooter.tsx
@@ -30,21 +30,24 @@ export function SidebarFooter({ className = '' }: { className?: string }) {
           <aside>
             <ul className="flex flex-col items-center lg:flex-row">
               <li>
-                <Button variantConfig={{ type: 'square', color: 'simple' }} onClick={handleClick}>
-                  <IconCog strokeWidth="1.5" />
-                </Button>
+                <Button
+                  variant={{ type: 'icon', color: 'simple' }}
+                  Icon={IconCog}
+                  aria-label="Configuration"
+                  onClick={handleClick}
+                />
               </li>
               <li>
                 <Button
                   onClick={handleLogout}
                   type="button"
-                  variantConfig={{
-                    type: 'square',
+                  variant={{
+                    type: 'icon',
                     color: 'simple',
                   }}
-                >
-                  <IconLogout className="-mr-1 size-6" />
-                </Button>
+                  Icon={IconLogout}
+                  aria-label="Log out"
+                />
               </li>
             </ul>
           </aside>

--- a/src/presentation/modules/sidebar/components/SidebarSection.tsx
+++ b/src/presentation/modules/sidebar/components/SidebarSection.tsx
@@ -10,7 +10,7 @@ export function SidebarSection({
   return (
     <section className={`relative ${className}`}>
       <header className="mb-2 hidden px-4 lg:block">
-        <h4 className="text-muted text-sm font-light tracking-widest uppercase">{name}</h4>
+        <h4 className="text-fg-subtle text-sm font-light tracking-widest uppercase">{name}</h4>
       </header>
       {children}
     </section>

--- a/src/presentation/modules/sidebar/components/SidebarSection.tsx
+++ b/src/presentation/modules/sidebar/components/SidebarSection.tsx
@@ -10,7 +10,7 @@ export function SidebarSection({
   return (
     <section className={`relative ${className}`}>
       <header className="mb-2 hidden px-4 lg:block">
-        <h4 className="fg-muted text-sm font-light tracking-widest uppercase">{name}</h4>
+        <h4 className="text-muted text-sm font-light tracking-widest uppercase">{name}</h4>
       </header>
       {children}
     </section>

--- a/src/presentation/modules/sidebar/components/nav/NavLink.tsx
+++ b/src/presentation/modules/sidebar/components/nav/NavLink.tsx
@@ -29,7 +29,7 @@ export function NavLink({
       {children}
       <span
         className={twMerge(
-          'bg-base border-bd-default light:shadow-black/5 shadow-back/50 shadow-lg',
+          'bg-fill-base border-bd-default light:shadow-black/5 shadow-back/50 shadow-lg',
           'absolute inset-y-0 left-14 my-auto hidden h-fit w-fit rounded-lg border px-3 py-1.5 transition-colors',
           'group-hover:text-strong group-hover:block',
           active

--- a/src/presentation/modules/sidebar/components/nav/NavLink.tsx
+++ b/src/presentation/modules/sidebar/components/nav/NavLink.tsx
@@ -31,10 +31,10 @@ export function NavLink({
         className={twMerge(
           'bg-fill-base border-bd-default light:shadow-black/5 shadow-back/50 shadow-lg',
           'absolute inset-y-0 left-14 my-auto hidden h-fit w-fit rounded-lg border px-3 py-1.5 transition-colors',
-          'group-hover:text-strong group-hover:block',
+          'group-hover:text-fg-strong group-hover:block',
           active
-            ? 'bg-primary group-hover:text-strong-dark text-strong-dark'
-            : 'lg:group-hover:text-default',
+            ? 'bg-primary group-hover:text-fg-strong-dark text-fg-strong-dark'
+            : 'lg:group-hover:text-fg-default',
           'lg:static lg:inset-auto lg:left-auto lg:inline lg:h-fit lg:w-auto lg:border-none lg:bg-transparent lg:p-0 lg:shadow-none'
         )}
       >

--- a/src/presentation/modules/sidebar/components/nav/NavLink.tsx
+++ b/src/presentation/modules/sidebar/components/nav/NavLink.tsx
@@ -29,12 +29,12 @@ export function NavLink({
       {children}
       <span
         className={twMerge(
-          'bg-middle border-bd-default light:shadow-black/5 shadow-back/50 shadow-lg',
+          'bg-base border-bd-default light:shadow-black/5 shadow-back/50 shadow-lg',
           'absolute inset-y-0 left-14 my-auto hidden h-fit w-fit rounded-lg border px-3 py-1.5 transition-colors',
-          'group-hover:fg-strong group-hover:block',
+          'group-hover:text-strong group-hover:block',
           active
-            ? 'bg-primary group-hover:fg-strong-dark fg-strong-dark'
-            : 'lg:group-hover:fg-default',
+            ? 'bg-primary group-hover:text-strong-dark text-strong-dark'
+            : 'lg:group-hover:text-default',
           'lg:static lg:inset-auto lg:left-auto lg:inline lg:h-fit lg:w-auto lg:border-none lg:bg-transparent lg:p-0 lg:shadow-none'
         )}
       >

--- a/src/presentation/modules/sidebar/components/nav/NavLinkBody.tsx
+++ b/src/presentation/modules/sidebar/components/nav/NavLinkBody.tsx
@@ -1,7 +1,7 @@
 export function NavLinkBody({ title }: { title: React.ReactNode }) {
   return (
     <div
-      className="bg-middle absolute top-0 left-16 z-50 hidden h-full place-content-center rounded group-hover:grid"
+      className="bg-base absolute top-0 left-16 z-50 hidden h-full place-content-center rounded group-hover:grid"
       style={{
         clipPath:
           "path('M 10,0 A 5,5 0,0,0 5,5 L 5,16 A 5,5 0,0,1 0,21 A 5,5 0,0,1 5,26 L 5,36 A 5,5 0,0,0 10,40 L 500,40 L 500,0 Z')",

--- a/src/presentation/modules/sidebar/components/nav/NavLinkBody.tsx
+++ b/src/presentation/modules/sidebar/components/nav/NavLinkBody.tsx
@@ -1,7 +1,7 @@
 export function NavLinkBody({ title }: { title: React.ReactNode }) {
   return (
     <div
-      className="bg-base absolute top-0 left-16 z-50 hidden h-full place-content-center rounded group-hover:grid"
+      className="bg-fill-base absolute top-0 left-16 z-50 hidden h-full place-content-center rounded group-hover:grid"
       style={{
         clipPath:
           "path('M 10,0 A 5,5 0,0,0 5,5 L 5,16 A 5,5 0,0,1 0,21 A 5,5 0,0,1 5,26 L 5,36 A 5,5 0,0,0 10,40 L 500,40 L 500,0 Z')",

--- a/src/presentation/modules/sidebar/components/nav/SubLink.tsx
+++ b/src/presentation/modules/sidebar/components/nav/SubLink.tsx
@@ -23,7 +23,7 @@ export function SubLink({
   return (
     <Link
       href={href}
-      className={`fg-strong hover:bg-front hover:fg-default relative aspect-square ${styles.nav_link} ${className} ${aditionalClassName}`}
+      className={`text-strong hover:bg-front hover:text-default relative aspect-square ${styles.nav_link} ${className} ${aditionalClassName}`}
     >
       {children}
     </Link>

--- a/src/presentation/modules/sidebar/components/nav/SubLink.tsx
+++ b/src/presentation/modules/sidebar/components/nav/SubLink.tsx
@@ -23,7 +23,7 @@ export function SubLink({
   return (
     <Link
       href={href}
-      className={`text-strong hover:bg-fill-middle hover:text-default relative aspect-square ${styles.nav_link} ${className} ${aditionalClassName}`}
+      className={`text-fg-strong hover:bg-fill-middle hover:text-fg-default relative aspect-square ${styles.nav_link} ${className} ${aditionalClassName}`}
     >
       {children}
     </Link>

--- a/src/presentation/modules/sidebar/components/nav/SubLink.tsx
+++ b/src/presentation/modules/sidebar/components/nav/SubLink.tsx
@@ -23,7 +23,7 @@ export function SubLink({
   return (
     <Link
       href={href}
-      className={`text-strong hover:bg-front hover:text-default relative aspect-square ${styles.nav_link} ${className} ${aditionalClassName}`}
+      className={`text-strong hover:bg-fill-middle hover:text-default relative aspect-square ${styles.nav_link} ${className} ${aditionalClassName}`}
     >
       {children}
     </Link>

--- a/src/presentation/modules/sidebar/config/sidebar.nav-link.variants.ts
+++ b/src/presentation/modules/sidebar/config/sidebar.nav-link.variants.ts
@@ -8,7 +8,7 @@ export const sidebarNavLinkVariants = tv({
     },
     notice: {
       unread:
-        'before:bg-unread before:absolute before:top-2.5 before:left-5.5 before:z-1 before:size-2.5 before:rounded-full lg:before:inset-y-0 lg:before:right-4 lg:before:left-auto lg:before:my-auto',
+        'before:bg-info before:absolute before:top-2.5 before:left-5.5 before:z-1 before:size-2.5 before:rounded-full lg:before:inset-y-0 lg:before:right-4 lg:before:left-auto lg:before:my-auto',
     },
   },
   compoundVariants: [

--- a/src/presentation/modules/sidebar/config/sidebar.nav-link.variants.ts
+++ b/src/presentation/modules/sidebar/config/sidebar.nav-link.variants.ts
@@ -1,10 +1,10 @@
 import { tv, type VariantProps } from 'tailwind-variants';
 
 export const sidebarNavLinkVariants = tv({
-  base: 'group text-strong hover:text-default relative mx-auto grid aspect-square h-10 w-10 place-content-center justify-center rounded-lg font-light transition-colors lg:mx-auto lg:flex lg:aspect-auto lg:w-full lg:place-content-start lg:items-center lg:gap-2 lg:px-4',
+  base: 'group text-fg-strong hover:text-fg-default relative mx-auto grid aspect-square h-10 w-10 place-content-center justify-center rounded-lg font-light transition-colors lg:mx-auto lg:flex lg:aspect-auto lg:w-full lg:place-content-start lg:items-center lg:gap-2 lg:px-4',
   variants: {
     active: {
-      true: 'bg-primary text-strong-dark hover:text-strong-dark',
+      true: 'bg-primary text-fg-strong-dark hover:text-fg-strong-dark',
     },
     notice: {
       unread:

--- a/src/presentation/modules/sidebar/config/sidebar.nav-link.variants.ts
+++ b/src/presentation/modules/sidebar/config/sidebar.nav-link.variants.ts
@@ -1,10 +1,10 @@
 import { tv, type VariantProps } from 'tailwind-variants';
 
 export const sidebarNavLinkVariants = tv({
-  base: 'group fg-strong hover:fg-default relative mx-auto grid aspect-square h-10 w-10 place-content-center justify-center rounded-lg font-light transition-colors lg:mx-auto lg:flex lg:aspect-auto lg:w-full lg:place-content-start lg:items-center lg:gap-2 lg:px-4',
+  base: 'group text-strong hover:text-default relative mx-auto grid aspect-square h-10 w-10 place-content-center justify-center rounded-lg font-light transition-colors lg:mx-auto lg:flex lg:aspect-auto lg:w-full lg:place-content-start lg:items-center lg:gap-2 lg:px-4',
   variants: {
     active: {
-      true: 'bg-primary fg-strong-dark hover:fg-strong-dark',
+      true: 'bg-primary text-strong-dark hover:text-strong-dark',
     },
     notice: {
       unread:

--- a/src/presentation/modules/sidebar/config/sidebar.nav-link.variants.ts
+++ b/src/presentation/modules/sidebar/config/sidebar.nav-link.variants.ts
@@ -15,7 +15,7 @@ export const sidebarNavLinkVariants = tv({
     {
       active: true,
       notice: 'unread',
-      class: 'before:bg-strong-dark',
+      class: 'before:bg-fg-strong-dark',
     },
   ],
 });

--- a/src/presentation/modules/statistics/components/Charts.tsx
+++ b/src/presentation/modules/statistics/components/Charts.tsx
@@ -39,7 +39,7 @@ export function LineChart({
         <linearGradient id="lineGradient" x1="0%" y1="0%" x2="0%" y2="0%">
           <animate attributeName="y2" values="0%;100%" dur="0.3s" begin="0.3s" fill="freeze" />
 
-          <stop offset="0%" stopColor="currentColor" className="fg-primary"></stop>
+          <stop offset="0%" stopColor="currentColor" className="text-primary"></stop>
           <stop offset="100%" stopColor="currentColor" className="text-secondary/0" />
         </linearGradient>
       </defs>
@@ -53,7 +53,7 @@ export function LineChart({
         stroke="currentColor"
         strokeWidth={1}
         strokeLinecap="round"
-        className="fg-bd-strong"
+        className="text-bd-strong"
       />
 
       {data.map((p, i) => (
@@ -63,7 +63,7 @@ export function LineChart({
           cy={scaleY(p.y)}
           r={3}
           fill="currentColor"
-          className="fg-primary"
+          className="text-primary"
           opacity={0}
         >
           <animate
@@ -81,7 +81,7 @@ export function LineChart({
         d={pathD + ` V ${height - padding} H ${scaleX(data[0].x)} Z`}
         fill="url(#lineGradient)"
         stroke="none"
-        className="fg-primary"
+        className="text-primary"
       ></path>
 
       <path
@@ -91,7 +91,7 @@ export function LineChart({
         strokeWidth={3}
         strokeLinejoin="round"
         strokeLinecap="round"
-        className="fg-primary"
+        className="text-primary"
         strokeDasharray={3000}
         strokeDashoffset={3000}
       >
@@ -146,7 +146,7 @@ export function BarCharts({
           <stop offset="100%" stopColor="currentColor" className="text-primary/5" opacity={0} />
         </linearGradient>
         <linearGradient id="strokeGradient" x1="0%" y1="0%" x2="0%" y2="100%">
-          <stop offset="10%" stopColor="currentColor" className="fg-primary" />
+          <stop offset="10%" stopColor="currentColor" className="text-primary" />
           <stop offset="80%" stopColor="currentColor" className="text-primary/5" />
           <stop offset="100%" stopColor="currentColor" className="text-primary/0" opacity={0} />
         </linearGradient>
@@ -161,7 +161,7 @@ export function BarCharts({
         stroke="currentColor"
         strokeWidth={1}
         strokeLinecap="round"
-        className="fg-bd-strong"
+        className="text-bd-strong"
       />
 
       {Array.from({ length: maxY - 1 }).map((_, i) => (
@@ -174,7 +174,7 @@ export function BarCharts({
           stroke="currentColor"
           strokeWidth={1}
           strokeLinecap="round"
-          className="fg-bd-default"
+          className="text-bd-default"
         />
       ))}
 

--- a/src/presentation/modules/statistics/components/Charts.tsx
+++ b/src/presentation/modules/statistics/components/Charts.tsx
@@ -34,7 +34,12 @@ export function LineChart({
     .join(' ');
 
   return (
-    <svg viewBox={`0 0 ${width} ${height}`} width={width} height={height} className="bg-subtle/5">
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      width={width}
+      height={height}
+      className="bg-fill-middle"
+    >
       <defs>
         <linearGradient id="lineGradient" x1="0%" y1="0%" x2="0%" y2="0%">
           <animate attributeName="y2" values="0%;100%" dur="0.3s" begin="0.3s" fill="freeze" />
@@ -139,7 +144,12 @@ export function BarCharts({
   const scaleY = (val: number) => height - padding - (val / maxY) * absoluteHeight;
 
   return (
-    <svg viewBox={`0 0 ${width} ${height}`} width={width} height={height} className="bg-subtle/5">
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      width={width}
+      height={height}
+      className="bg-fill-middle"
+    >
       <defs>
         <linearGradient id="barGradient" x1="0%" y1="0%" x2="0%" y2="100%">
           <stop offset="0%" stopColor="currentColor" className="text-primary/50"></stop>

--- a/src/presentation/modules/statistics/components/StatisticCircle.tsx
+++ b/src/presentation/modules/statistics/components/StatisticCircle.tsx
@@ -11,8 +11,8 @@ export function StatisticCircle({
 }) {
   return (
     <div className="relative grid size-28 place-content-center text-center">
-      <header className="text-muted relative z-1 text-sm leading-[1.2]">{title}</header>
-      <main className="text-strong font-funnel-display relative z-1 text-xl leading-[1.2]">
+      <header className="text-fg-subtle relative z-1 text-sm leading-[1.2]">{title}</header>
+      <main className="text-fg-strong font-funnel-display relative z-1 text-xl leading-[1.2]">
         {value}
       </main>
       <div className="text-primary absolute inset-0 rounded-full">

--- a/src/presentation/modules/statistics/components/StatisticCircle.tsx
+++ b/src/presentation/modules/statistics/components/StatisticCircle.tsx
@@ -11,11 +11,11 @@ export function StatisticCircle({
 }) {
   return (
     <div className="relative grid size-28 place-content-center text-center">
-      <header className="fg-muted relative z-1 text-sm leading-[1.2]">{title}</header>
-      <main className="fg-strong font-funnel-display relative z-1 text-xl leading-[1.2]">
+      <header className="text-muted relative z-1 text-sm leading-[1.2]">{title}</header>
+      <main className="text-strong font-funnel-display relative z-1 text-xl leading-[1.2]">
         {value}
       </main>
-      <div className="fg-primary absolute inset-0 rounded-full">
+      <div className="text-primary absolute inset-0 rounded-full">
         <IconCircle
           className="size-28 -rotate-90"
           strokeWidth="0.5"

--- a/src/presentation/modules/theme/components/ToggleTheme.tsx
+++ b/src/presentation/modules/theme/components/ToggleTheme.tsx
@@ -28,7 +28,7 @@ export function ToggleTheme({ className, children }: Props) {
             type: 'iconText',
             color: 'simple',
           }}
-          className={twMerge('light:hidden', className)}
+          className={twMerge('light:hidden flex', className)}
           onClick={handleClick}
           Icon={IconSun}
         >
@@ -40,7 +40,7 @@ export function ToggleTheme({ className, children }: Props) {
             type: 'iconText',
             color: 'simple',
           }}
-          className={twMerge('light:block hidden', className)}
+          className={twMerge('light:flex hidden', className)}
           onClick={handleClick}
           Icon={IconMoon}
         >
@@ -57,7 +57,7 @@ export function ToggleTheme({ className, children }: Props) {
           type: 'icon',
           color: 'simple',
         }}
-        className={twMerge('light:hidden', className)}
+        className={twMerge('light:hidden flex', className)}
         onClick={handleClick}
         aria-label={'Switch to light theme'}
         Icon={IconSun}
@@ -68,7 +68,7 @@ export function ToggleTheme({ className, children }: Props) {
           type: 'icon',
           color: 'simple',
         }}
-        className={twMerge('light:block hidden', className)}
+        className={twMerge('light:flex hidden', className)}
         onClick={handleClick}
         aria-label={'Switch to dark theme'}
         Icon={IconMoon}

--- a/src/presentation/modules/theme/components/ToggleTheme.tsx
+++ b/src/presentation/modules/theme/components/ToggleTheme.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useTheme } from 'next-themes';
+import { twMerge } from 'tailwind-merge';
 import { THEME } from '@/presentation/modules/theme/constants/client';
-import { DefaultIcon } from '@/presentation/globals/components/icons/DefaultIcon';
 import { IconMoon } from '@/presentation/globals/components/icons/outline/IconMoon';
 import { IconSun } from '@/presentation/globals/components/icons/outline/IconSun';
 import { Button } from '@/presentation/modules/button/components/Button';
@@ -19,20 +19,60 @@ export function ToggleTheme({ className, children }: Props) {
     setTheme(theme === THEME.DARK ? THEME.LIGHT : THEME.DARK);
   };
 
+  if (children)
+    return (
+      <>
+        <Button
+          type="button"
+          variant={{
+            type: 'iconText',
+            color: 'simple',
+          }}
+          className={twMerge('light:hidden', className)}
+          onClick={handleClick}
+          Icon={IconSun}
+        >
+          {children}
+        </Button>
+        <Button
+          type="button"
+          variant={{
+            type: 'iconText',
+            color: 'simple',
+          }}
+          className={twMerge('light:block hidden', className)}
+          onClick={handleClick}
+          Icon={IconMoon}
+        >
+          {children && children}
+        </Button>
+      </>
+    );
+
   return (
-    <Button
-      type="button"
-      variantConfig={{
-        type: children ? undefined : 'square',
-        color: 'simple',
-      }}
-      className={className}
-      onClick={handleClick}
-      aria-label={children ? undefined : 'Switch between light and dark themes'}
-    >
-      <DefaultIcon Icon={IconSun} className="light:hidden" />
-      <DefaultIcon Icon={IconMoon} className="light:block hidden" />
-      {children}
-    </Button>
+    <>
+      <Button
+        type="button"
+        variant={{
+          type: 'icon',
+          color: 'simple',
+        }}
+        className={twMerge('light:hidden', className)}
+        onClick={handleClick}
+        aria-label={'Switch to light theme'}
+        Icon={IconSun}
+      />
+      <Button
+        type="button"
+        variant={{
+          type: 'icon',
+          color: 'simple',
+        }}
+        className={twMerge('light:block hidden', className)}
+        onClick={handleClick}
+        aria-label={'Switch to dark theme'}
+        Icon={IconMoon}
+      />
+    </>
   );
 }

--- a/src/presentation/modules/toast/components/ToastItem.tsx
+++ b/src/presentation/modules/toast/components/ToastItem.tsx
@@ -42,7 +42,7 @@ export function ToastItem({ toast, onClose }: Props) {
       <button
         type="button"
         onClick={onClose}
-        className="fg-muted cursor-pointer transition-opacity hover:opacity-50"
+        className="text-muted cursor-pointer transition-opacity hover:opacity-50"
       >
         <IconXMark className="size-5" />
       </button>

--- a/src/presentation/modules/toast/components/ToastItem.tsx
+++ b/src/presentation/modules/toast/components/ToastItem.tsx
@@ -42,7 +42,7 @@ export function ToastItem({ toast, onClose }: Props) {
       <button
         type="button"
         onClick={onClose}
-        className="text-muted cursor-pointer transition-opacity hover:opacity-50"
+        className="text-fg-subtle cursor-pointer transition-opacity hover:opacity-50"
       >
         <IconXMark className="size-5" />
       </button>

--- a/src/shared/shared.types.d.ts
+++ b/src/shared/shared.types.d.ts
@@ -1,0 +1,1 @@
+export type NonEmptyString<T extends string> = T extends '' ? never : T;


### PR DESCRIPTION
### Summary
Improve style updating color pallete and adjusting spacing in components

### Issue
This PR closes #71 

### Changes

1. Update color pallete:
  - Increase color ranges for filling and text colors
  - Add dark primary color version
  - Add new status color `warning`
  - Update colors naming:
    - Filling colors have `fill-` prefix
    - Text colors have `fg-` prefix
    - Border colors have `bd-` prefix
    - Status updated colors are: 
      - `success` from "complete"
      - `danger` from "cancel"
      - `info` from "unread"
  - Add new colors for status depth: `border` and `fill`

2.  Update button variants:
  - Remove primaryDeluxe color variant
  - Adjust primary, subtle, and simple color variants
  - Add new danger color variant
  - Improve button base styles
  - Add icon integration with aria-label requiring when no text provided