### PR TITLE
refactor(types): update warnings of types usages

### DIFF
--- a/src/app/dev/buttons/components/DevButtons.tsx
+++ b/src/app/dev/buttons/components/DevButtons.tsx
@@ -42,13 +42,23 @@ export function DevButtons({ className, colors }: Props) {
   );
 }
 
-function AllButtonSizes(props: React.ComponentProps<typeof Button>) {
+function AllButtonSizes({ variant, ...props }: React.ComponentProps<typeof Button>) {
+  if (!variant) return;
+  if (!variant.type) return;
+
+  const variantSize = (size: ButtonVariantProps['size']): ButtonVariantProps => {
+    return {
+      ...variant,
+      size,
+    };
+  };
+
   return (
     <div className="space-y-2">
-      <Button {...props} variant={{ ...props.variant, size: 'lg' }} />
-      <Button {...props} variant={{ ...props.variant, size: 'md' }} />
-      <Button {...props} variant={{ ...props.variant, size: 'sm' }} />
-      <Button {...props} variant={{ ...props.variant, size: 'xs' }} />
+      <Button {...props} variant={variantSize('lg') as any} />
+      <Button {...props} variant={variantSize('md') as any} />
+      <Button {...props} variant={variantSize('sm') as any} />
+      <Button {...props} variant={variantSize('xs') as any} />
     </div>
   );
 }

--- a/src/modules/exercise/presentation/ui/components/fields/ExerciseRepsField.tsx
+++ b/src/modules/exercise/presentation/ui/components/fields/ExerciseRepsField.tsx
@@ -2,7 +2,7 @@ import { useFormContext } from 'react-hook-form';
 import { InputNumber } from '@/presentation/modules/form/components/fields/InputNumber';
 import { inputNumberConfig } from '@/presentation/modules/form/config/input-config';
 import { Label } from '@/presentation/modules/form/components/fields/Label';
-import { ExerciseDTO } from '@/modules/exercise/application/dtos/exercise.dto';
+import type { ExerciseDTO } from '@/modules/exercise/application/dtos/exercise.dto';
 import type { ExerciseFormProps } from '@/modules/exercise/presentation/ui/schemas/exercise.schema';
 
 type Props = {

--- a/src/modules/exercise/presentation/ui/components/fields/ExerciseSetsField.tsx
+++ b/src/modules/exercise/presentation/ui/components/fields/ExerciseSetsField.tsx
@@ -2,7 +2,7 @@ import { useFormContext } from 'react-hook-form';
 import { InputNumber } from '@/presentation/modules/form/components/fields/InputNumber';
 import { inputNumberConfig } from '@/presentation/modules/form/config/input-config';
 import { Label } from '@/presentation/modules/form/components/fields/Label';
-import { ExerciseDTO } from '@/modules/exercise/application/dtos/exercise.dto';
+import type { ExerciseDTO } from '@/modules/exercise/application/dtos/exercise.dto';
 import type { ExerciseFormProps } from '@/modules/exercise/presentation/ui/schemas/exercise.schema';
 
 type Props = {

--- a/src/modules/exercise/presentation/ui/components/fields/ExerciseWeightField.tsx
+++ b/src/modules/exercise/presentation/ui/components/fields/ExerciseWeightField.tsx
@@ -2,7 +2,7 @@ import { useFormContext } from 'react-hook-form';
 import { InputNumber } from '@/presentation/modules/form/components/fields/InputNumber';
 import { inputNumberConfig } from '@/presentation/modules/form/config/input-config';
 import { Label } from '@/presentation/modules/form/components/fields/Label';
-import { ExerciseDTO } from '@/modules/exercise/application/dtos/exercise.dto';
+import type { ExerciseDTO } from '@/modules/exercise/application/dtos/exercise.dto';
 import type { ExerciseFormProps } from '@/modules/exercise/presentation/ui/schemas/exercise.schema';
 
 type Props = {

--- a/src/modules/session/presentation/ui/components/fields/SessionDescription.tsx
+++ b/src/modules/session/presentation/ui/components/fields/SessionDescription.tsx
@@ -1,7 +1,7 @@
 import { useFormContext } from 'react-hook-form';
 import { Label } from '@/presentation/modules/form/components/fields/Label';
 import { TextArea } from '@/presentation/modules/form/components/fields/TextArea';
-import { SessionDTO } from '@/modules/session/application/dtos/session.dto';
+import type { SessionDTO } from '@/modules/session/application/dtos/session.dto';
 import type { SessionForm } from '@/modules/session/presentation/ui/config/session.schema';
 
 type Props = {

--- a/src/modules/session/presentation/ui/components/fields/SessionName.tsx
+++ b/src/modules/session/presentation/ui/components/fields/SessionName.tsx
@@ -1,7 +1,7 @@
 import { useFormContext } from 'react-hook-form';
 import { InputText } from '@/presentation/modules/form/components/fields/InputText';
 import { Label } from '@/presentation/modules/form/components/fields/Label';
-import { SessionDTO } from '@/modules/session/application/dtos/session.dto';
+import type { SessionDTO } from '@/modules/session/application/dtos/session.dto';
 import type { SessionForm } from '@/modules/session/presentation/ui/config/session.schema';
 
 type Props = {

--- a/src/presentation/modules/landing/components/bentogrid/IconHeaderCard.tsx
+++ b/src/presentation/modules/landing/components/bentogrid/IconHeaderCard.tsx
@@ -1,5 +1,5 @@
 import { BentoCard } from '@/presentation/modules/landing/components/bentogrid/BentoCard';
-import { type IconProps } from '@/presentation/globals/presentation.types';
+import type { IconProps } from '@/presentation/globals/presentation.types';
 
 type Props = {
   className?: string;


### PR DESCRIPTION
### Summary
Remove types warning and update type imports

### Changes
- Update type imports as type when only used as types
- Remove multiple Button render warning when passing variant prop