### PR TITLE
Dashboard warnings

### DIFF
--- a/src/presentation/modules/dashboard/components/home/ExercisesList.tsx
+++ b/src/presentation/modules/dashboard/components/home/ExercisesList.tsx
@@ -5,18 +5,17 @@ import { Card } from '@/presentation/modules/card/components/Card';
 import { IconBarbell } from '@/presentation/globals/components/icons/outline/IconBarbell';
 
 export function ExercisesList({ className = '' }: { className?: string }) {
-  const exerciseKeys = Object.keys(EXERCISES)
-    .slice(0, 5)
-    .map((key, index) => ({
-      key: index,
-      name: EXERCISES[key].name,
-    }));
+  const exercisesKeys = Object.keys(EXERCISES).slice(0, 5) as (keyof typeof EXERCISES)[];
+  const exercises = exercisesKeys.map((key, index) => ({
+    key: index,
+    name: EXERCISES[key].name,
+  }));
 
   return (
     <Card className={`flex flex-col gap-4 ${className}`}>
       <CardTitle Icon={IconBarbell} title="Exercises" />
       <main>
-        <SimpleTable header={{ key: '#', name: 'Exercise' }} values={exerciseKeys} />
+        <SimpleTable header={{ key: '#', name: 'Exercise' }} values={exercises} />
       </main>
     </Card>
   );

--- a/src/presentation/modules/dashboard/components/home/MusclesList.tsx
+++ b/src/presentation/modules/dashboard/components/home/MusclesList.tsx
@@ -5,17 +5,16 @@ import { Card } from '@/presentation/modules/card/components/Card';
 import { IconMan } from '@/presentation/globals/components/icons/outline/IconMan';
 
 export function MusclesList({ className = '' }: { className?: string }) {
-  const muscleKeys = Object.keys(MUSCLES)
-    .slice(0, 5)
-    .map((key, index) => ({
-      key: index,
-      name: MUSCLES[key].name,
-    }));
+  const musclesKeys = Object.keys(MUSCLES).slice(0, 5) as (keyof typeof MUSCLES)[];
+  const muscles = musclesKeys.map((key, index) => ({
+    key: index,
+    name: MUSCLES[key].name,
+  }));
   return (
     <Card className={`flex flex-col gap-4 ${className}`}>
       <CardTitle Icon={IconMan} title="Muscles" />
       <main>
-        <SimpleTable header={{ key: '#', name: 'Muscle' }} values={muscleKeys} />
+        <SimpleTable header={{ key: '#', name: 'Muscle' }} values={muscles} />
       </main>
     </Card>
   );


### PR DESCRIPTION
### Summary
Deletion of errors and warnings presented in presentation -> dashboard module

### Issue
This PR closes #137

### Changes
- Improve array index access logic

### Checklist
No errors/warnigs are found in `presentation -> dashboard` module on running:
- [x] `pnpm typecheck`
- [x] `pnpm safe-fixes`

### Evidence

**Before**:
<img width="622" height="219" alt="image" src="https://github.com/user-attachments/assets/4b444c8f-b79a-43d5-9563-e7a05c931440" />

**After**:
<img width="617" height="224" alt="image" src="https://github.com/user-attachments/assets/b694286f-5d25-4069-a4ba-952b6f521946" />

