### PR TITLE
feat(GetAllUsers): add unit tests

### DIFF
--- a/src/modules/user/application/use-cases/get-all-users.test.ts
+++ b/src/modules/user/application/use-cases/get-all-users.test.ts
@@ -1,0 +1,42 @@
+import '@testing-library/jest-dom';
+import { Failure } from '@/shared/domain/result';
+import { TechnicalError } from '@/shared/domain/errors/domain.errors';
+import { InMemoryUserRepository } from '@/modules/user/mocks/user.mocks.repository';
+import { GetAllUsers } from '@/modules/user/application/use-cases/get-all-users';
+
+describe('GetAllUsers use case', () => {
+  describe('Happy Path', () => {
+    it('should get all users successfully', async () => {
+      // Set up
+      const userRepoMock = new InMemoryUserRepository();
+      const createSpy = jest.spyOn(userRepoMock, 'findAll');
+      const useCase = new GetAllUsers(userRepoMock);
+
+      // Execute
+      const getAllUsers = await useCase.execute();
+
+      // Assert interaction
+      expect(createSpy).toHaveBeenCalledTimes(1);
+
+      // Assert result pattern
+      expect(getAllUsers.success).toBe(true);
+      expect(getAllUsers.success && getAllUsers.data).toHaveLength(10);
+    });
+  });
+
+  describe('Dependency Interaction', () => {
+    it('should return failure when repository findAll operation fails', async () => {
+      // Set up
+      const userRepoMock = new InMemoryUserRepository();
+      const useCase = new GetAllUsers(userRepoMock);
+      jest.spyOn(userRepoMock, 'findAll').mockResolvedValue(Failure(new TechnicalError() as never));
+
+      // Execute
+      const createUserResult = await useCase.execute();
+
+      // Assert result pattern
+      expect(createUserResult.success).toBe(false);
+      expect(!createUserResult.success && createUserResult.error.code).toBe('TECHNICAL_ERROR');
+    });
+  });
+});


### PR DESCRIPTION
## New Feature: Unit tests for `GetAllUsers` use case

### Overview

- **Ticket:** This PR closes #113
- **Main Goal:**: add a base coverage of application layer with unit tests for `GetAllUsers` use case
- **User Impact:** add reliability to user management processes

### Architectural Impact

- [ ] **Domain:** N/A
- [x] **Application:** unit tests implementation for `GetAllUsers` use case
- [ ] **Infrastructure:**  N/A
- [ ] **Presentation:** N/A

### Technical Implementation Details

- **Logic Placement:** Mocks/fakes are used to satisfy use cases dependencies when tested to guarantee consistence of business logic
- **State Management:** in-memory repository mocks are used to verify the data persistence without a real database.
- **Data Fetching:** As domain operations use `Result Pattern` it makes easier to test happy paths and domain exceptions without throws

### Verification & Quality

- [x] **Unit Tests:** `GetAllUsers` use case have 100% coverage
- [ ] **Integration:** N/A
- [x] **Types:** All mocks used satisfy the original contracts
- [x] **Performance:** tests are fast considering mocks are not consuming external services
- [ ] **Accessibility:** N/A

### Checklist

- [x] My code follows the project's style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally.
- [x] `pnpm typecheck` and `pnpm safe-fixes` pass without warning/errors.
---
