### PR TITLE
refactor(auth): remove warnings/errors for types and linting

### DIFF
--- a/src/modules/auth/infrastructure/next-auth/auth.next-auth.config.ts
+++ b/src/modules/auth/infrastructure/next-auth/auth.next-auth.config.ts
@@ -1,11 +1,24 @@
-import { signIn as nextAuthSignIn, signOut as nextAuthSignOut } from 'next-auth/react';
+import {
+  signIn as nextAuthSignIn,
+  signOut as nextAuthSignOut,
+  type SignInOptions,
+} from 'next-auth/react';
 import { AUTH_PROVIDER } from '@/modules/auth/infrastructure/next-auth/auth.next-auth.constants';
 
-export const nextAuthLogin = (redirect: boolean = false) =>
-  nextAuthSignIn(AUTH_PROVIDER, {
+const authLoginOptionsHandler = (redirect: boolean): SignInOptions => {
+  if (redirect)
+    return {
+      redirect,
+      callbackUrl: '/dashboard',
+    };
+
+  return {
     redirect,
-    callbackUrl: redirect ? '/dashboard' : undefined,
-  });
+  };
+};
+
+export const nextAuthLogin = (redirect: boolean = false) =>
+  nextAuthSignIn(AUTH_PROVIDER, authLoginOptionsHandler(redirect));
 
 export const nextAuthLogout = () =>
   nextAuthSignOut({

--- a/src/modules/auth/presentation/auth.actions.ts
+++ b/src/modules/auth/presentation/auth.actions.ts
@@ -4,11 +4,11 @@ import { getContainer } from '@/di/containers';
 import {
   ActionFailure,
   ActionSuccess,
-  type ActionResponse,
+  type ActionResponseProps,
 } from '@/shared/presentation/action.response';
 import type { AuthSession } from '@/modules/auth/domain/errors/auth-session.types';
 
-export async function getSession(): ActionResponse<AuthSession | null> {
+export async function getSession(): Promise<ActionResponseProps<AuthSession | null>> {
   const container = getContainer();
   const getCurrentSession = container.auth.GetCurrentSessionUseCase;
   const sessionResult = await getCurrentSession.execute();
@@ -25,7 +25,7 @@ export async function getSession(): ActionResponse<AuthSession | null> {
   };
 }
 
-export async function logout(): ActionResponse<null> {
+export async function logout(): Promise<ActionResponseProps<null>> {
   const container = getContainer();
   const logout = container.auth.LogoutUseCase;
   const logoutResult = await logout.execute();

--- a/src/modules/user/presentation/ui/components/UserAvatar.tsx
+++ b/src/modules/user/presentation/ui/components/UserAvatar.tsx
@@ -1,7 +1,9 @@
 import Image from 'next/image';
 import { IconUser } from '@/presentation/globals/components/icons/outline/IconUser';
 
-export function UserAvatar({ src, size = 32 }: { src?: string | null; size?: number }) {
+type Props = { src?: string | null | undefined; size?: number };
+
+export function UserAvatar({ src, size = 32 }: Props) {
   return (
     <>
       {!src && <IconUser className="opacity-50" strokeWidth="1" />}

--- a/src/modules/user/presentation/ui/components/UserLogout.tsx
+++ b/src/modules/user/presentation/ui/components/UserLogout.tsx
@@ -1,7 +1,9 @@
 import { LogOutButton } from '@/modules/auth/presentation/ui/components/LogOutButton';
 import { UserAvatar } from './UserAvatar';
 
-export function UserLogout({ src }: { src?: string | null }) {
+type Props = { src?: string | null | undefined };
+
+export function UserLogout({ src }: Props) {
   return (
     <div className="flex items-center gap-4">
       <picture className="grid aspect-square size-8 place-items-center overflow-hidden rounded-full">


### PR DESCRIPTION
### Summary


### Issue
This PR closes #128 

### Changes
- Update Auth server actions response type by using Promise directly
- Create a function to handle the correct options generation for NextAuth sign in depending on redirect parameter
- Include undefined type in particular optional props components (UserLogout, UserAvatar) 

### Checklist
- [x] Passes `pnpm typecheck` wihtout errors/warnings in Auth module
- [x] Passes `pnpm safe-fixes` without errors/warnings in Auth module

### Evidence

Before: Types check before removing warnings/errors
<img width="780" height="844" alt="image" src="https://github.com/user-attachments/assets/f72bb6ec-b904-4ed9-97dd-543f36313e1e" />


After: Types check after removing warnings/errors
<img width="780" height="768" alt="image" src="https://github.com/user-attachments/assets/20b18728-6a86-43b9-9443-e1a510d955f4" />

### Notes
`UserAvatar` component is not part of `Auth` module, actually it is part of `User` module, but `UserLogout ` is an `Auth` component that uses `UserAvatar`, as the warning/error is displayed in `UserLogout` component it is needed to be fixed also in `UserAvatar`. That's why errors show **-8** errors/warnings instead of **-4**.