### PR TITLE
feat(auth): add Login and Logout unit tests

### DIFF
--- a/src/modules/auth/application/use-cases/login.test.ts
+++ b/src/modules/auth/application/use-cases/login.test.ts
@@ -1,10 +1,10 @@
 import '@testing-library/jest-dom';
-import { MockAuthRepository } from '../../mocks/auth.mocks.repository';
 import { Failure } from '@/shared/domain/result';
-import { TechnicalError } from '@/shared/domain/errors/domain.errors';
-import { Login } from './login';
-import { InMemoryUserRepository } from '@/modules/user/mocks/user.mocks.repository';
 import { MockIdGenerator } from '@/shared/test/mocks/id-generator.repository.mock';
+import { InMemoryUserRepository } from '@/modules/user/mocks/user.mocks.repository';
+import { MockAuthRepository } from '@/modules/auth/mocks/auth.mocks.repository';
+import { TechnicalError } from '@/shared/domain/errors/domain.errors';
+import { Login } from '@/modules/auth/application/use-cases/login';
 import type { User } from '@/modules/user/domain/user.entity';
 
 describe('Login use case', () => {

--- a/src/modules/auth/application/use-cases/login.test.ts
+++ b/src/modules/auth/application/use-cases/login.test.ts
@@ -1,0 +1,154 @@
+import '@testing-library/jest-dom';
+import { MockAuthRepository } from '../../mocks/auth.mocks.repository';
+import { Failure } from '@/shared/domain/result';
+import { TechnicalError } from '@/shared/domain/errors/domain.errors';
+import { Login } from './login';
+import { InMemoryUserRepository } from '@/modules/user/mocks/user.mocks.repository';
+import { MockIdGenerator } from '@/shared/test/mocks/id-generator.repository.mock';
+import type { User } from '@/modules/user/domain/user.entity';
+
+describe('Login use case', () => {
+  describe('Happy Path', () => {
+    it('should login and create user successfully when not registered', async () => {
+      const authRepoMock = new MockAuthRepository();
+      const userRepoMock = new InMemoryUserRepository();
+      const idGeneratorRepoMock = new MockIdGenerator();
+      const login = new Login(authRepoMock, userRepoMock, idGeneratorRepoMock);
+
+      const loginResult = await login.execute({
+        email: 'new.email@gmail.com',
+        name: 'New Name',
+      });
+
+      // Assert result pattern
+      expect(loginResult.success).toBe(true);
+      expect(loginResult.success && loginResult.data).toBe(null);
+
+      // Assert DB state
+      expect(userRepoMock.users).toHaveLength(11); // 10 + 1
+      expect(userRepoMock.users[10]?.name).toBe('New Name');
+    });
+
+    it('should login and not create user when already registered', async () => {
+      const authRepoMock = new MockAuthRepository();
+      const userRepoMock = new InMemoryUserRepository();
+      const idGeneratorRepoMock = new MockIdGenerator();
+      const login = new Login(authRepoMock, userRepoMock, idGeneratorRepoMock);
+
+      const user = userRepoMock.users[0] as User;
+
+      const loginResult = await login.execute({
+        email: user.email,
+        name: user.name,
+      });
+
+      // Assert result pattern
+      expect(loginResult.success).toBe(true);
+      expect(loginResult.success && loginResult.data).toBe(null);
+
+      // Assert DB state
+      expect(userRepoMock.users).toHaveLength(10); // no changes
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should return failure when a session is already active', async () => {
+      const authRepoMock = new MockAuthRepository();
+      const userRepoMock = new InMemoryUserRepository();
+      const idGeneratorRepoMock = new MockIdGenerator();
+      const login = new Login(authRepoMock, userRepoMock, idGeneratorRepoMock);
+
+      authRepoMock.session = {
+        avatar: '',
+        email: 'email@gmail.com',
+      };
+
+      const loginResult = await login.execute({
+        email: '',
+        name: '',
+      });
+
+      // Assert result pattern
+      expect(loginResult.success).toBe(false);
+      expect(!loginResult.success && loginResult.error.code).toBe('SESSION_ALREADY_ACTIVE');
+    });
+  });
+
+  describe('Dependency Interaction', () => {
+    it('should return failure when auth getSession operation fails', async () => {
+      const authRepoMock = new MockAuthRepository();
+      const userRepoMock = new InMemoryUserRepository();
+      const idGeneratorRepoMock = new MockIdGenerator();
+      const getSessionSpy = jest
+        .spyOn(authRepoMock, 'getSession')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+      const login = new Login(authRepoMock, userRepoMock, idGeneratorRepoMock);
+
+      const loginResult = await login.execute({ email: '', name: '' });
+
+      // Assert Interaction
+      expect(getSessionSpy).toHaveBeenCalledTimes(1);
+
+      // Assert Result pattern
+      expect(loginResult.success).toBe(false);
+      expect(!loginResult.success && loginResult.error.code).toBe('TECHNICAL_ERROR');
+    });
+
+    it('should return failure when user findByEmail operation fails', async () => {
+      const authRepoMock = new MockAuthRepository();
+      const userRepoMock = new InMemoryUserRepository();
+      const idGeneratorRepoMock = new MockIdGenerator();
+      const findByEmailSpy = jest
+        .spyOn(userRepoMock, 'findByEmail')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+      const login = new Login(authRepoMock, userRepoMock, idGeneratorRepoMock);
+
+      const loginResult = await login.execute({ email: '', name: '' });
+
+      // Assert Interaction
+      expect(findByEmailSpy).toHaveBeenCalledTimes(1);
+
+      // Assert Result pattern
+      expect(loginResult.success).toBe(false);
+      expect(!loginResult.success && loginResult.error.code).toBe('TECHNICAL_ERROR');
+    });
+
+    it('should return failure when user create operation fails', async () => {
+      const authRepoMock = new MockAuthRepository();
+      const userRepoMock = new InMemoryUserRepository();
+      const idGeneratorRepoMock = new MockIdGenerator();
+      const createSpy = jest
+        .spyOn(userRepoMock, 'create')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+      const login = new Login(authRepoMock, userRepoMock, idGeneratorRepoMock);
+
+      const loginResult = await login.execute({ email: '', name: '' });
+
+      // Assert Interaction
+      expect(createSpy).toHaveBeenCalledTimes(1);
+
+      // Assert Result pattern
+      expect(loginResult.success).toBe(false);
+      expect(!loginResult.success && loginResult.error.code).toBe('TECHNICAL_ERROR');
+    });
+
+    it('should return failure when idGenerator generate operation fails', async () => {
+      const authRepoMock = new MockAuthRepository();
+      const userRepoMock = new InMemoryUserRepository();
+      const idGeneratorRepoMock = new MockIdGenerator();
+      const generateSpy = jest
+        .spyOn(idGeneratorRepoMock, 'generate')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+      const login = new Login(authRepoMock, userRepoMock, idGeneratorRepoMock);
+
+      const loginResult = await login.execute({ email: '', name: '' });
+
+      // Assert Interaction
+      expect(generateSpy).toHaveBeenCalledTimes(1);
+
+      // Assert Result pattern
+      expect(loginResult.success).toBe(false);
+      expect(!loginResult.success && loginResult.error.code).toBe('TECHNICAL_ERROR');
+    });
+  });
+});

--- a/src/modules/auth/application/use-cases/logout.test.ts
+++ b/src/modules/auth/application/use-cases/logout.test.ts
@@ -1,8 +1,8 @@
 import '@testing-library/jest-dom';
-import { MockAuthRepository } from '../../mocks/auth.mocks.repository';
-import { Logout } from './logout';
-import { TechnicalError } from '@/shared/domain/errors/domain.errors';
 import { Failure } from '@/shared/domain/result';
+import { TechnicalError } from '@/shared/domain/errors/domain.errors';
+import { MockAuthRepository } from '@/modules/auth/mocks/auth.mocks.repository';
+import { Logout } from '@/modules/auth/application/use-cases/logout';
 
 describe('Logout use case', () => {
   describe('Happy Path', () => {

--- a/src/modules/auth/application/use-cases/logout.test.ts
+++ b/src/modules/auth/application/use-cases/logout.test.ts
@@ -1,0 +1,56 @@
+import '@testing-library/jest-dom';
+import { MockAuthRepository } from '../../mocks/auth.mocks.repository';
+import { Logout } from './logout';
+import { TechnicalError } from '@/shared/domain/errors/domain.errors';
+import { Failure } from '@/shared/domain/result';
+
+describe('Logout use case', () => {
+  describe('Happy Path', () => {
+    it('should logout successfully', async () => {
+      const authRepoMock = new MockAuthRepository();
+      const logout = new Logout(authRepoMock);
+      authRepoMock.session = {
+        avatar: '',
+        email: '',
+      };
+
+      const logoutResult = await logout.execute();
+
+      // Assert result pattern
+      expect(logoutResult.success).toBe(true);
+      expect(logoutResult.success && logoutResult.data).toBe(null);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should return failure when session not found', async () => {
+      const authRepoMock = new MockAuthRepository();
+      const logout = new Logout(authRepoMock);
+
+      const logoutResult = await logout.execute();
+
+      // Assert result pattern
+      expect(logoutResult.success).toBe(false);
+      expect(!logoutResult.success && logoutResult.error.code).toBe('SESSION_NOT_FOUND');
+    });
+  });
+
+  describe('Dependency Interaction', () => {
+    it('should return failure when auth getSession operation fails', async () => {
+      const authRepoMock = new MockAuthRepository();
+      const getSessionSpy = jest
+        .spyOn(authRepoMock, 'getSession')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+      const logout = new Logout(authRepoMock);
+
+      const logoutResult = await logout.execute();
+
+      // Assert interaction
+      expect(getSessionSpy).toHaveBeenCalledTimes(1);
+
+      // Assert result pattern
+      expect(logoutResult.success).toBe(false);
+      expect(!logoutResult.success && logoutResult.error.code).toBe('TECHNICAL_ERROR');
+    });
+  });
+});


### PR DESCRIPTION
## New Feature: Unit tests for `Login`, `Logout` use cases

### Overview

- **Ticket:** This PR closes #117
- **Main Goal:**: add a base coverage of application layer with unit tests for  `Login`, `Logout` use cases
- **User Impact:** add reliability to authentication management processes

### Architectural Impact

- [ ] **Domain:** N/A
- [x] **Application:** unit tests implementation for `Login`, `Logout` use cases
- [ ] **Infrastructure:**  N/A
- [ ] **Presentation:** N/A

### Technical Implementation Details

- **Logic Placement:** Mocks/fakes are used to satisfy use cases dependencies when tested to guarantee consistence of business logic
- **State Management:** in-memory repository mocks are used to verify the data persistence without a real database.
- **Data Fetching:** As domain operations use `Result Pattern` it makes easier to test happy paths and domain exceptions without throws

### Verification & Quality

- [x] **Unit Tests:** `Login`, `Logout` use cases have 100% coverage
- [ ] **Integration:** N/A
- [x] **Types:** All mocks used satisfy the original contracts
- [x] **Performance:** tests are fast considering mocks are not consuming external services
- [ ] **Accessibility:** N/A

### Checklist

- [x] My code follows the project's style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally.
- [x] `pnpm typecheck` and `pnpm safe-fixes` pass without warning/errors.
---
