### PR TITLE
Exercise/warnings

### DIFF
--- a/src/modules/exercise/presentation/exercise.actions.ts
+++ b/src/modules/exercise/presentation/exercise.actions.ts
@@ -6,7 +6,7 @@ import { ExerciseFormSchema } from '@/modules/exercise/presentation/ui/schemas/e
 import { ExerciseMapper } from '@/modules/exercise/infrastructure/exercise.mapper';
 import { getContainer } from '@/di/containers';
 import { getCurrentUserId } from '@/modules/user/presentation/user.actions';
-import type { ActionResponse } from '@/shared/presentation/action.response';
+import type { ActionResponseProps } from '@/shared/presentation/action.response';
 import type { CreateExerciseInput } from '@/modules/exercise/application/dtos/create-exercise.dto';
 import type { ExerciseDTO } from '@/modules/exercise/application/dtos/exercise.dto';
 import type { ExerciseProps } from '@/modules/exercise/domain/exercise.types';
@@ -14,7 +14,7 @@ import type { ExerciseFormProps } from '@/modules/exercise/presentation/ui/schem
 
 export async function createExerciseAction(
   data: ExerciseFormProps
-): ActionResponse<ExerciseDTO | null> {
+): Promise<ActionResponseProps<ExerciseDTO | null>> {
   const exerciseParseResult = ExerciseFormSchema.safeParse(data);
 
   if (!exerciseParseResult.success) {
@@ -48,7 +48,7 @@ export async function createExerciseAction(
   return ActionSuccess(exerciseDTO, 'Exercise created successfully');
 }
 
-export async function getAllUserExercises(): ActionResponse<ExerciseDTO[]> {
+export async function getAllUserExercises(): Promise<ActionResponseProps<ExerciseDTO[]>> {
   const container = getContainer();
 
   const userIdResult = await getCurrentUserId();
@@ -66,7 +66,9 @@ export async function getAllUserExercises(): ActionResponse<ExerciseDTO[]> {
   return ActionSuccess(exercisesDTOs, 'User exercises found successfully');
 }
 
-export async function deleteExercise(exerciseId: ExerciseProps['id']): ActionResponse<ExerciseDTO> {
+export async function deleteExercise(
+  exerciseId: ExerciseProps['id']
+): Promise<ActionResponseProps<ExerciseDTO>> {
   const container = getContainer();
 
   const userIdResult = await getCurrentUserId();

--- a/src/modules/exercise/presentation/ui/components/fields/ExerciseDescriptionField.tsx
+++ b/src/modules/exercise/presentation/ui/components/fields/ExerciseDescriptionField.tsx
@@ -5,7 +5,7 @@ import type { ExerciseFormProps } from '@/modules/exercise/presentation/ui/schem
 import type { ExerciseDTO } from '@/modules/exercise/application/dtos/exercise.dto';
 
 type Props = {
-  value?: ExerciseDTO['description'];
+  value?: ExerciseDTO['description'] | undefined;
 };
 
 export function ExerciseDescriptionField({ value }: Props) {

--- a/src/modules/exercise/presentation/ui/components/fields/ExerciseNameField.tsx
+++ b/src/modules/exercise/presentation/ui/components/fields/ExerciseNameField.tsx
@@ -4,7 +4,9 @@ import { Label } from '@/presentation/modules/form/components/fields/Label';
 import type { ExerciseDTO } from '@/modules/exercise/application/dtos/exercise.dto';
 import type { ExerciseFormProps } from '@/modules/exercise/presentation/ui/schemas/exercise.schema';
 
-export function ExerciseNameField({ value }: { value?: ExerciseDTO['name'] }) {
+type Props = { value?: ExerciseDTO['name'] | undefined };
+
+export function ExerciseNameField({ value }: Props) {
   const {
     register,
     formState: { errors },

--- a/src/modules/exercise/presentation/ui/components/fields/ExerciseRepsField.tsx
+++ b/src/modules/exercise/presentation/ui/components/fields/ExerciseRepsField.tsx
@@ -6,7 +6,7 @@ import type { ExerciseDTO } from '@/modules/exercise/application/dtos/exercise.d
 import type { ExerciseFormProps } from '@/modules/exercise/presentation/ui/schemas/exercise.schema';
 
 type Props = {
-  value?: ExerciseDTO['reps'];
+  value?: ExerciseDTO['reps'] | undefined;
 };
 export function ExerciseRepsField({ value }: Props) {
   const {

--- a/src/modules/exercise/presentation/ui/components/fields/ExerciseSetsField.tsx
+++ b/src/modules/exercise/presentation/ui/components/fields/ExerciseSetsField.tsx
@@ -6,7 +6,7 @@ import type { ExerciseDTO } from '@/modules/exercise/application/dtos/exercise.d
 import type { ExerciseFormProps } from '@/modules/exercise/presentation/ui/schemas/exercise.schema';
 
 type Props = {
-  value?: ExerciseDTO['sets'];
+  value?: ExerciseDTO['sets'] | undefined;
 };
 
 export function ExerciseSetsField({ value }: Props) {

--- a/src/modules/exercise/presentation/ui/components/fields/ExerciseWeightField.tsx
+++ b/src/modules/exercise/presentation/ui/components/fields/ExerciseWeightField.tsx
@@ -6,7 +6,7 @@ import type { ExerciseDTO } from '@/modules/exercise/application/dtos/exercise.d
 import type { ExerciseFormProps } from '@/modules/exercise/presentation/ui/schemas/exercise.schema';
 
 type Props = {
-  value?: ExerciseDTO['weight'];
+  value?: ExerciseDTO['weight'] | undefined;
 };
 
 export function ExerciseWeightField({ value }: Props) {

--- a/src/presentation/modules/form/components/ErrorMessage.tsx
+++ b/src/presentation/modules/form/components/ErrorMessage.tsx
@@ -1,4 +1,6 @@
-export function ErrorMessage({ message }: { message?: string }) {
+type Props = { message?: string | undefined };
+
+export function ErrorMessage({ message }: Props) {
   if (!message) return null;
   return <p className="text-danger leading-tight font-medium">{message}</p>;
 }

--- a/src/presentation/modules/form/components/MultipleSelectBox.tsx
+++ b/src/presentation/modules/form/components/MultipleSelectBox.tsx
@@ -44,7 +44,7 @@ type Props<TForm extends FieldValues, TName extends FieldArrayPath<TForm>> = {
   control: Control<TForm>;
   label: string;
   selectingTitle: string;
-  error?: string;
+  error?: string | undefined;
 };
 
 export function MultipleSelectBox<TForm extends FieldValues, TName extends FieldArrayPath<TForm>>({

--- a/src/presentation/modules/form/form.types.d.ts
+++ b/src/presentation/modules/form/form.types.d.ts
@@ -3,12 +3,12 @@ import type { FieldArrayWithId } from 'react-hook-form';
 export type HTMLInputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 export type InputTextProps = InputProps & {
-  error?: string;
-  value?: string;
+  error?: string | undefined;
+  value?: string | undefined;
 };
 
 export type InputNumberProps = Omit<InputTextProps, 'value'> & {
-  value?: string | number;
+  value?: string | number | undefined;
 };
 
 export type InputDateProps = Omit<InputTextProps, 'value'> & {

--- a/src/presentation/modules/form/form.types.d.ts
+++ b/src/presentation/modules/form/form.types.d.ts
@@ -16,7 +16,7 @@ export type InputDateProps = Omit<InputTextProps, 'value'> & {
 };
 
 export type TextAreaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
-  error?: string;
+  error?: string | undefined;
 };
 
 export type SelectOptionValue = string;


### PR DESCRIPTION
### Summary
Deletion of warnings inside `Exercise` module

### Changes
- Add undefined as acceptable value in conditional props in components used in `Exercise` module
- Add Promise type directly in async function result type.

### Checklist
- [x] Passes `pnpm typecheck` without warnings/errors in `Exercise` module
- [x] Passes `pnpm safe-fixes` without warnings/errors in `Exercise` module

### Evidence

**Before**
<img width="787" height="776" alt="image" src="https://github.com/user-attachments/assets/1289b7d5-b8f9-48d7-b32f-e27bb8283ce9" />


**After**
<img width="786" height="556" alt="image" src="https://github.com/user-attachments/assets/b56758d1-8ad9-4b2c-bc82-94c3ecd8454c" />

### Notes
There are some components affected by warnings/errors deletion. Some `Exercise` module components depend on those components. That's why there are **20 errors** less instead **13 errors**.