### PR TITLE
feat(routine): add result pattern to domain logic and its dependent use cases

### DIFF
--- a/src/modules/routine/application/use-cases/create-routine.ts
+++ b/src/modules/routine/application/use-cases/create-routine.ts
@@ -2,10 +2,8 @@ import { Failure } from '@/shared/domain/result';
 import { Routine } from '@/modules/routine/domain/routine.entity';
 import {
   InvalidRoutineDays,
-  RoutineCycleNotFound,
   RoutineNotFoundError,
 } from '@/modules/routine/domain/errors/routine.errors';
-import { CYCLE_TYPES } from '@/modules/routine/domain/constants/routine.constants.cycle-types';
 import type { CreateRoutineInput } from '@/modules/routine/application/dtos/create-routine.dto';
 import type { IdGeneratorRepository } from '@/shared/application/id-generator.repository';
 import type { IRoutineRepository } from '@/modules/routine/domain/routine.repository';
@@ -28,9 +26,6 @@ export class CreateRoutine implements UseCase {
     const routineId = idResult.data;
 
     const sessions: (Session | null)[] = [];
-
-    const cycleType = Object.values(CYCLE_TYPES).find((c) => c.id === routineData.cycleId);
-    if (!cycleType) return Failure(new RoutineCycleNotFound());
 
     for (const routineDay of routineData.routineDays) {
       if (!routineDay.sessionId) {
@@ -63,8 +58,12 @@ export class CreateRoutine implements UseCase {
       });
     }
 
-    const newRoutine = Routine.create(routineId, { ...routineData, cycle: cycleType, routineDays });
+    const newRoutineResult = Routine.create(routineId, {
+      ...routineData,
+      routineDays,
+    });
+    if (!newRoutineResult.success) return newRoutineResult;
 
-    return await this.routineRepository.create(newRoutine);
+    return await this.routineRepository.create(newRoutineResult.data);
   }
 }

--- a/src/modules/routine/application/use-cases/update-routine.ts
+++ b/src/modules/routine/application/use-cases/update-routine.ts
@@ -1,9 +1,5 @@
-import { CYCLE_TYPES } from '@/modules/routine/domain/constants/routine.constants.cycle-types';
 import { Failure } from '@/shared/domain/result';
-import {
-  RoutineCycleNotFound,
-  RoutineNotFoundError,
-} from '@/modules/routine/domain/errors/routine.errors';
+import { RoutineNotFoundError } from '@/modules/routine/domain/errors/routine.errors';
 import type { UseCase } from '@/shared/application/shared.use-case';
 import type { RoutineProps } from '@/modules/routine/domain/routine.types';
 import type { IRoutineRepository } from '@/modules/routine/domain/routine.repository';
@@ -27,15 +23,29 @@ export class UpdateRoutine implements UseCase {
 
     const routine = routineResult.data;
 
-    if (data.name) routine.changeName(data.name);
-    if (data.description) routine.changeDescription(data.description);
-    if (data.active) routine.changeActive(data.active);
-    if (data.days) routine.changeDays(data.days);
-    if (data.initialDate) routine.changeInitialDate(data.initialDate);
+    if (data.name) {
+      const nameResult = routine.changeName(data.name);
+      if (!nameResult.success) return nameResult;
+    }
+    if (data.description) {
+      const descResult = routine.changeDescription(data.description);
+      if (!descResult.success) return descResult;
+    }
+    if (data.active !== undefined) {
+      const activeResult = routine.changeActive(data.active);
+      if (!activeResult.success) return activeResult;
+    }
+    if (data.days) {
+      const daysResult = routine.changeDays(data.days);
+      if (!daysResult.success) return daysResult;
+    }
+    if (data.initialDate) {
+      const dateResult = routine.changeInitialDate(data.initialDate);
+      if (!dateResult.success) return dateResult;
+    }
     if (data.cycleId) {
-      const cycleType = Object.values(CYCLE_TYPES).find((c) => c.id === data.cycleId);
-      if (!cycleType) return Failure(new RoutineCycleNotFound());
-      routine.changeCycle(cycleType);
+      const cycleResult = routine.changeCycle(data.cycleId);
+      if (!cycleResult.success) return cycleResult;
     }
     if (data.routineDays) {
       const routineDays: RoutineProps['routineDays'] = [];
@@ -64,7 +74,8 @@ export class UpdateRoutine implements UseCase {
           session: sessionResult.data,
         });
       }
-      routine.changeRoutineDays(routineDays);
+      const routineDaysResult = routine.changeRoutineDays(routineDays);
+      if (!routineDaysResult.success) return routineDaysResult;
     }
 
     return await this.routineRepository.update(routine);

