### PR TITLE
refactor: remove type errors/warnings for presentation/globals, shared and User modules

### DIFF
--- a/src/modules/user/presentation/user.actions.ts
+++ b/src/modules/user/presentation/user.actions.ts
@@ -1,13 +1,13 @@
 'use server';
+import { getContainer } from '@/di/containers';
 import type { User } from '@/modules/user/domain/user.entity';
 import {
   ActionFailure,
-  type ActionResponse,
   ActionSuccess,
+  type ActionResponseProps,
 } from '@/shared/presentation/action.response';
-import type { UserProps } from '../domain/user.types';
-import { getContainer } from '@/di/containers';
-export async function getUser(): ActionResponse<User | null> {
+import type { UserProps } from '@/modules/user/domain/user.types';
+export async function getUser(): Promise<ActionResponseProps<User | null>> {
   return {
     success: false,
     data: null,
@@ -15,7 +15,7 @@ export async function getUser(): ActionResponse<User | null> {
   };
 }
 
-export async function getCurrentUser(): ActionResponse<User> {
+export async function getCurrentUser(): Promise<ActionResponseProps<User>> {
   const container = getContainer();
   const getCurrentUser = container.user.GetCurrentUserUseCase;
 
@@ -27,7 +27,7 @@ export async function getCurrentUser(): ActionResponse<User> {
   return ActionSuccess(userResult.data, 'User found');
 }
 
-export async function getCurrentUserId(): ActionResponse<UserProps['id']> {
+export async function getCurrentUserId(): Promise<ActionResponseProps<UserProps['id']>> {
   const container = getContainer();
   const getCurrentUserId = container.user.GetCurrentUserIdUseCase;
 

--- a/src/presentation/globals/constants/db.ts
+++ b/src/presentation/globals/constants/db.ts
@@ -8,7 +8,7 @@ export const BODY_SECTIONS = {
   ARMS: 'Arms',
   LEGS: 'Legs',
   TORSO: 'Torso',
-};
+} as const;
 
 export const MUSCULAR_GROUPS = {
   // ARMS
@@ -64,7 +64,7 @@ export const MUSCULAR_GROUPS = {
     name: 'Chest',
     bodySection: BODY_SECTIONS.TORSO,
   },
-};
+} as const;
 
 export type MuscleType = {
   name: string;
@@ -76,9 +76,8 @@ export type MusclesType = {
   [key: string]: MuscleType;
 };
 
-export const MUSCLES: MusclesType = {
+export const MUSCLES = {
   // ARMS
-
   // BICEPS
   BICEPS: {
     name: 'Biceps',
@@ -266,7 +265,7 @@ export const MUSCLES: MusclesType = {
     muscularGroup: MUSCULAR_GROUPS.CHEST.name,
     bodySection: BODY_SECTIONS.TORSO,
   },
-};
+} as const satisfies MusclesType;
 
 export type ExerciseType = {
   name: string;
@@ -278,7 +277,7 @@ export type ExercisesType = {
   [key: string]: ExerciseType;
 };
 
-export const EXERCISES: ExercisesType = {
+export const EXERCISES = {
   // PUSH DAY
   ABS: {
     name: 'Abs',
@@ -364,4 +363,4 @@ export const EXERCISES: ExercisesType = {
     description: 'Wide Grip',
     muscles: [MUSCLES.BACK, MUSCLES.BICEPS],
   },
-};
+} as const satisfies ExercisesType;

--- a/src/shared/domain/errors/domain.errors.ts
+++ b/src/shared/domain/errors/domain.errors.ts
@@ -1,8 +1,11 @@
 import type { DomainErrorCode } from '@/shared/domain/errors/error.types';
 
 export abstract class DomainError extends Error {
+  public readonly code: DomainErrorCode;
   constructor(code: DomainErrorCode) {
     super(code);
+    this.code = code;
+    this.name = new.target.name;
   }
 }
 

--- a/src/shared/infrastructure/errors/error.translator.ts
+++ b/src/shared/infrastructure/errors/error.translator.ts
@@ -15,7 +15,8 @@ export class InfrastructureErrorTranslator {
       const domainError = handler.translate(error);
       if (domainError) return domainError;
     }
-    console.log(error);
+    // biome-ignore lint: <suspicious>
+    console.error(error);
     return new TechnicalError();
   }
 }


### PR DESCRIPTION
## Refactor: Remove `User` and `Shared` lint and types warnings/errors

### Intent

- **Goal:** Ensure there are no errors nor warnings related to `User module` nor `Shared`
- **Refactor Type:** `Readability`

### Changes
- Add Promise type directly in server action functions response
- Add missing property code in DomainError abstraction class for domain error insurance of having code property
- Add property name to abstraction class DomainError to avoid conflicts with the parent Error name

### Stability & Safety

- [x] **Behavioral Parity:** I have confirmed that the application behavior remains unchanged.
- [x] **Existing Tests:** All existing unit and integration tests pass.
- [x] **Static Analysis:** `pnpm typecheck` and `pnpm safe-fixes` pass without warnings in the mentioned modules.

### Evidence

**Before**:
<img width="618" height="321" alt="image" src="https://github.com/user-attachments/assets/75c6bdb5-4e0c-46ca-b49f-7dd279f18ef7" />


**After**:
<img width="623" height="324" alt="image" src="https://github.com/user-attachments/assets/b483e80e-7205-4073-94a8-030f947e1749" />


---