### PR TITLE
feat(user tests): add unit test for CreateUser, UpdateUser use cases

### DIFF
--- a/src/modules/user/application/use-cases/create-user.test.ts
+++ b/src/modules/user/application/use-cases/create-user.test.ts
@@ -71,6 +71,37 @@ describe('CreateUser use case', () => {
       // Verify DB state
       expect(userRepoMock2.users).toHaveLength(10); // no users added
     });
+
+    it('should return failure result when user role not exists', async () => {
+      // Set up
+      const userRepoMock2 = new InMemoryUserRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const createSpy = jest.spyOn(userRepoMock2, 'create');
+      const useCase = new CreateUser(userRepoMock2, idGeneratorMock);
+
+      // Config
+      idGeneratorMock.id = 'user-id-1234';
+
+      // Data
+      const userData: CreateUserInput = {
+        email: 'angel1234@gmail.com',
+        name: 'Angel',
+        roleId: 'notExistingRole',
+      };
+
+      // Execute
+      const createUserResult = await useCase.execute(userData);
+
+      // Assert interaction -> do not create
+      expect(createSpy).toHaveBeenCalledTimes(0);
+
+      // Assert result pattern
+      expect(createUserResult.success).toBe(false);
+      expect(!createUserResult.success && createUserResult.error.code).toBe('ROLE_NOT_FOUND'); // <- update for the correspondent User error
+
+      // Verify DB state
+      expect(userRepoMock2.users).toHaveLength(10); // no users added
+    });
   });
 
   describe('Dependency Interaction', () => {
@@ -81,7 +112,32 @@ describe('CreateUser use case', () => {
       const useCase = new CreateUser(userRepoMock, idGeneratorMock);
       jest.spyOn(userRepoMock, 'create').mockResolvedValue(Failure(new TechnicalError() as never));
 
-      // Config
+      // Data
+      const userData: CreateUserInput = {
+        email: 'angel1234@gmail.com',
+        name: 'Angel',
+        roleId: 'base',
+      };
+
+      // Execute
+      const createUserResult = await useCase.execute(userData);
+
+      // Assert result pattern
+      expect(createUserResult.success).toBe(false);
+      expect(!createUserResult.success && createUserResult.error.code).toBe('TECHNICAL_ERROR');
+
+      // Verify DB state
+      expect(userRepoMock.users).toHaveLength(10); // no users added
+    });
+
+    it('sould return failure when repository findByEmail operation fails', async () => {
+      // Set up
+      const userRepoMock = new InMemoryUserRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new CreateUser(userRepoMock, idGeneratorMock);
+      jest
+        .spyOn(userRepoMock, 'findByEmail')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
 
       // Data
       const userData: CreateUserInput = {

--- a/src/modules/user/application/use-cases/create-user.test.ts
+++ b/src/modules/user/application/use-cases/create-user.test.ts
@@ -1,0 +1,104 @@
+import '@testing-library/jest-dom';
+import { InMemoryUserRepository } from '@/modules/user/mocks/user.mocks.repository';
+import { CreateUser } from '@/modules/user/application/use-cases/create-user';
+import { MockIdGenerator } from '@/shared/test/mocks/id-generator.repository.mock';
+import { Failure } from '@/shared/domain/result';
+import { TechnicalError } from '@/shared/domain/errors/domain.errors';
+import type { CreateUserInput } from '@/modules/user/application/dtos/create-user.dto';
+
+describe('CreateUser use case', () => {
+  describe('Happy Path', () => {
+    it('should create user successfully and persist them', async () => {
+      // Set up
+      const userRepoMock = new InMemoryUserRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const createSpy = jest.spyOn(userRepoMock, 'create');
+      const useCase = new CreateUser(userRepoMock, idGeneratorMock);
+      const userData: CreateUserInput = {
+        email: 'angel1234@gmail.com',
+        name: 'Angel',
+        roleId: 'base',
+      };
+
+      // Config
+      idGeneratorMock.id = 'user-id-1234';
+
+      // Execute
+      const createUserResult = await useCase.execute(userData);
+
+      // Assert interaction
+      expect(createSpy).toHaveBeenCalledTimes(1);
+
+      // Assert result pattern
+      expect(createUserResult.success).toBe(true);
+      expect(createUserResult.success && createUserResult.data.id).toBe('user-id-1234');
+      expect(createUserResult.success && createUserResult.data.email).toBe('angel1234@gmail.com');
+
+      // Verify DB state
+      expect(userRepoMock.users).toHaveLength(11); // initial users (10) + 1
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should return failure result when user email already exists', async () => {
+      // Set up
+      const userRepoMock2 = new InMemoryUserRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const createSpy = jest.spyOn(userRepoMock2, 'create');
+      const useCase = new CreateUser(userRepoMock2, idGeneratorMock);
+
+      // Config
+      userRepoMock2.users[0]?.changeEmail('angel1234@gmail.com');
+      idGeneratorMock.id = 'user-id-1234';
+
+      // Data
+      const userData: CreateUserInput = {
+        email: 'angel1234@gmail.com',
+        name: 'Angel',
+        roleId: 'base',
+      };
+
+      // Execute
+      const createUserResult = await useCase.execute(userData);
+
+      // Assert interaction -> do not create
+      expect(createSpy).toHaveBeenCalledTimes(0);
+
+      // Assert result pattern
+      expect(createUserResult.success).toBe(false);
+      expect(!createUserResult.success && createUserResult.error.code).toBe('TECHNICAL_ERROR'); // <- update for the correspondent User error
+
+      // Verify DB state
+      expect(userRepoMock2.users).toHaveLength(10); // no users added
+    });
+  });
+
+  describe('Dependency Interaction', () => {
+    it('sould return failure when repository create operation fails', async () => {
+      // Set up
+      const userRepoMock = new InMemoryUserRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new CreateUser(userRepoMock, idGeneratorMock);
+      jest.spyOn(userRepoMock, 'create').mockResolvedValue(Failure(new TechnicalError() as never));
+
+      // Config
+
+      // Data
+      const userData: CreateUserInput = {
+        email: 'angel1234@gmail.com',
+        name: 'Angel',
+        roleId: 'base',
+      };
+
+      // Execute
+      const createUserResult = await useCase.execute(userData);
+
+      // Assert result pattern
+      expect(createUserResult.success).toBe(false);
+      expect(!createUserResult.success && createUserResult.error.code).toBe('TECHNICAL_ERROR');
+
+      // Verify DB state
+      expect(userRepoMock.users).toHaveLength(10); // no users added
+    });
+  });
+});

--- a/src/modules/user/application/use-cases/create-user.ts
+++ b/src/modules/user/application/use-cases/create-user.ts
@@ -1,11 +1,12 @@
+import { Failure } from '@/shared/domain/result';
 import { User } from '@/modules/user/domain/user.entity';
 import { ROLES } from '@/modules/user/domain/user.constants.roles';
-import { Failure } from '@/shared/domain/result';
+import { TechnicalError } from '@/shared/domain/errors/domain.errors';
 import { RoleNotFound } from '@/modules/user/domain/errors/user.errors';
-import type { IUserRepository } from '@/modules/user/domain/user.repository';
-import type { CreateUserInput } from '@/modules/user/application/dtos/create-user.dto';
 import type { UseCase } from '@/shared/application/use-case';
 import type { IdGeneratorRepository } from '@/shared/application/id-generator';
+import type { IUserRepository } from '@/modules/user/domain/user.repository';
+import type { CreateUserInput } from '@/modules/user/application/dtos/create-user.dto';
 
 export class CreateUser implements UseCase {
   constructor(
@@ -15,10 +16,12 @@ export class CreateUser implements UseCase {
 
   async execute(data: CreateUserInput) {
     const id = this.generator.generate();
-
     const role = Object.values(ROLES).find((r) => r.id === data.roleId);
-
     if (!role) return Failure(new RoleNotFound());
+
+    const userByEmailResult = await this.repository.findByEmail(data.email);
+    if (!userByEmailResult.success) return userByEmailResult;
+    if (userByEmailResult.data) return Failure(new TechnicalError()); // more User exceptions needed
 
     const user = User.create(id, {
       email: data.email,

--- a/src/modules/user/application/use-cases/update-user.test.ts
+++ b/src/modules/user/application/use-cases/update-user.test.ts
@@ -94,5 +94,31 @@ describe('UpdateUser use case', () => {
       // Verify DB state
       expect(userRepoMock.users).toHaveLength(10); // no users added
     });
+
+    it('sould return failure when repository finById operation fails', async () => {
+      // Set up
+      const userRepoMock = new InMemoryUserRepository();
+      const useCase = new UpdateUser(userRepoMock);
+      jest
+        .spyOn(userRepoMock, 'findById')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+
+      // Data
+      const user = userRepoMock.users[0] as User;
+      const userData: UpdateUserInput = {
+        email: 'angel1234@gmail.com',
+        name: 'Angel',
+      };
+
+      // Execute
+      const createUserResult = await useCase.execute(user.id, userData);
+
+      // Assert result pattern
+      expect(createUserResult.success).toBe(false);
+      expect(!createUserResult.success && createUserResult.error.code).toBe('TECHNICAL_ERROR');
+
+      // Verify DB state
+      expect(userRepoMock.users).toHaveLength(10); // no users added
+    });
   });
 });

--- a/src/modules/user/application/use-cases/update-user.test.ts
+++ b/src/modules/user/application/use-cases/update-user.test.ts
@@ -1,0 +1,98 @@
+import '@testing-library/jest-dom';
+import { Failure } from '@/shared/domain/result';
+import { TechnicalError } from '@/shared/domain/errors/domain.errors';
+import { MockIdGenerator } from '@/shared/test/mocks/id-generator.repository.mock';
+import { UpdateUser } from '@/modules/user/application/use-cases/update-user';
+import { InMemoryUserRepository } from '@/modules/user/mocks/user.mocks.repository';
+import type { User } from '@/modules/user/domain/user.entity';
+import type { UpdateUserInput } from '@/modules/user/application/dtos/update-user.dto';
+
+describe('UpdateUser use case', () => {
+  describe('Happy Path', () => {
+    it('should update user successfully and persist them', async () => {
+      // Set up
+      const userRepoMock = new InMemoryUserRepository();
+      const createSpy = jest.spyOn(userRepoMock, 'update');
+      const useCase = new UpdateUser(userRepoMock);
+
+      // Data
+      const user = userRepoMock.users[0] as User;
+
+      // Verify DB state before execution
+      expect(userRepoMock.users[0]?.name).not.toBe('Angel');
+
+      // Execute
+      const updateUserResult = await useCase.execute(user.id, {
+        name: 'Angel',
+      });
+
+      // Assert interaction
+      expect(createSpy).toHaveBeenCalledTimes(1);
+
+      // Assert result pattern
+      expect(updateUserResult.success).toBe(true);
+      expect(updateUserResult.success && updateUserResult.data.id).toBe(user.id);
+      expect(updateUserResult.success && updateUserResult.data.name).toBe('Angel');
+
+      // Verify DB state
+      expect(userRepoMock.users).toHaveLength(10);
+      expect(userRepoMock.users[0]?.name).toBe('Angel');
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should return failure result when user not found', async () => {
+      // Set up
+      const userRepoMock = new InMemoryUserRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const createSpy = jest.spyOn(userRepoMock, 'update');
+      const useCase = new UpdateUser(userRepoMock);
+
+      // Config
+      userRepoMock.users[0]?.changeEmail('angel1234@gmail.com');
+      idGeneratorMock.id = 'user-id-1234';
+
+      // Data
+      const userData: UpdateUserInput = {
+        email: 'angel@gmail.com',
+        name: 'Angel',
+      };
+
+      // Execute
+      const updateUserResult = await useCase.execute('not-existing-id-1234', userData);
+
+      // Assert interaction -> do not update
+      expect(createSpy).toHaveBeenCalledTimes(0);
+
+      // Assert result pattern
+      expect(updateUserResult.success).toBe(false);
+      expect(!updateUserResult.success && updateUserResult.error.code).toBe('USER_NOT_FOUND');
+    });
+  });
+
+  describe('Dependency Interaction', () => {
+    it('sould return failure when repository update operation fails', async () => {
+      // Set up
+      const userRepoMock = new InMemoryUserRepository();
+      const useCase = new UpdateUser(userRepoMock);
+      jest.spyOn(userRepoMock, 'update').mockResolvedValue(Failure(new TechnicalError() as never));
+
+      // Data
+      const user = userRepoMock.users[0] as User;
+      const userData: UpdateUserInput = {
+        email: 'angel1234@gmail.com',
+        name: 'Angel',
+      };
+
+      // Execute
+      const createUserResult = await useCase.execute(user.id, userData);
+
+      // Assert result pattern
+      expect(createUserResult.success).toBe(false);
+      expect(!createUserResult.success && createUserResult.error.code).toBe('TECHNICAL_ERROR');
+
+      // Verify DB state
+      expect(userRepoMock.users).toHaveLength(10); // no users added
+    });
+  });
+});

--- a/src/modules/user/application/use-cases/update-user.ts
+++ b/src/modules/user/application/use-cases/update-user.ts
@@ -1,9 +1,9 @@
-import type { IUserRepository } from '@/modules/user/domain/user.repository';
-import type { UseCase } from '@/shared/application/use-case';
-import type { UpdateUserInput } from '../dtos/update-user.dto';
-import type { UserProps } from '../../domain/user.types';
 import { Failure } from '@/shared/domain/result';
-import { UserNotFoundError } from '../../domain/errors/user.errors';
+import { UserNotFoundError } from '@/modules/user/domain/errors/user.errors';
+import type { UseCase } from '@/shared/application/use-case';
+import type { UserProps } from '@/modules/user/domain/user.types';
+import type { IUserRepository } from '@/modules/user/domain/user.repository';
+import type { UpdateUserInput } from '@/modules/user/application/dtos/update-user.dto';
 
 export class UpdateUser implements UseCase {
   constructor(private repository: IUserRepository) {}
@@ -11,7 +11,8 @@ export class UpdateUser implements UseCase {
   async execute(id: UserProps['id'], data: UpdateUserInput) {
     const userResult = await this.repository.findById(id);
 
-    if (!userResult.success || !userResult.data) return Failure(new UserNotFoundError());
+    if (!userResult.success) return userResult;
+    if (!userResult.data) return Failure(new UserNotFoundError());
     const user = userResult.data;
 
     if (data.name) user.changeName(data.name);

--- a/src/modules/user/domain/user.repository.ts
+++ b/src/modules/user/domain/user.repository.ts
@@ -1,10 +1,10 @@
 import type { RepositoryResult } from '@/shared/domain/repository.result';
-import type { User } from './user.entity';
-import type { UserProps } from './user.types';
+import type { User } from '@/modules/user/domain/user.entity';
+import type { UserProps } from '@/modules/user/domain/user.types';
 
 export interface IUserRepository {
   create: (data: User) => RepositoryResult<User>;
-  update: (data: User) => RepositoryResult<User | null>;
+  update: (data: User) => RepositoryResult<User>;
   findAll: () => RepositoryResult<User[]>;
   findById: (id: UserProps['id']) => RepositoryResult<User | null>;
   findByEmail: (email: UserProps['email']) => RepositoryResult<User | null>;

--- a/src/modules/user/mocks/user.mocks.entities.ts
+++ b/src/modules/user/mocks/user.mocks.entities.ts
@@ -1,0 +1,114 @@
+import { User } from '../domain/user.entity';
+
+export const USERS_MOCK = [
+  new User({
+    id: '3f1c2a9e-1d4a-4f8c-9a2a-1b2c3d4e5f01',
+    name: 'Carlos Martínez',
+    email: 'carlos.mtz@gmail.com',
+    createdAt: new Date('2024-01-10T10:15:00Z'),
+    updatedAt: new Date('2024-02-12T14:20:00Z'),
+    role: {
+      id: 'base',
+      name: 'Base',
+    },
+  }),
+  new User({
+    id: '7b2d9c4f-2e6a-4c1f-8d3b-2c3d4e5f6a02',
+    name: 'Ana López',
+    email: 'ana.lopez@gmail.com',
+    createdAt: new Date('2024-03-05T09:00:00Z'),
+    updatedAt: new Date('2024-03-06T11:30:00Z'),
+    role: {
+      id: 'admin',
+      name: 'Admin',
+    },
+  }),
+  new User({
+    id: '1a9e3c7b-3f8d-4b2a-9c4d-3d4e5f6a7b03',
+    name: 'Luis Fernández',
+    email: 'luis.fernandez@gmail.com',
+    createdAt: new Date('2024-04-01T08:45:00Z'),
+    updatedAt: new Date('2024-04-02T10:10:00Z'),
+    role: {
+      id: 'base',
+      name: 'Base',
+    },
+  }),
+  new User({
+    id: '5c4d2e1f-4a9b-4d3c-8e5f-4e5f6a7b8c04',
+    name: 'María González',
+    email: 'maria.gonzalez@gmail.com',
+    createdAt: new Date('2024-05-12T13:20:00Z'),
+    updatedAt: new Date('2024-05-13T15:25:00Z'),
+    role: {
+      id: 'admin',
+      name: 'Admin',
+    },
+  }),
+  new User({
+    id: '8d5e3f2a-5b1c-4e4d-9f6a-5f6a7b8c9d05',
+    name: 'Jorge Ramírez',
+    email: 'jorge.ramirez@gmail.com',
+    createdAt: new Date('2024-06-18T07:10:00Z'),
+    updatedAt: new Date('2024-06-19T09:40:00Z'),
+    role: {
+      id: 'base',
+      name: 'Base',
+    },
+  }),
+  new User({
+    id: '9e6f4a3b-6c2d-4f5e-a07b-6a7b8c9d0e06',
+    name: 'Sofía Torres',
+    email: 'sofia.torres@gmail.com',
+    createdAt: new Date('2024-07-22T16:30:00Z'),
+    updatedAt: new Date('2024-07-23T18:00:00Z'),
+    role: {
+      id: 'admin',
+      name: 'Admin',
+    },
+  }),
+  new User({
+    id: 'af7a5b4c-7d3e-406f-b18c-7b8c9d0e1f07',
+    name: 'Pedro Sánchez',
+    email: 'pedro.sanchez@gmail.com',
+    createdAt: new Date('2024-08-10T11:55:00Z'),
+    updatedAt: new Date('2024-08-11T13:15:00Z'),
+    role: {
+      id: 'base',
+      name: 'Base',
+    },
+  }),
+  new User({
+    id: 'bf8b6c5d-8e4f-4170-c29d-8c9d0e1f2a08',
+    name: 'Lucía Herrera',
+    email: 'lucia.herrera@gmail.com',
+    createdAt: new Date('2024-09-14T06:40:00Z'),
+    updatedAt: new Date('2024-09-15T08:50:00Z'),
+    role: {
+      id: 'admin',
+      name: 'Admin',
+    },
+  }),
+  new User({
+    id: 'cf9c7d6e-9f50-4281-d3ae-9d0e1f2a3b09',
+    name: 'Diego Cruz',
+    email: 'diego.cruz@gmail.com',
+    createdAt: new Date('2024-10-01T12:00:00Z'),
+    updatedAt: new Date('2024-10-02T14:10:00Z'),
+    role: {
+      id: 'base',
+      name: 'Base',
+    },
+  }),
+  new User({
+    id: 'dfad8e7f-a061-4392-e4bf-0e1f2a3b4c10',
+    name: 'Valeria Méndez',
+    email: 'valeria.mendez@gmail.com',
+    createdAt: new Date('2024-11-20T17:25:00Z'),
+    updatedAt: new Date('2024-11-21T19:35:00Z'),
+    role: {
+      id: 'admin',
+      name: 'Admin',
+    },
+  }),
+];

--- a/src/modules/user/mocks/user.mocks.repository.ts
+++ b/src/modules/user/mocks/user.mocks.repository.ts
@@ -1,0 +1,36 @@
+import { Failure, Success } from '@/shared/domain/result';
+import { USERS_MOCK } from '@/modules/user/mocks/user.mocks.entities';
+import type { User } from '@/modules/user/domain/user.entity';
+import type { UserProps } from '@/modules/user/domain/user.types';
+import type { IUserRepository } from '@/modules/user/domain/user.repository';
+import { UserNotFoundError } from '../domain/errors/user.errors';
+
+/**
+ * An in-memory mock implementation of IUserRepository for testing purposes.
+ *
+ * @property users: An array of User entities, initialized with 10 mock users by default.
+ */
+export class InMemoryUserRepository implements IUserRepository {
+  public users: User[] = [...USERS_MOCK];
+  async create(data: User) {
+    this.users.push(data);
+    return Success(data);
+  }
+  async findAll() {
+    return Success(this.users);
+  }
+  async findByEmail(email: UserProps['email']) {
+    const user = this.users.find((u) => u.email === email);
+    return Success(user ?? null);
+  }
+  async findById(id: UserProps['id']) {
+    const user = this.users.find((u) => u.id === id);
+    return Success(user ?? null);
+  }
+  async update(data: User) {
+    const userIndex = this.users.findIndex((u) => u.id === data.id);
+    if (userIndex === -1) return Failure(new UserNotFoundError());
+    this.users[userIndex] = data;
+    return Success(data);
+  }
+}

--- a/src/shared/domain/result.ts
+++ b/src/shared/domain/result.ts
@@ -1,4 +1,8 @@
-export type Result<T, E> = { success: false; error: E } | { success: true; data: T };
+import type { DomainError } from './errors/domain.errors';
+
+export type Result<T, E extends DomainError> =
+  | { success: false; error: E }
+  | { success: true; data: T };
 
 export function Success<T>(data: T): Result<T, never> {
   return {
@@ -7,7 +11,7 @@ export function Success<T>(data: T): Result<T, never> {
   };
 }
 
-export function Failure<E>(error: E): Result<never, E> {
+export function Failure<E extends DomainError>(error: E): Result<never, E> {
   return {
     success: false,
     error,

--- a/src/shared/test/mocks/id-generator.repository.mock.ts
+++ b/src/shared/test/mocks/id-generator.repository.mock.ts
@@ -1,0 +1,13 @@
+import type { IdGeneratorRepository } from '@/shared/application/id-generator';
+
+/**
+ * Mock for IdGeneratorRepository to control ID generation in tests.
+ *
+ * @property id: the string returned in `generate` method.
+ */
+export class MockIdGenerator implements IdGeneratorRepository {
+  public id: string = 'Hello';
+  generate() {
+    return this.id;
+  }
+}


### PR DESCRIPTION
## New Feature: Unit tests for `CreateUser` and `UpdateUser` use cases

### Overview

- **Ticket:** This PR closes #112 
- **Main Goal:**: add a base coverage of application layer with unit tests for `CreateUser` and `UpdateUser` use cases
- **User Impact:** add reliability to user management processes

### Architectural Impact

- [ ] **Domain:** N/A
- [x] **Application:** unit tests implementation for `CreateUser`, `UpdateUser` use cases
- [ ] **Infrastructure:**  N/A
- [ ] **Presentation:** N/A

### Technical Implementation Details

- **Logic Placement:** Mocks/fakes are created to satisfy use cases dependencies when tested to guarantee consistence of business logic
- **State Management:** in-memory repository mocks are used to verify the data persistence without a real database.
- **Data Fetching:** As domain operations use `Result Pattern` it makes easier to test happy paths and domain exceptions without throws

### Verification & Quality

- [x] **Unit Tests:** `CreateUser` and `UpdateUser` have 100% coverage
- [ ] **Integration:** N/A
- [x] **Types:** All types used for mocks satisfy the original contracts
- [x] **Performance:** tests are fast considering mocks are not consuming external services
- [ ] **Accessibility:** N/A

### Checklist

- [x] My code follows the project's style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally.
- [x] `pnpm typecheck` and `pnpm safe-fixes` pass without warning/errors.
---
