### PR TITLE
refactor(presentation): remove type/lint warnigs from presentation layer

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,3 +1,5 @@
-export { default } from 'next-auth/middleware';
+import middleware from 'next-auth/middleware';
+
+export default middleware;
 
 export const config = { matcher: ['/dashboard'] };

--- a/src/presentation/modules/form/components/RadiobuttonGroup.test.tsx
+++ b/src/presentation/modules/form/components/RadiobuttonGroup.test.tsx
@@ -2,21 +2,10 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import { RadiobuttonGroup } from '@/presentation/modules/form/components/RadiobuttonGroup';
 import userEvent from '@testing-library/user-event';
-
-const options = [
-  {
-    label: 'Strength',
-    value: 'strength',
-  },
-  {
-    label: 'Health',
-    value: 'health',
-  },
-  {
-    label: 'Hypertrophy',
-    value: 'hypertrophy',
-  },
-];
+import {
+  MOCK_SELECT_OPTIONS,
+  MOCK_SELECT_OPTIONS_LIST,
+} from '@/shared/test/mocks/test.mocks.select-options';
 
 describe('<RadiobuttonGroup />', () => {
   describe('Basic Rendering', () => {
@@ -26,7 +15,7 @@ describe('<RadiobuttonGroup />', () => {
     });
 
     it('Should render radio input elements when at least one option provided', () => {
-      render(<RadiobuttonGroup options={[options[0]]} />);
+      render(<RadiobuttonGroup options={[MOCK_SELECT_OPTIONS.STRENGTH]} />);
       expect(screen.getByRole('radiogroup')).toBeInTheDocument();
       expect(screen.getByRole('radio')).toBeInTheDocument();
     });
@@ -34,28 +23,33 @@ describe('<RadiobuttonGroup />', () => {
 
   describe('Integration with Props', () => {
     it('Should render {n} radio input elements when {n} options provided', () => {
-      render(<RadiobuttonGroup options={options} />);
+      render(<RadiobuttonGroup options={MOCK_SELECT_OPTIONS_LIST} />);
       expect(screen.getByRole('radiogroup')).toBeInTheDocument();
       const radios = screen.getAllByRole('radio');
-      expect(radios.length).toBe(options.length);
+      expect(radios.length).toBe(3);
     });
 
     it('Should render a radio input element with "Strength" label text when is provided by options prop', () => {
-      render(<RadiobuttonGroup options={[options[0]]} />);
+      render(<RadiobuttonGroup options={[MOCK_SELECT_OPTIONS.STRENGTH]} />);
       expect(screen.getByRole('radio', { name: /strength/i })).toBeInTheDocument();
     });
 
     it('Should have radio input checked when its value is provided by checked prop', () => {
-      render(<RadiobuttonGroup options={options} checked="health" />);
+      render(<RadiobuttonGroup options={MOCK_SELECT_OPTIONS_LIST} checked="health" />);
       expect(screen.getByRole('radio', { name: /health/i })).toBeChecked();
     });
 
     it('Should update radio input elements on options updating when rerendered', () => {
       const { rerender } = render(<RadiobuttonGroup options={[]} />);
       expect(screen.queryByRole('radio')).not.toBeInTheDocument();
-      rerender(<RadiobuttonGroup options={options} checked="health" />);
+      rerender(<RadiobuttonGroup options={MOCK_SELECT_OPTIONS_LIST} checked="health" />);
       expect(screen.getByRole('radio', { name: /health/i })).toBeInTheDocument();
-      rerender(<RadiobuttonGroup options={[options[0], options[2]]} checked="strength" />);
+      rerender(
+        <RadiobuttonGroup
+          options={[MOCK_SELECT_OPTIONS.STRENGTH, MOCK_SELECT_OPTIONS.HYPERTROPHY]}
+          checked="strength"
+        />
+      );
       expect(screen.queryByRole('radio', { name: /health/i })).not.toBeInTheDocument();
       expect(screen.getByRole('radio', { name: /strength/i })).toBeInTheDocument();
     });
@@ -66,7 +60,7 @@ describe('<RadiobuttonGroup />', () => {
       const fn = jest.fn();
       const user = userEvent.setup();
       const handleChange = (_e: React.ChangeEvent<HTMLInputElement>) => fn();
-      render(<RadiobuttonGroup options={options} onChange={handleChange} />);
+      render(<RadiobuttonGroup options={MOCK_SELECT_OPTIONS_LIST} onChange={handleChange} />);
       await user.click(screen.getByRole('radio', { name: /health/i }));
       expect(fn).toHaveBeenCalledTimes(1);
     });
@@ -75,7 +69,7 @@ describe('<RadiobuttonGroup />', () => {
   describe('Accessibility', () => {
     it('Should support keyboard navigation (focus)', async () => {
       const user = userEvent.setup();
-      render(<RadiobuttonGroup options={options} />);
+      render(<RadiobuttonGroup options={MOCK_SELECT_OPTIONS_LIST} />);
       await user.tab();
       expect(screen.getByRole('radio', { name: /strength/i })).toHaveFocus();
     });

--- a/src/presentation/modules/form/components/SelectBoxOption.test.tsx
+++ b/src/presentation/modules/form/components/SelectBoxOption.test.tsx
@@ -2,52 +2,46 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import { SelectBoxOption } from '@/presentation/modules/form/components/SelectBoxOption';
 import userEvent from '@testing-library/user-event';
-
-const options = [
-  {
-    label: 'Strength',
-    value: 'strength',
-  },
-  {
-    label: 'Health',
-    value: 'health',
-  },
-  {
-    label: 'Hypertrophy',
-    value: 'hypertrophy',
-  },
-];
+import { MOCK_SELECT_OPTIONS } from '@/shared/test/mocks/test.mocks.select-options';
 
 describe('<SelectBoxOption />', () => {
   describe('Basic Rendering', () => {
     it('Should be rendered with minimum props', () => {
-      render(<SelectBoxOption onSelect={() => {}} option={options[0]} />);
-      expect(screen.getByLabelText(options[0].label)).toBeInTheDocument();
+      render(<SelectBoxOption onSelect={() => {}} option={MOCK_SELECT_OPTIONS.STRENGTH} />);
+      expect(screen.getByLabelText(MOCK_SELECT_OPTIONS.STRENGTH.label)).toBeInTheDocument();
     });
   });
 
   describe('Integration with Props', () => {
     it('Should have radio input checked when isSelected prop provided as "true" ', () => {
-      render(<SelectBoxOption onSelect={() => {}} option={options[0]} isSelected />);
+      render(
+        <SelectBoxOption onSelect={() => {}} option={MOCK_SELECT_OPTIONS.STRENGTH} isSelected />
+      );
       expect(screen.getByRole('checkbox')).toBeChecked();
     });
 
     it('Should not have radio input checked when isSelected prop is not provided (false)', () => {
-      render(<SelectBoxOption onSelect={() => {}} option={options[0]} />);
+      render(<SelectBoxOption onSelect={() => {}} option={MOCK_SELECT_OPTIONS.STRENGTH} />);
       expect(screen.getByRole('checkbox')).not.toBeChecked();
     });
 
     it('Should update input check when rerendered', () => {
-      const { rerender } = render(<SelectBoxOption onSelect={() => {}} option={options[0]} />);
+      const { rerender } = render(
+        <SelectBoxOption onSelect={() => {}} option={MOCK_SELECT_OPTIONS.STRENGTH} />
+      );
       expect(screen.getByRole('checkbox')).not.toBeChecked();
-      rerender(<SelectBoxOption onSelect={() => {}} option={options[0]} isSelected />);
+      rerender(
+        <SelectBoxOption onSelect={() => {}} option={MOCK_SELECT_OPTIONS.STRENGTH} isSelected />
+      );
       expect(screen.getByRole('checkbox')).toBeChecked();
     });
 
     it('Should update checkbox by option prop when rerendered', () => {
-      const { rerender } = render(<SelectBoxOption onSelect={() => {}} option={options[0]} />);
+      const { rerender } = render(
+        <SelectBoxOption onSelect={() => {}} option={MOCK_SELECT_OPTIONS.STRENGTH} />
+      );
       expect(screen.getByRole('checkbox', { name: /strength/i })).toBeInTheDocument();
-      rerender(<SelectBoxOption onSelect={() => {}} option={options[1]} />);
+      rerender(<SelectBoxOption onSelect={() => {}} option={MOCK_SELECT_OPTIONS.HEALTH} />);
       expect(screen.queryByRole('checkbox', { name: /strength/i })).not.toBeInTheDocument();
       expect(screen.getByRole('checkbox', { name: /health/i })).toBeInTheDocument();
     });
@@ -58,8 +52,8 @@ describe('<SelectBoxOption />', () => {
       const fn = jest.fn();
       const user = userEvent.setup();
       const handleChange = (_v: string) => fn();
-      render(<SelectBoxOption onSelect={handleChange} option={options[0]} />);
-      await user.click(screen.getByLabelText(options[0].label));
+      render(<SelectBoxOption onSelect={handleChange} option={MOCK_SELECT_OPTIONS.STRENGTH} />);
+      await user.click(screen.getByLabelText(MOCK_SELECT_OPTIONS.STRENGTH.label));
       expect(fn).toHaveBeenCalledTimes(1);
     });
   });
@@ -67,19 +61,21 @@ describe('<SelectBoxOption />', () => {
   describe('Accessibility', () => {
     it('Should support keyboard navigation (focus)', async () => {
       const user = userEvent.setup();
-      render(<SelectBoxOption onSelect={() => {}} option={options[0]} />);
+      render(<SelectBoxOption onSelect={() => {}} option={MOCK_SELECT_OPTIONS.STRENGTH} />);
       await user.tab();
       expect(screen.getByRole('checkbox', { name: /strength/i })).toHaveFocus();
     });
 
     it('Should be highlighted when isSelected prop is "true"', async () => {
-      render(<SelectBoxOption onSelect={() => {}} option={options[0]} isSelected />);
-      expect(screen.getByText(options[0].label)).toHaveClass('border-success');
+      render(
+        <SelectBoxOption onSelect={() => {}} option={MOCK_SELECT_OPTIONS.STRENGTH} isSelected />
+      );
+      expect(screen.getByText(MOCK_SELECT_OPTIONS.STRENGTH.label)).toHaveClass('border-success');
     });
 
     it('Should not be highlighted when isSelected prop is not provided or as "false"', () => {
-      render(<SelectBoxOption onSelect={() => {}} option={options[0]} />);
-      expect(screen.getByText(options[0].label)).toHaveClass('border-bd-default');
+      render(<SelectBoxOption onSelect={() => {}} option={MOCK_SELECT_OPTIONS.STRENGTH} />);
+      expect(screen.getByText(MOCK_SELECT_OPTIONS.STRENGTH.label)).toHaveClass('border-bd-default');
     });
   });
 });

--- a/src/presentation/modules/form/components/SortableInputItem.test.tsx
+++ b/src/presentation/modules/form/components/SortableInputItem.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import { SortableInputItem } from '@/presentation/modules/form/components/SortableInputItem';
 import userEvent from '@testing-library/user-event';
+import { MOCK_SELECT_OPTIONS } from '@/shared/test/mocks/test.mocks.select-options';
 
 jest.mock('@dnd-kit/react/sortable', () => ({
   SortableContext: ({ children }: any) => children,
@@ -24,64 +25,99 @@ jest.mock('@dnd-kit/react/sortable', () => ({
   },
 }));
 
-const options = [
-  {
-    label: 'Strength',
-    value: 'strength',
-  },
-  {
-    label: 'Health',
-    value: 'health',
-  },
-];
-
 const testId = 'sortable-item';
 
 describe('<SortableInputItem />', () => {
   describe('Basic Rendering', () => {
     it('Should be rendered with minimum props', () => {
-      render(<SortableInputItem index={0} item={options[0]} onRemoveOption={() => {}} />);
+      render(
+        <SortableInputItem
+          index={0}
+          item={MOCK_SELECT_OPTIONS.STRENGTH}
+          onRemoveOption={() => {}}
+        />
+      );
       expect(screen.getByTestId(testId)).toBeInTheDocument();
     });
 
     it('Should have button drag item', () => {
-      render(<SortableInputItem index={0} item={options[0]} onRemoveOption={() => {}} />);
+      render(
+        <SortableInputItem
+          index={0}
+          item={MOCK_SELECT_OPTIONS.STRENGTH}
+          onRemoveOption={() => {}}
+        />
+      );
       expect(screen.getByRole('button', { name: /drag item/i })).toBeInTheDocument();
     });
 
     it('Should have button to remove item', () => {
-      render(<SortableInputItem index={0} item={options[0]} onRemoveOption={() => {}} />);
+      render(
+        <SortableInputItem
+          index={0}
+          item={MOCK_SELECT_OPTIONS.STRENGTH}
+          onRemoveOption={() => {}}
+        />
+      );
       expect(screen.getByRole('button', { name: /remove item/i })).toBeInTheDocument();
     });
   });
 
   describe('Integration with Props', () => {
     it('Should have text when provided in item prop label', () => {
-      render(<SortableInputItem index={0} item={options[0]} onRemoveOption={() => {}} />);
-      expect(screen.getByText(options[0].label)).toBeInTheDocument();
+      render(
+        <SortableInputItem
+          index={0}
+          item={MOCK_SELECT_OPTIONS.STRENGTH}
+          onRemoveOption={() => {}}
+        />
+      );
+      expect(screen.getByText(MOCK_SELECT_OPTIONS.STRENGTH.label)).toBeInTheDocument();
     });
 
     it('Should have number {n + 1} when n is provided by index prop', () => {
-      render(<SortableInputItem index={0} item={options[0]} onRemoveOption={() => {}} />);
+      render(
+        <SortableInputItem
+          index={0}
+          item={MOCK_SELECT_OPTIONS.STRENGTH}
+          onRemoveOption={() => {}}
+        />
+      );
       expect(screen.getByText('1')).toBeInTheDocument();
     });
 
     it('Should update text when rerendered', () => {
       const { rerender } = render(
-        <SortableInputItem index={0} item={options[0]} onRemoveOption={() => {}} />
+        <SortableInputItem
+          index={0}
+          item={MOCK_SELECT_OPTIONS.STRENGTH}
+          onRemoveOption={() => {}}
+        />
       );
-      expect(screen.getByText(options[0].label)).toBeInTheDocument();
-      rerender(<SortableInputItem index={0} item={options[1]} onRemoveOption={() => {}} />);
-      expect(screen.queryByText(options[0].label)).not.toBeInTheDocument();
-      expect(screen.getByText(options[1].label)).toBeInTheDocument();
+      expect(screen.getByText(MOCK_SELECT_OPTIONS.STRENGTH.label)).toBeInTheDocument();
+      rerender(
+        <SortableInputItem index={0} item={MOCK_SELECT_OPTIONS.HEALTH} onRemoveOption={() => {}} />
+      );
+      expect(screen.queryByText(MOCK_SELECT_OPTIONS.STRENGTH.label)).not.toBeInTheDocument();
+      expect(screen.getByText(MOCK_SELECT_OPTIONS.HEALTH.label)).toBeInTheDocument();
     });
 
     it('Should update number when rerendered', () => {
       const { rerender } = render(
-        <SortableInputItem index={0} item={options[0]} onRemoveOption={() => {}} />
+        <SortableInputItem
+          index={0}
+          item={MOCK_SELECT_OPTIONS.STRENGTH}
+          onRemoveOption={() => {}}
+        />
       );
       expect(screen.getByText('1')).toBeInTheDocument();
-      rerender(<SortableInputItem index={1} item={options[0]} onRemoveOption={() => {}} />);
+      rerender(
+        <SortableInputItem
+          index={1}
+          item={MOCK_SELECT_OPTIONS.STRENGTH}
+          onRemoveOption={() => {}}
+        />
+      );
       expect(screen.queryByText('1')).not.toBeInTheDocument();
       expect(screen.getByText('2')).toBeInTheDocument();
     });
@@ -91,7 +127,9 @@ describe('<SortableInputItem />', () => {
     it('Should trigger onRemove callback when remove item button clicked', async () => {
       const fn = jest.fn();
       const user = userEvent.setup();
-      render(<SortableInputItem index={0} item={options[0]} onRemoveOption={fn} />);
+      render(
+        <SortableInputItem index={0} item={MOCK_SELECT_OPTIONS.STRENGTH} onRemoveOption={fn} />
+      );
       await user.click(screen.getByRole('button', { name: /remove item/i }));
       expect(fn).toHaveBeenCalledTimes(1);
     });
@@ -100,7 +138,13 @@ describe('<SortableInputItem />', () => {
   describe('Accessibility', () => {
     it('Should support keyboard navigation (focus)', async () => {
       const user = userEvent.setup();
-      render(<SortableInputItem index={0} item={options[0]} onRemoveOption={() => {}} />);
+      render(
+        <SortableInputItem
+          index={0}
+          item={MOCK_SELECT_OPTIONS.STRENGTH}
+          onRemoveOption={() => {}}
+        />
+      );
       await user.tab();
       expect(screen.getByRole('button', { name: /drag item/i })).toHaveFocus();
       await user.tab();

--- a/src/presentation/modules/form/hooks/useMultipleSelectBox.ts
+++ b/src/presentation/modules/form/hooks/useMultipleSelectBox.ts
@@ -91,7 +91,7 @@ export function useMultipleSelectBox<
     if (itemsSelected.length < 1) return;
     const selectedFields = itemsSelected.map((i) => ({ id: i }));
     replace(selectedFields as any);
-  }, [itemsSelected]);
+  }, [itemsSelected, replace]);
 
   return {
     fields,

--- a/src/presentation/modules/form/hooks/useSortableInputItems.ts
+++ b/src/presentation/modules/form/hooks/useSortableInputItems.ts
@@ -96,7 +96,7 @@ export function useSortableInputItems<
     if (itemsSelected.length < 1) return;
     const initialFields = itemsSelected.map((i) => ({ id: i }));
     replace(initialFields as any);
-  }, [itemsSelected]);
+  }, [itemsSelected, replace]);
 
   return {
     fields,

--- a/src/shared/test/mocks/test.mocks.select-options.ts
+++ b/src/shared/test/mocks/test.mocks.select-options.ts
@@ -1,0 +1,20 @@
+export const MOCK_SELECT_OPTIONS = {
+  STRENGTH: {
+    label: 'Strength',
+    value: 'strength',
+  },
+  HEALTH: {
+    label: 'Health',
+    value: 'health',
+  },
+  HYPERTROPHY: {
+    label: 'Hypertrophy',
+    value: 'hypertrophy',
+  },
+};
+
+export const MOCK_SELECT_OPTIONS_LIST = [
+  MOCK_SELECT_OPTIONS.STRENGTH,
+  MOCK_SELECT_OPTIONS.HEALTH,
+  MOCK_SELECT_OPTIONS.HYPERTROPHY,
+];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,
-    "target": "ES2022",
+    "target": "es2022",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
### Summary
Deletion of rest errors/warnings in presentation layer

### Issue
This PR closes #138 

### Changes
- Add mocks for components with select option props
- Add default export function for `NextAuth` middleware
- Add missing dependency in useEffect hook
- Update target configuration for tsconfig

### Checklist
- [x] Passes `pnpm typecheck` without warnings/errors
- [x] Passes `pnpm safe-fixes` without warnings/errors

### Evidence

**Before**:
<img width="617" height="161" alt="image" src="https://github.com/user-attachments/assets/4b873fa4-9ac6-424e-b54b-79c83688ad0e" />
<img width="399" height="187" alt="image" src="https://github.com/user-attachments/assets/24ff7f18-37d6-4e18-97de-a6c2fdf39fd6" />


**After**:
<img width="591" height="223" alt="image" src="https://github.com/user-attachments/assets/66a8de39-2c56-44c9-bed4-59a7877657c4" />

