### PR TITLE
feat(GetCurrentSession): add unit tests

### DIFF
--- a/src/modules/auth/application/use-cases/get-current-session.test.ts
+++ b/src/modules/auth/application/use-cases/get-current-session.test.ts
@@ -1,0 +1,52 @@
+import '@testing-library/jest-dom';
+import { MockAuthRepository } from '../../mocks/auth.mocks.repository';
+import { GetCurrentSession } from './get-current-session';
+import { Failure } from '@/shared/domain/result';
+import { TechnicalError } from '@/shared/domain/errors/domain.errors';
+
+describe('GetCurrentSession use case', () => {
+  describe('Happy Path', () => {
+    it('should get current session successfully', async () => {
+      const authRepoMock = new MockAuthRepository();
+      const getCurrentSession = new GetCurrentSession(authRepoMock);
+
+      // When session exists
+      authRepoMock.session = {
+        avatar: '',
+        email: 'email@gmail.com',
+      };
+      const sessionResult = await getCurrentSession.execute();
+
+      // When session not exists
+      authRepoMock.session = null;
+      const nullSessionResult = await getCurrentSession.execute();
+
+      // Assert result pattern - when session exists
+      expect(sessionResult.success).toBe(true);
+      expect(sessionResult.success && sessionResult.data?.email).toBe('email@gmail.com');
+
+      // Assert result pattern - when session not exists
+      expect(nullSessionResult.success).toBe(true);
+      expect(nullSessionResult.success && nullSessionResult.data).toBe(null);
+    });
+  });
+
+  describe('Dependency Interaction', () => {
+    it('should return failure when auth getSession operation fails', async () => {
+      const authRepoMock = new MockAuthRepository();
+      const getCurrentSession = new GetCurrentSession(authRepoMock);
+      const getCurrentSessionSpy = jest
+        .spyOn(authRepoMock, 'getSession')
+        .mockResolvedValueOnce(Failure(new TechnicalError() as never));
+
+      const sessionResult = await getCurrentSession.execute();
+
+      // Assert interaction
+      expect(getCurrentSessionSpy).toHaveBeenCalledTimes(1);
+
+      // Assert result pattern
+      expect(sessionResult.success).toBe(false);
+      expect(!sessionResult.success && sessionResult.error.code).toBe('TECHNICAL_ERROR');
+    });
+  });
+});


### PR DESCRIPTION
## New Feature: Unit tests for `GetCurrentSession` use case

### Overview

- **Ticket:** This PR closes #115 
- **Main Goal:**: add a base coverage of application layer with unit tests for `GetCurrentSession` use case
- **User Impact:** add reliability to user management processes

### Architectural Impact

- [ ] **Domain:** N/A
- [x] **Application:** unit tests implementation for `GetCurrentSession` use case
- [ ] **Infrastructure:**  N/A
- [ ] **Presentation:** N/A

### Technical Implementation Details

- **Logic Placement:** Mocks/fakes are used to satisfy use cases dependencies when tested to guarantee consistence of business logic
- **State Management:** in-memory repository mocks are used to verify the data persistence without a real database.
- **Data Fetching:** As domain operations use `Result Pattern` it makes easier to test happy paths and domain exceptions without throws

### Verification & Quality

- [x] **Unit Tests:** `GetCurrentSession` use case has 100% coverage
- [ ] **Integration:** N/A
- [x] **Types:** All mocks used satisfy the original contracts
- [x] **Performance:** tests are fast considering mocks are not consuming external services
- [ ] **Accessibility:** N/A

### Checklist

- [x] My code follows the project's style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally.
- [x] `pnpm typecheck` and `pnpm safe-fixes` pass without warning/errors.
---
