### PR TITLE
refactor(user): improve UpdateUser use case logic

### DIFF
--- a/src/modules/user/application/helpers/update-user.use-case.helpers.ts
+++ b/src/modules/user/application/helpers/update-user.use-case.helpers.ts
@@ -1,0 +1,27 @@
+import { Success } from '@/shared/domain/result';
+import type { Result } from '@/shared/domain/result';
+import type { DomainError } from '@/shared/domain/errors/domain.errors';
+import type { User } from '@/modules/user/domain/user.entity';
+import type { UserMethods } from '@/modules/user/domain/user.types';
+import type { UpdateUserInput } from '@/modules/user/application/dtos/update-user.dto';
+
+type UpdateOperations = {
+  [K in keyof UpdateUserInput]: keyof UserMethods;
+};
+
+const updateOperations: UpdateOperations = {
+  name: 'changeName',
+  email: 'changeEmail',
+};
+
+export function updateUserProperties(data: UpdateUserInput, user: User): Result<null, DomainError> {
+  const dataKeys = Object.keys(data) as (keyof UpdateUserInput)[];
+  for (const key of dataKeys) {
+    const functionkey = updateOperations[key];
+    if (!functionkey || !data[key]) continue;
+    const newValue = data[key];
+    const updateResult = user[functionkey](newValue);
+    if (!updateResult.success) return updateResult;
+  }
+  return Success(null);
+}

--- a/src/modules/user/application/use-cases/update-user.test.ts
+++ b/src/modules/user/application/use-cases/update-user.test.ts
@@ -83,8 +83,9 @@ describe('UpdateUser use case', () => {
       // Data
       const user = userRepoMock.users[0] as User;
       const userData: UpdateUserInput = {
+        invalidKey: 'Skipped',
         name: 'New',
-      };
+      } as UpdateUserInput;
 
       // Execute
       const updateUserResult = await useCase.execute(user.id, userData);

--- a/src/modules/user/application/use-cases/update-user.ts
+++ b/src/modules/user/application/use-cases/update-user.ts
@@ -1,5 +1,6 @@
-import { Failure, Success } from '@/shared/domain/result';
+import { Failure } from '@/shared/domain/result';
 import { UserNotFoundError } from '@/modules/user/domain/errors/user.errors';
+import { updateUserProperties } from '@/modules/user/application/helpers/update-user.use-case.helpers';
 import type { UseCase } from '@/shared/application/shared.use-case';
 import type { UserProps } from '@/modules/user/domain/user.types';
 import type { IUserRepository } from '@/modules/user/domain/user.repository';
@@ -15,11 +16,8 @@ export class UpdateUser implements UseCase {
     if (!userResult.data) return Failure(new UserNotFoundError());
     const user = userResult.data;
 
-    const nameResult = data.name ? user.changeName(data.name) : Success(null);
-    if (!nameResult.success) return nameResult;
-
-    const emailResult = data.email ? user.changeEmail(data.email) : Success(null);
-    if (!emailResult.success) return emailResult;
+    const updateUserResult = updateUserProperties(data, user);
+    if (!updateUserResult.success) return updateUserResult;
 
     return await this.repository.update(user);
   }

--- a/src/modules/user/domain/user.types.ts
+++ b/src/modules/user/domain/user.types.ts
@@ -1,3 +1,5 @@
+import type { ClassMethods } from '@/shared/shared.types';
+import type { User } from '@/modules/user/domain/user.entity';
 import type { RoleIds } from '@/modules/user/domain/user.constants.roles';
 
 export type UserProps = {
@@ -15,3 +17,5 @@ export type UserProps = {
 export type UserFactoryData = Omit<UserProps, 'id' | 'createdAt' | 'updatedAt' | 'role'> & {
   roleId: string;
 };
+
+export type UserMethods = ClassMethods<User>;

--- a/src/shared/shared.types.d.ts
+++ b/src/shared/shared.types.d.ts
@@ -1,1 +1,9 @@
+import type { Result } from '@/shared/domain/result';
+
 export type NonEmptyString<T extends string> = T extends '' ? never : T;
+
+export type EntityMethod = (...args: any[]) => Result<any, DomainError>;
+
+export type ClassMethods<T> = {
+  [K in keyof T as T[K] extends EntityMethod ? K : never]: T[K];
+};


### PR DESCRIPTION
## Refactor: update `UpdateUser` use case logic

### Intent

- **Goal:** Apply `Open-Closed Principle` to `UpdateUser` use case
- **Refactor Type:**  `Readability` | 'Structural'

### Architectural Changes

- **Before:** if a new property need to be updated in `UpdateUser` logic needs to be changed
- **After:** Using `Chain of Responsibility` pattern we can handle `User` properties updates without touching `UpdateUser` logic
- **Pattern Used:** `Chain of Responsibility` | `Result Pattern`; every property update  is validated by internal logic of `User` methods using standardize results for better error handling

### Scope of Work

- [ ] **Code Cleanup:** N/A
- [x] **Abstraction:** Add `UpdateUser` helper abstraction to keep `Result Pattern` integration
- [x] **File Movement:** Add `UpdateUser` helper file in application layer

### Stability & Safety

- [x] **Behavioral Parity:** I have confirmed that the application behavior remains unchanged.
- [x] **Existing Tests:** All existing unit and integration tests pass.
- [ ] **New Tests:** N/A
- [x] **Static Analysis:** `pnpm typecheck` and `pnpm safe-fixes` pass without warnings.
---
