### PR TITLE
feat(user): add unit tests for GetCurrentUser and GetCurrentUserId use cases

### DIFF
--- a/src/modules/auth/mocks/auth.mocks.repository.ts
+++ b/src/modules/auth/mocks/auth.mocks.repository.ts
@@ -1,0 +1,14 @@
+import { Success } from '@/shared/domain/result';
+import type { RepositoryResult } from '@/shared/domain/repository.result';
+import type { IAuthRepository } from '@/modules/auth/domain/auth.respository';
+import type { AuthSession } from '@/modules/auth/domain/errors/auth-session.types';
+
+/**
+ * @property session: An `AuthSession` | `null` type to control fake-active session
+ */
+export class MockAuthRepository implements IAuthRepository {
+  public session: AuthSession | null = null;
+  async getSession(): RepositoryResult<AuthSession | null> {
+    return Success(this.session);
+  }
+}

--- a/src/modules/user/application/use-cases/get-current-user-id.test.ts
+++ b/src/modules/user/application/use-cases/get-current-user-id.test.ts
@@ -1,0 +1,132 @@
+import '@testing-library/jest-dom';
+import { Failure } from '@/shared/domain/result';
+import { TechnicalError } from '@/shared/domain/errors/domain.errors';
+import { InMemoryUserRepository } from '@/modules/user/mocks/user.mocks.repository';
+import { MockAuthRepository } from '@/modules/auth/mocks/auth.mocks.repository';
+import { GetCurrentUserId } from '@/modules/user/application/use-cases/get-current-user-id';
+import type { User } from '@/modules/user/domain/user.entity';
+
+describe('GetUserById use case', () => {
+  describe('Happy Path', () => {
+    it('should get current user ID successfully', async () => {
+      // Set up
+      const userRepoMock = new InMemoryUserRepository();
+      const authRepoMock = new MockAuthRepository();
+      const findByEmailSpy = jest.spyOn(userRepoMock, 'findByEmail');
+      const useCase = new GetCurrentUserId(userRepoMock, authRepoMock);
+
+      // Data
+      const user = userRepoMock.users[0] as User;
+      authRepoMock.session = {
+        avatar: 'https://www.images.com/',
+        email: user.email,
+      };
+
+      // Execute
+      const getCurrentUserId = await useCase.execute();
+
+      // Assert interaction
+      expect(findByEmailSpy).toHaveBeenCalledTimes(1);
+
+      // Assert result pattern
+      expect(getCurrentUserId.success).toBe(true);
+      expect(getCurrentUserId.success && getCurrentUserId.data).toBe(user.id);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should return failure when session not found', async () => {
+      // Set up
+      const userRepoMock = new InMemoryUserRepository();
+      const authRepoMock = new MockAuthRepository();
+      const getSessionSpy = jest.spyOn(authRepoMock, 'getSession');
+      const useCase = new GetCurrentUserId(userRepoMock, authRepoMock);
+
+      // Execute
+      const getCurrentUserId = await useCase.execute();
+
+      // Assert interaction
+      expect(getSessionSpy).toHaveBeenCalledTimes(1);
+
+      // Assert result pattern
+      expect(getCurrentUserId.success).toBe(false);
+      expect(!getCurrentUserId.success && getCurrentUserId.error.code).toBe('SESSION_NOT_FOUND');
+    });
+
+    it('should return failure when user email not found', async () => {
+      // Set up
+      const userRepoMock = new InMemoryUserRepository();
+      const authRepoMock = new MockAuthRepository();
+      const findByEmailSpy = jest.spyOn(userRepoMock, 'findByEmail');
+      const useCase = new GetCurrentUserId(userRepoMock, authRepoMock);
+
+      // Data
+      authRepoMock.session = {
+        avatar: '',
+        email: 'not.existing@gmail.com',
+      };
+
+      // Execute
+      const getCurrentUserId = await useCase.execute();
+
+      // Assert interaction
+      expect(findByEmailSpy).toHaveBeenCalledTimes(1);
+
+      // Assert result pattern
+      expect(getCurrentUserId.success).toBe(false);
+      expect(!getCurrentUserId.success && getCurrentUserId.error.code).toBe('USER_NOT_FOUND');
+    });
+  });
+
+  describe('Dependency Interaction', () => {
+    it('should return failure when auth getSession operation fails', async () => {
+      // Set up
+      const userRepoMock = new InMemoryUserRepository();
+      const authRepoMock = new MockAuthRepository();
+
+      const getSessionSpy = jest.spyOn(authRepoMock, 'getSession');
+      const useCase = new GetCurrentUserId(userRepoMock, authRepoMock);
+      jest
+        .spyOn(authRepoMock, 'getSession')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+
+      // Execute
+      const getCurrentUserId = await useCase.execute();
+
+      // Assert interaction
+      expect(getSessionSpy).toHaveBeenCalledTimes(1);
+
+      // Assert result pattern
+      expect(getCurrentUserId.success).toBe(false);
+      expect(!getCurrentUserId.success && getCurrentUserId.error.code).toBe('TECHNICAL_ERROR');
+    });
+
+    it('should return failure when user findByEmail operation fails', async () => {
+      // Set up
+      const userRepoMock = new InMemoryUserRepository();
+      const authRepoMock = new MockAuthRepository();
+      const findByEmailSpy = jest.spyOn(userRepoMock, 'findByEmail');
+      const useCase = new GetCurrentUserId(userRepoMock, authRepoMock);
+      jest
+        .spyOn(userRepoMock, 'findByEmail')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+
+      // Data
+      const user = userRepoMock.users[0] as User;
+      authRepoMock.session = {
+        avatar: 'https://www.images.com/',
+        email: user.email,
+      };
+
+      // Execute
+      const getCurrentUserId = await useCase.execute();
+
+      // Assert interaction
+      expect(findByEmailSpy).toHaveBeenCalledTimes(1);
+
+      // Assert result pattern
+      expect(getCurrentUserId.success).toBe(false);
+      expect(!getCurrentUserId.success && getCurrentUserId.error.code).toBe('TECHNICAL_ERROR');
+    });
+  });
+});

