### PR TITLE
refactor(session): remove types errors and warnings

### DIFF
--- a/src/modules/session/presentation/session.actions.ts
+++ b/src/modules/session/presentation/session.actions.ts
@@ -6,15 +6,17 @@ import { getCurrentUserId } from '@/modules/user/presentation/user.actions';
 import { SessionMapper } from '@/modules/session/infrastructure/session.mapper';
 import {
   ActionFailure,
-  type ActionResponse,
   ActionSuccess,
+  type ActionResponseProps,
 } from '@/shared/presentation/action.response';
 import type { SessionForm } from '@/modules/session/presentation/ui/config/session.schema';
 import type { CreateSessionInput } from '@/modules/session/application/dtos/create-session.dto';
 import type { SessionDTO } from '@/modules/session/application/dtos/session.dto';
 import type { SessionProps } from '@/modules/session/domain/session.types';
 
-export async function createSessionAction(data: SessionForm): ActionResponse<SessionDTO> {
+export async function createSessionAction(
+  data: SessionForm
+): Promise<ActionResponseProps<SessionDTO>> {
   const parseResult = sessionFormSchema.safeParse(data);
   if (!parseResult.success) return ActionFailure(parseResult.error.errors.join(', '));
   const sessionParsedData = parseResult.data;
@@ -41,7 +43,7 @@ export async function createSessionAction(data: SessionForm): ActionResponse<Ses
   return ActionSuccess(sessionDTO, 'Session created successfully');
 }
 
-export async function getAllSessions(): ActionResponse<SessionDTO[]> {
+export async function getAllSessions(): Promise<ActionResponseProps<SessionDTO[]>> {
   const container = getContainer();
 
   const getAllSessions = container.session.GetAllSessionsUseCase;
@@ -66,7 +68,9 @@ export async function getAllSessions(): ActionResponse<SessionDTO[]> {
   };
 }
 
-export async function getSessionsByIds(ids: SessionProps['id'][]): ActionResponse<SessionDTO[]> {
+export async function getSessionsByIds(
+  ids: SessionProps['id'][]
+): Promise<ActionResponseProps<SessionDTO[]>> {
   const container = getContainer();
 
   const getAllSessions = container.session.GetSessionsByIdsUseCase;
@@ -91,7 +95,9 @@ export async function getSessionsByIds(ids: SessionProps['id'][]): ActionRespons
   };
 }
 
-export async function deleteSession(sessionId: SessionProps['id']): ActionResponse<SessionDTO> {
+export async function deleteSession(
+  sessionId: SessionProps['id']
+): Promise<ActionResponseProps<SessionDTO>> {
   const container = getContainer();
 
   const userIdResult = await getCurrentUserId();

--- a/src/modules/session/presentation/ui/components/fields/SessionDescription.tsx
+++ b/src/modules/session/presentation/ui/components/fields/SessionDescription.tsx
@@ -5,7 +5,7 @@ import type { SessionDTO } from '@/modules/session/application/dtos/session.dto'
 import type { SessionForm } from '@/modules/session/presentation/ui/config/session.schema';
 
 type Props = {
-  value?: SessionDTO['description'];
+  value?: SessionDTO['description'] | undefined;
 };
 
 export function SessionDescription({ value }: Props) {

--- a/src/modules/session/presentation/ui/components/fields/SessionName.tsx
+++ b/src/modules/session/presentation/ui/components/fields/SessionName.tsx
@@ -5,7 +5,7 @@ import type { SessionDTO } from '@/modules/session/application/dtos/session.dto'
 import type { SessionForm } from '@/modules/session/presentation/ui/config/session.schema';
 
 type Props = {
-  value?: SessionDTO['name'];
+  value?: SessionDTO['name'] | undefined;
 };
 
 export function SessionName({ value }: Props) {

--- a/src/modules/tracking/presentation/ui/components/CurrentMonthSessionsCounter.tsx
+++ b/src/modules/tracking/presentation/ui/components/CurrentMonthSessionsCounter.tsx
@@ -7,12 +7,12 @@ import { IconCalendarCheck } from '@/presentation/globals/components/icons/outli
 
 export function CurrentMonthSessionsCounter({ className }: { className?: string }) {
   const { currentMonth } = SESSIONS_COUNTERS;
-  const monthName = MONTH_NAMES[TODAY.getMonth()].name;
+  const monthName = MONTH_NAMES[TODAY.getMonth()]?.name;
 
   return (
     <Card className={`flex flex-col gap-1 font-light ${className}`}>
       <header>
-        <CardTitle Icon={IconCalendarCheck} title={`${monthName}'s Reached Sessions`} />
+        <CardTitle Icon={IconCalendarCheck} title={`${monthName ?? 'Month'}'s Reached Sessions`} />
       </header>
       <main className="flex flex-1 items-center gap-1">
         <Counter number={currentMonth} />

--- a/src/presentation/globals/lib/dates.ts
+++ b/src/presentation/globals/lib/dates.ts
@@ -84,14 +84,16 @@ export function getSessionFromDate(date: Date): SessionsTypes {
 }
 
 export function getISOStringDate(date: Date): string {
-  return date.toISOString().split('T')[0];
+  return date.toISOString().split('T')[0] ?? '';
 }
 
 export function isToday(date: Date): boolean {
   return getISOStringDate(date) === getISOStringDate(TODAY);
 }
 
-function getMonthDays(year: number, month: number) {
+type MonthDays = (typeof MONTH_DAYS_LEAP)[number] | (typeof MONTH_DAYS)[number];
+function getMonthDays(year: number, month: number): MonthDays {
+  if (!MONTH_DAYS_LEAP[month] || !MONTH_DAYS[month]) return 31;
   return isLeapYear(year) ? MONTH_DAYS_LEAP[month] : MONTH_DAYS[month];
 }
 
@@ -188,7 +190,9 @@ function getPrevNextMonthYear(
 }
 
 function getPrevNextMonthDay(month: number, day: number): number {
-  return day > MONTH_DAYS[month] ? MONTH_DAYS[month] : day;
+  const monthLimit = MONTH_DAYS[month];
+  if (!monthLimit) return 0;
+  return day > monthLimit ? monthLimit : day;
 }
 
 export function getPreviousNextMonthDate(prevDate: Date, config: MonthDisplacement = 'next') {
@@ -203,7 +207,7 @@ export function getPreviousNextMonthDate(prevDate: Date, config: MonthDisplaceme
   return new Date(newYear, newMonth, newDay);
 }
 
-export function getPrevAndNextDate(date: Date) {
+export function getPrevAndNextDate(date: Date): [Date, Date] {
   return [getPastDate(date, 1), getNextDate(date, 1)];
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,
+    "target": "ES2022",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
### Summary
Deletion of types warnings/errors in `Session` module

### Issue
This PR closes #132 

### Changes
- Add Promise type directly in server actions functions' results
- Add missing target `ES2022` configuration in `tsconfig` file
- Improve type checking in date lib
- Consider array index access for `possibly undefined` case

### Checklist
- [x] Passes `pnpm typecheck` without warnings/errors in `Session` module
- [x] Passes `pnpm safe-fixes` without warnings/errors in `Session` module

### Evidence

**Before**:
<img width="703" height="414" alt="image" src="https://github.com/user-attachments/assets/c854875e-8d0a-49dc-93c3-8e39dd77a5f8" />

**After**:
<img width="629" height="330" alt="image" src="https://github.com/user-attachments/assets/e3a4fd62-719b-4c62-92e3-66e5f047c5c2" />
