### PR TITLE
feat(user tests): add unit tests for GetUserById, GetUserByEmail use cases

### DIFF
--- a/src/modules/user/application/use-cases/get-user-by-email.test.ts
+++ b/src/modules/user/application/use-cases/get-user-by-email.test.ts
@@ -1,0 +1,56 @@
+import '@testing-library/jest-dom';
+import { Failure } from '@/shared/domain/result';
+import { TechnicalError } from '@/shared/domain/errors/domain.errors';
+import { InMemoryUserRepository } from '@/modules/user/mocks/user.mocks.repository';
+import { GetUserByEmail } from '@/modules/user/application/use-cases/get-user-by-email';
+import type { User } from '@/modules/user/domain/user.entity';
+
+describe('GetUserById use case', () => {
+  describe('Happy Path', () => {
+    it('should get user by email successfully', async () => {
+      // Set up
+      const userRepoMock = new InMemoryUserRepository();
+      const findByEmailSpy = jest.spyOn(userRepoMock, 'findByEmail');
+      const useCase = new GetUserByEmail(userRepoMock);
+
+      // Data
+      const user = userRepoMock.users[0] as User;
+
+      // Execute
+      const getUserByEmail = await useCase.execute(user.email);
+      const getUserByEmailNotFound = await useCase.execute('email.never@gmail.com');
+
+      // Assert interaction
+      expect(findByEmailSpy).toHaveBeenCalledTimes(2);
+
+      // Assert result pattern when user found
+      expect(getUserByEmail.success).toBe(true);
+      expect(getUserByEmail.success && getUserByEmail.data).toBe(user);
+      // Assert result pattern When user NOT found
+      expect(getUserByEmailNotFound.success).toBe(true);
+      expect(getUserByEmailNotFound.success && getUserByEmailNotFound.data).toBe(null);
+    });
+  });
+
+  describe('Dependency Interaction', () => {
+    it('should return failure when user findByEmail operation fails', async () => {
+      // Set up
+      const userRepoMock = new InMemoryUserRepository();
+      const findByEmailSpy = jest.spyOn(userRepoMock, 'findByEmail');
+      const useCase = new GetUserByEmail(userRepoMock);
+      jest
+        .spyOn(userRepoMock, 'findByEmail')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+
+      // Execute
+      const getUserByEmail = await useCase.execute('email.never@gmail.com');
+
+      // Assert interaction
+      expect(findByEmailSpy).toHaveBeenCalledTimes(1);
+
+      // Assert result pattern
+      expect(getUserByEmail.success).toBe(false);
+      expect(!getUserByEmail.success && getUserByEmail.error.code).toBe('TECHNICAL_ERROR');
+    });
+  });
+});

--- a/src/modules/user/application/use-cases/get-user-by-id.test.ts
+++ b/src/modules/user/application/use-cases/get-user-by-id.test.ts
@@ -1,0 +1,56 @@
+import '@testing-library/jest-dom';
+import { Failure } from '@/shared/domain/result';
+import { TechnicalError } from '@/shared/domain/errors/domain.errors';
+import { InMemoryUserRepository } from '@/modules/user/mocks/user.mocks.repository';
+import { GetUserById } from '@/modules/user/application/use-cases/get-user-by-id';
+import type { User } from '@/modules/user/domain/user.entity';
+
+describe('GetUserById use case', () => {
+  describe('Happy Path', () => {
+    it('should get user by id successfully', async () => {
+      // Set up
+      const userRepoMock = new InMemoryUserRepository();
+      const findByIdSpy = jest.spyOn(userRepoMock, 'findById');
+      const useCase = new GetUserById(userRepoMock);
+
+      // Data
+      const user = userRepoMock.users[0] as User;
+
+      // Execute
+      const getUserById = await useCase.execute(user.id);
+      const getUserByIdNotFound = await useCase.execute('userid-never-1234');
+
+      // Assert interaction
+      expect(findByIdSpy).toHaveBeenCalledTimes(2);
+
+      // Assert result pattern when user found
+      expect(getUserById.success).toBe(true);
+      expect(getUserById.success && getUserById.data).toBe(user);
+      // Assert result pattern when user NOT found
+      expect(getUserByIdNotFound.success).toBe(true);
+      expect(getUserByIdNotFound.success && getUserByIdNotFound.data).toBe(null);
+    });
+  });
+
+  describe('Dependency Interaction', () => {
+    it('should return failure when user findById operation fails', async () => {
+      // Set up
+      const userRepoMock = new InMemoryUserRepository();
+      const findByIdSpy = jest.spyOn(userRepoMock, 'findById');
+      const useCase = new GetUserById(userRepoMock);
+      jest
+        .spyOn(userRepoMock, 'findById')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+
+      // Execute
+      const getUserById = await useCase.execute('userid-never-1234');
+
+      // Assert interaction
+      expect(findByIdSpy).toHaveBeenCalledTimes(1);
+
+      // Assert result pattern
+      expect(getUserById.success).toBe(false);
+      expect(!getUserById.success && getUserById.error.code).toBe('TECHNICAL_ERROR');
+    });
+  });
+});

--- a/src/modules/user/application/use-cases/get-user-by-id.ts
+++ b/src/modules/user/application/use-cases/get-user-by-id.ts
@@ -1,10 +1,11 @@
 import type { UseCase } from '@/shared/application/use-case';
+import type { UserProps } from '@/modules/user/domain/user.types';
 import type { IUserRepository } from '@/modules/user/domain/user.repository';
 
 export class GetUserById implements UseCase {
   constructor(private repository: IUserRepository) {}
 
-  async execute(id: string) {
+  async execute(id: UserProps['id']) {
     return await this.repository.findById(id);
   }
 }


### PR DESCRIPTION
## New Feature: Unit tests for `GetUserById`, `GetUserByEmail` use cases

### Overview

- **Ticket:** This PR closes #114 
- **Main Goal:**: add a base coverage of application layer with unit tests for ``GetUserById`, `GetUserByEmail` use cases
- **User Impact:** add reliability to user management processes

### Architectural Impact

- [ ] **Domain:** N/A
- [x] **Application:** unit tests implementation for `GetUserById`, `GetUserByEmail` use cases
- [ ] **Infrastructure:**  N/A
- [ ] **Presentation:** N/A

### Technical Implementation Details

- **Logic Placement:** Mocks/fakes are used to satisfy use cases dependencies when tested to guarantee consistence of business logic
- **State Management:** in-memory repository mocks are used to verify the data persistence without a real database.
- **Data Fetching:** As domain operations use `Result Pattern` it makes easier to test happy paths and domain exceptions without throws

### Verification & Quality

- [x] **Unit Tests:**`GetUserById`, `GetUserByEmail` use cases have 100% coverage
- [ ] **Integration:** N/A
- [x] **Types:** All mocks used satisfy the original contracts
- [x] **Performance:** tests are fast considering mocks are not consuming external services
- [ ] **Accessibility:** N/A

### Checklist

- [x] My code follows the project's style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally.
- [x] `pnpm typecheck` and `pnpm safe-fixes` pass without warning/errors.
---