--- a/src/modules/user/application/use-cases/get-current-user-id.test.ts
+++ b/src/modules/user/application/use-cases/get-current-user-id.test.ts
@@ -6,13 +6,12 @@ import { MockAuthRepository } from '@/modules/auth/mocks/auth.mocks.repository';
 import { GetCurrentUserId } from '@/modules/user/application/use-cases/get-current-user-id';
 import type { User } from '@/modules/user/domain/user.entity';
 
-describe('GetUserById use case', () => {
+describe('GetCurrentUserId use case', () => {
   describe('Happy Path', () => {
     it('should get current user ID successfully', async () => {
       // Set up
       const userRepoMock = new InMemoryUserRepository();
       const authRepoMock = new MockAuthRepository();
-      const findByEmailSpy = jest.spyOn(userRepoMock, 'findByEmail');
       const useCase = new GetCurrentUserId(userRepoMock, authRepoMock);
 
       // Data
@@ -25,9 +24,6 @@ describe('GetUserById use case', () => {
       // Execute
       const getCurrentUserId = await useCase.execute();
 
-      // Assert interaction
-      expect(findByEmailSpy).toHaveBeenCalledTimes(1);
-
       // Assert result pattern
       expect(getCurrentUserId.success).toBe(true);
       expect(getCurrentUserId.success && getCurrentUserId.data).toBe(user.id);
@@ -39,25 +35,20 @@ describe('GetUserById use case', () => {
       // Set up
       const userRepoMock = new InMemoryUserRepository();
       const authRepoMock = new MockAuthRepository();
-      const getSessionSpy = jest.spyOn(authRepoMock, 'getSession');
       const useCase = new GetCurrentUserId(userRepoMock, authRepoMock);
 
       // Execute
       const getCurrentUserId = await useCase.execute();
-
-      // Assert interaction
-      expect(getSessionSpy).toHaveBeenCalledTimes(1);
 
       // Assert result pattern
       expect(getCurrentUserId.success).toBe(false);
       expect(!getCurrentUserId.success && getCurrentUserId.error.code).toBe('SESSION_NOT_FOUND');
     });
 
-    it('should return failure when user email not found', async () => {
+    it('should return failure when user not found by email', async () => {
       // Set up
       const userRepoMock = new InMemoryUserRepository();
       const authRepoMock = new MockAuthRepository();
-      const findByEmailSpy = jest.spyOn(userRepoMock, 'findByEmail');
       const useCase = new GetCurrentUserId(userRepoMock, authRepoMock);
 
       // Data
@@ -68,9 +59,6 @@ describe('GetUserById use case', () => {
 
       // Execute
       const getCurrentUserId = await useCase.execute();
-
-      // Assert interaction
-      expect(findByEmailSpy).toHaveBeenCalledTimes(1);
 
       // Assert result pattern
       expect(getCurrentUserId.success).toBe(false);
@@ -83,7 +71,6 @@ describe('GetUserById use case', () => {
       // Set up
       const userRepoMock = new InMemoryUserRepository();
       const authRepoMock = new MockAuthRepository();
-
       const getSessionSpy = jest.spyOn(authRepoMock, 'getSession');
       const useCase = new GetCurrentUserId(userRepoMock, authRepoMock);
       jest

--- a/src/modules/user/application/use-cases/get-current-user-id.ts
+++ b/src/modules/user/application/use-cases/get-current-user-id.ts
@@ -1,9 +1,9 @@
+import { Failure, Success } from '@/shared/domain/result';
+import { UserNotFoundError } from '@/modules/user/domain/errors/user.errors';
+import { SessionNotFoundError } from '@/modules/auth/domain/errors/auth.errors';
 import type { UseCase } from '@/shared/application/use-case';
 import type { IUserRepository } from '@/modules/user/domain/user.repository';
 import type { IAuthRepository } from '@/modules/auth/domain/auth.respository';
-import { Failure, Success } from '@/shared/domain/result';
-import { UserNotFoundError } from '../../domain/errors/user.errors';
-import { SessionNotFoundError } from '@/modules/auth/domain/errors/auth.errors';
 
 export class GetCurrentUserId implements UseCase {
   constructor(
@@ -12,11 +12,15 @@ export class GetCurrentUserId implements UseCase {
   ) {}
 
   async execute() {
-    const session = await this.authRepo.getSession();
-    if (!session.success || !session.data) return Failure(new SessionNotFoundError());
-    const { email } = session.data;
-    const user = await this.repository.findByEmail(email);
-    if (!user.success || !user.data) return Failure(new UserNotFoundError());
-    return Success(user.data.id);
+    const sessionResult = await this.authRepo.getSession();
+    if (!sessionResult.success) return sessionResult;
+    if (!sessionResult.data) return Failure(new SessionNotFoundError());
+
+    const { email } = sessionResult.data;
+    const userResult = await this.repository.findByEmail(email);
+    if (!userResult.success) return userResult;
+    if (!userResult.data) return Failure(new UserNotFoundError());
+
+    return Success(userResult.data.id);
   }
 }

--- a/src/modules/user/application/use-cases/get-current-user.test.ts
+++ b/src/modules/user/application/use-cases/get-current-user.test.ts
@@ -1,0 +1,134 @@
+import '@testing-library/jest-dom';
+import { Failure } from '@/shared/domain/result';
+import { TechnicalError } from '@/shared/domain/errors/domain.errors';
+import { InMemoryUserRepository } from '@/modules/user/mocks/user.mocks.repository';
+import { MockAuthRepository } from '@/modules/auth/mocks/auth.mocks.repository';
+import { GetCurrentUser } from '@/modules/user/application/use-cases/get-current-user';
+import type { User } from '@/modules/user/domain/user.entity';
+
+describe('GetUserById use case', () => {
+  describe('Happy Path', () => {
+    it('should get current user successfully', async () => {
+      // Set up
+      const userRepoMock = new InMemoryUserRepository();
+      const authRepoMock = new MockAuthRepository();
+      const findByEmailSpy = jest.spyOn(userRepoMock, 'findByEmail');
+      const getSessionSpy = jest.spyOn(authRepoMock, 'getSession');
+      const useCase = new GetCurrentUser(userRepoMock, authRepoMock);
+
+      // Data
+      const user = userRepoMock.users[0] as User;
+      authRepoMock.session = {
+        avatar: 'https://www.images.com/',
+        email: user.email,
+      };
+
+      // Execute
+      const getCurrentUser = await useCase.execute();
+
+      // Assert interaction
+      expect(findByEmailSpy).toHaveBeenCalledTimes(1);
+      expect(getSessionSpy).toHaveBeenCalledTimes(1);
+
+      // Assert result pattern
+      expect(getCurrentUser.success).toBe(true);
+      expect(getCurrentUser.success && getCurrentUser.data).toBe(user);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should return failure when session not found', async () => {
+      // Set up
+      const userRepoMock = new InMemoryUserRepository();
+      const authRepoMock = new MockAuthRepository();
+      const getSessionSpy = jest.spyOn(authRepoMock, 'getSession');
+      const useCase = new GetCurrentUser(userRepoMock, authRepoMock);
+
+      // Execute
+      const getCurrentUser = await useCase.execute();
+
+      // Assert interaction
+      expect(getSessionSpy).toHaveBeenCalledTimes(1);
+
+      // Assert result pattern
+      expect(getCurrentUser.success).toBe(false);
+      expect(!getCurrentUser.success && getCurrentUser.error.code).toBe('SESSION_NOT_FOUND');
+    });
+
+    it('should return failure when user email not found', async () => {
+      // Set up
+      const userRepoMock = new InMemoryUserRepository();
+      const authRepoMock = new MockAuthRepository();
+      const findByEmailSpy = jest.spyOn(userRepoMock, 'findByEmail');
+      const useCase = new GetCurrentUser(userRepoMock, authRepoMock);
+
+      // Data
+      authRepoMock.session = {
+        avatar: '',
+        email: 'not.existing@gmail.com',
+      };
+
+      // Execute
+      const getCurrentUser = await useCase.execute();
+
+      // Assert interaction
+      expect(findByEmailSpy).toHaveBeenCalledTimes(1);
+
+      // Assert result pattern
+      expect(getCurrentUser.success).toBe(false);
+      expect(!getCurrentUser.success && getCurrentUser.error.code).toBe('USER_NOT_FOUND');
+    });
+  });
+
+  describe('Dependency Interaction', () => {
+    it('should return failure when auth getSession operation fails', async () => {
+      // Set up
+      const userRepoMock = new InMemoryUserRepository();
+      const authRepoMock = new MockAuthRepository();
+
+      const getSessionSpy = jest.spyOn(authRepoMock, 'getSession');
+      const useCase = new GetCurrentUser(userRepoMock, authRepoMock);
+      jest
+        .spyOn(authRepoMock, 'getSession')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+
+      // Execute
+      const getCurrentUser = await useCase.execute();
+
+      // Assert interaction
+      expect(getSessionSpy).toHaveBeenCalledTimes(1);
+
+      // Assert result pattern
+      expect(getCurrentUser.success).toBe(false);
+      expect(!getCurrentUser.success && getCurrentUser.error.code).toBe('TECHNICAL_ERROR');
+    });
+
+    it('should return failure when user findByEmail operation fails', async () => {
+      // Set up
+      const userRepoMock = new InMemoryUserRepository();
+      const authRepoMock = new MockAuthRepository();
+      const findByEmailSpy = jest.spyOn(userRepoMock, 'findByEmail');
+      const useCase = new GetCurrentUser(userRepoMock, authRepoMock);
+      jest
+        .spyOn(userRepoMock, 'findByEmail')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+
+      // Data
+      const user = userRepoMock.users[0] as User;
+      authRepoMock.session = {
+        avatar: 'https://www.images.com/',
+        email: user.email,
+      };
+
+      // Execute
+      const getCurrentUser = await useCase.execute();
+
+      // Assert interaction
+      expect(findByEmailSpy).toHaveBeenCalledTimes(1);
+
+      // Assert result pattern
+      expect(getCurrentUser.success).toBe(false);
+      expect(!getCurrentUser.success && getCurrentUser.error.code).toBe('TECHNICAL_ERROR');
+    });
+  });
+});

--- a/src/modules/user/application/use-cases/get-current-user.test.ts
+++ b/src/modules/user/application/use-cases/get-current-user.test.ts
@@ -6,14 +6,12 @@ import { MockAuthRepository } from '@/modules/auth/mocks/auth.mocks.repository';
 import { GetCurrentUser } from '@/modules/user/application/use-cases/get-current-user';
 import type { User } from '@/modules/user/domain/user.entity';
 
-describe('GetUserById use case', () => {
+describe('GetCurrentUser use case', () => {
   describe('Happy Path', () => {
     it('should get current user successfully', async () => {
       // Set up
       const userRepoMock = new InMemoryUserRepository();
       const authRepoMock = new MockAuthRepository();
-      const findByEmailSpy = jest.spyOn(userRepoMock, 'findByEmail');
-      const getSessionSpy = jest.spyOn(authRepoMock, 'getSession');
       const useCase = new GetCurrentUser(userRepoMock, authRepoMock);
 
       // Data
@@ -26,10 +24,6 @@ describe('GetUserById use case', () => {
       // Execute
       const getCurrentUser = await useCase.execute();
 
-      // Assert interaction
-      expect(findByEmailSpy).toHaveBeenCalledTimes(1);
-      expect(getSessionSpy).toHaveBeenCalledTimes(1);
-
       // Assert result pattern
       expect(getCurrentUser.success).toBe(true);
       expect(getCurrentUser.success && getCurrentUser.data).toBe(user);
@@ -41,25 +35,20 @@ describe('GetUserById use case', () => {
       // Set up
       const userRepoMock = new InMemoryUserRepository();
       const authRepoMock = new MockAuthRepository();
-      const getSessionSpy = jest.spyOn(authRepoMock, 'getSession');
       const useCase = new GetCurrentUser(userRepoMock, authRepoMock);
 
       // Execute
       const getCurrentUser = await useCase.execute();
-
-      // Assert interaction
-      expect(getSessionSpy).toHaveBeenCalledTimes(1);
 
       // Assert result pattern
       expect(getCurrentUser.success).toBe(false);
       expect(!getCurrentUser.success && getCurrentUser.error.code).toBe('SESSION_NOT_FOUND');
     });
 
-    it('should return failure when user email not found', async () => {
+    it('should return failure when user not found by email', async () => {
       // Set up
       const userRepoMock = new InMemoryUserRepository();
       const authRepoMock = new MockAuthRepository();
-      const findByEmailSpy = jest.spyOn(userRepoMock, 'findByEmail');
       const useCase = new GetCurrentUser(userRepoMock, authRepoMock);
 
       // Data
@@ -70,9 +59,6 @@ describe('GetUserById use case', () => {
 
       // Execute
       const getCurrentUser = await useCase.execute();
-
-      // Assert interaction
-      expect(findByEmailSpy).toHaveBeenCalledTimes(1);
 
       // Assert result pattern
       expect(getCurrentUser.success).toBe(false);

--- a/src/modules/user/application/use-cases/get-current-user.ts
+++ b/src/modules/user/application/use-cases/get-current-user.ts
@@ -1,9 +1,9 @@
+import { Failure, Success } from '@/shared/domain/result';
+import { UserNotFoundError } from '@/modules/user/domain/errors/user.errors';
+import { SessionNotFoundError } from '@/modules/auth/domain/errors/auth.errors';
 import type { UseCase } from '@/shared/application/use-case';
 import type { IUserRepository } from '@/modules/user/domain/user.repository';
 import type { IAuthRepository } from '@/modules/auth/domain/auth.respository';
-import { Failure, Success } from '@/shared/domain/result';
-import { UserNotFoundError } from '../../domain/errors/user.errors';
-import { SessionNotFoundError } from '@/modules/auth/domain/errors/auth.errors';
 
 export class GetCurrentUser implements UseCase {
   constructor(
@@ -12,11 +12,15 @@ export class GetCurrentUser implements UseCase {
   ) {}
 
   async execute() {
-    const session = await this.authRepo.getSession();
-    if (!session.success || !session.data) return Failure(new SessionNotFoundError());
-    const { email } = session.data;
-    const user = await this.repository.findByEmail(email);
-    if (!user.success || !user.data) return Failure(new UserNotFoundError());
-    return Success(user.data);
+    const sessionResult = await this.authRepo.getSession();
+    if (!sessionResult.success) return sessionResult;
+    if (!sessionResult.data) return Failure(new SessionNotFoundError());
+
+    const { email } = sessionResult.data;
+    const userResult = await this.repository.findByEmail(email);
+    if (!userResult.success) return userResult;
+    if (!userResult.data) return Failure(new UserNotFoundError());
+
+    return Success(userResult.data);
   }
 }


### PR DESCRIPTION
## New Feature: Unit tests for `GetCurrentUser `, `GetCurrentUserId ` use cases

### Overview

- **Ticket:** This PR closes #115 
- **Main Goal:**: add a base coverage of application layer with unit tests for `GetCurrentUser `, `GetCurrentUserId ` use cases
- **User Impact:** add reliability to user management processes

### Architectural Impact

- [ ] **Domain:** N/A
- [x] **Application:** unit tests implementation for `GetCurrentUser `, `GetCurrentUserId ` use cases
- [ ] **Infrastructure:**  N/A
- [ ] **Presentation:** N/A

### Technical Implementation Details

- **Logic Placement:** Mocks/fakes are used/created to satisfy use cases dependencies when tested to guarantee consistence of business logic
- **State Management:** in-memory repository mocks are used to verify the data persistence without a real database.
- **Data Fetching:** As domain operations use `Result Pattern` it makes easier to test happy paths and domain exceptions without throws

### Verification & Quality

- [x] **Unit Tests:** `GetCurrentUser `, `GetCurrentUserId ` use cases have 100% coverage
- [ ] **Integration:** N/A
- [x] **Types:** All mocks used/created satisfy the original contracts
- [x] **Performance:** tests are fast considering mocks are not consuming external services
- [ ] **Accessibility:** N/A

### Checklist

- [x] My code follows the project's style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally.
- [x] `pnpm typecheck` and `pnpm safe-fixes` pass without warning/errors.
---