--- a/src/modules/routine/domain/routine.entity.ts
+++ b/src/modules/routine/domain/routine.entity.ts
@@ -1,4 +1,9 @@
-import type { RoutineProps } from '@/modules/routine/domain/routine.types';
+import { Failure, Success } from '@/shared/domain/result';
+import { InvalidRoutineData } from '@/modules/routine/domain/errors/routine.errors';
+import { CYCLE_TYPES } from '@/modules/routine/domain/constants/routine.constants.cycle-types';
+import type { Result } from '@/shared/domain/result';
+import type { DomainError } from '@/shared/domain/errors/domain.errors';
+import type { RoutineFactoryData, RoutineProps } from '@/modules/routine/domain/routine.types';
 
 export class Routine {
   constructor(private data: RoutineProps) {}
@@ -36,36 +41,55 @@ export class Routine {
   get routineDays() {
     return this.data.routineDays;
   }
-  changeName(name: string) {
+  changeName(name: RoutineProps['name']): Result<null, DomainError> {
     this.data.name = name;
+    return Success(null);
   }
-  changeDescription(description: string) {
+  changeDescription(description: RoutineProps['description']): Result<null, DomainError> {
     this.data.description = description;
+    return Success(null);
   }
-  changeActive(active: boolean) {
+  changeActive(active: RoutineProps['active']): Result<null, DomainError> {
     this.data.active = active;
+    return Success(null);
   }
-  changeDays(days: number) {
+  changeDays(days: RoutineProps['days']): Result<null, DomainError> {
     this.data.days = days;
+    return Success(null);
   }
-  changeInitialDate(initialDate: Date) {
+  changeInitialDate(initialDate: RoutineProps['initialDate']): Result<null, DomainError> {
     this.data.initialDate = initialDate;
+    return Success(null);
   }
-  changeCycle(cycle: RoutineProps['cycle']) {
+  changeCycle(cycleId: RoutineProps['cycle']['id']): Result<null, DomainError> {
+    const cycle = Object.values(CYCLE_TYPES).find((c) => c.id === cycleId);
+    if (!cycle) return Failure(new InvalidRoutineData('CYCLE'));
     this.data.cycle = cycle;
+    return Success(null);
   }
-  changeRoutineDays(routineDays: RoutineProps['routineDays']) {
+  changeRoutineDays(routineDays: RoutineProps['routineDays']): Result<null, DomainError> {
+    if (!routineDays || routineDays.length !== this.data.days) {
+      return Failure(new InvalidRoutineData('ROUTINE_DAYS_LENGTH'));
+    }
     this.data.routineDays = routineDays;
+    return Success(null);
   }
-  static create(
-    id: RoutineProps['id'],
-    data: Omit<RoutineProps, 'id' | 'createdAt' | 'updatedAt'>
-  ) {
-    return new Routine({
-      ...data,
-      id,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    });
+  static create(id: RoutineProps['id'], data: RoutineFactoryData): Result<Routine, DomainError> {
+    if (!data.routineDays || data.routineDays.length !== data.days) {
+      return Failure(new InvalidRoutineData('ROUTINE_DAYS_LENGTH'));
+    }
+
+    const cycle = Object.values(CYCLE_TYPES).find((c) => c.id === data.cycleId);
+    if (!cycle) return Failure(new InvalidRoutineData('CYCLE'));
+
+    return Success(
+      new Routine({
+        ...data,
+        id,
+        cycle,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+    );
   }
 }

--- a/src/modules/routine/domain/routine.types.ts
+++ b/src/modules/routine/domain/routine.types.ts
@@ -23,3 +23,8 @@ export type RoutineProps = {
     session: Session | null;
   }[];
 };
+
+export type RoutineFactoryData = Omit<RoutineProps, 'id' | 'createdAt' | 'updatedAt' | 'cycle'> & {
+  cycleId: string;
+};
+


### PR DESCRIPTION
## New Feature: Result Pattern Integration in Routine Entity and Use Cases

### Overview

- **Ticket:**: N/A
- **Main Goal:** Integrate the Result pattern into Routine entity methods and use cases to provide explicit error handling and type-safe error propagation.
- **User Impact:** Improved error handling in the application layer with consistent error flow from domain entities to use cases.

Architectural Impact

- [x] **Domain:** 
  - Routine entity methods (changeName, changeDescription, changeActive, changeDays, changeInitialDate, changeCycle, changeRoutineDays) now return Result<null, DomainError>
  - Routine.create() now validates cycleId and routineDays length, returning Result<Routine, DomainError>
  - Added RoutineFactoryData type to handle factory input with cycleId instead of full cycle object
- [x] **Application:** 
  - CreateRoutine use case now handles Result from Routine.create() 
  - UpdateRoutine use case now handles Result from all entity mutation methods
  - Removed redundant CYCLE_TYPES validation from use cases (now in entity)
- [ ] **Infrastructure:** N/A
- [ ] **Presentation:** N/A

Technical Implementation Details

- **Logic Placement:** Validation logic moved from Application layer (use cases) to Domain layer (entity). This ensures business rules are enforced at the entity level, making the entity self-validating and reusable.
- **State Management:** N/A
- **Data Fetching:** N/A

### Verification & Quality

- [ ] **Unit Tests:** N/A
- [ ] **Integration:** N/A
- [x] **Types:** `Result` type is used properly to keep `Result Pattern` structure
- [ ] **Performance:** N/A
- [ ] **Accessibility:** N/A

### Checklist

- [x] My code follows the project's style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally.

---