### PR TITLE
feat(routine): Add routine validation types, utilities, and unit tests

### DIFF
--- a/src/modules/routine/domain/routine.entity.test.ts
+++ b/src/modules/routine/domain/routine.entity.test.ts
@@ -1,0 +1,203 @@
+import '@testing-library/jest-dom';
+import { Routine } from './routine.entity';
+
+function createTestRoutine(): Routine {
+  const result = Routine.create('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
+    name: 'Test Routine',
+    description: 'Test description',
+    active: true,
+    days: 3,
+    initialDate: new Date(),
+    cycleId: 'week',
+    routineDays: [
+      { id: '1df38173-6fae-4abb-8cb2-ce33b6c24da1', name: 'Day 1', day: 1, session: null },
+      { id: '1df38173-6fae-4abb-8cb2-ce33b6c24da2', name: 'Day 2', day: 2, session: null },
+      { id: '1df38173-6fae-4abb-8cb2-ce33b6c24da3', name: 'Day 3', day: 3, session: null },
+    ],
+    userId: 'user-123',
+  });
+  if (!result.success) throw new Error('Failed to create routine');
+  return result.data;
+}
+
+describe('Routine entity', () => {
+  describe('create()', () => {
+    it('should create routine instance successfully', async () => {
+      const routineResult = Routine.create('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
+        name: 'My Routine',
+        description: 'Test description',
+        active: true,
+        days: 3,
+        initialDate: new Date(),
+        cycleId: 'week',
+        routineDays: [
+          { id: '1df38173-6fae-4abb-8cb2-ce33b6c24da1', name: 'Day 1', day: 1, session: null },
+          { id: '1df38173-6fae-4abb-8cb2-ce33b6c24da2', name: 'Day 2', day: 2, session: null },
+          { id: '1df38173-6fae-4abb-8cb2-ce33b6c24da3', name: 'Day 3', day: 3, session: null },
+        ],
+        userId: 'user-123',
+      });
+
+      expect(routineResult.success).toBe(true);
+      expect(routineResult.success && routineResult.data instanceof Routine).toBe(true);
+    });
+
+    it('should return failure when invalid id provided', async () => {
+      const routineResult = Routine.create('invalid-id', {
+        name: 'My Routine',
+        description: 'Test description',
+        active: true,
+        days: 3,
+        initialDate: new Date(),
+        cycleId: 'week',
+        routineDays: [
+          { id: '1df38173-6fae-4abb-8cb2-ce33b6c24da1', name: 'Day 1', day: 1, session: null },
+          { id: '1df38173-6fae-4abb-8cb2-ce33b6c24da2', name: 'Day 2', day: 2, session: null },
+          { id: '1df38173-6fae-4abb-8cb2-ce33b6c24da3', name: 'Day 3', day: 3, session: null },
+        ],
+        userId: 'user-123',
+      });
+
+      expect(routineResult.success).toBe(false);
+      expect(!routineResult.success && routineResult.error.code).toBe('INVALID_ROUTINE_DATA');
+    });
+  });
+
+  describe('changeName()', () => {
+    it('should change routine name successfully', async () => {
+      const routine = createTestRoutine();
+      const result = routine.changeName('New Name');
+      expect(result.success).toBe(true);
+      expect(result.success && result.data).toBe(null);
+      expect(routine.name).toBe('New Name');
+    });
+
+    it('should return failure when name is not a string', async () => {
+      const routine = createTestRoutine();
+      const result = routine.changeName(123 as never);
+      expect(result.success).toBe(false);
+      expect(!result.success && result.error.code).toBe('INVALID_ROUTINE_DATA.NAME');
+      expect(routine.name).not.toBe(123);
+    });
+  });
+
+  describe('changeDescription()', () => {
+    it('should change routine description successfully', async () => {
+      const routine = createTestRoutine();
+      const result = routine.changeDescription('New description');
+      expect(result.success).toBe(true);
+      expect(result.success && result.data).toBe(null);
+      expect(routine.description).toBe('New description');
+    });
+
+    it('should return failure when description is not a string or null', async () => {
+      const routine = createTestRoutine();
+      const result = routine.changeDescription(123 as never);
+      expect(result.success).toBe(false);
+      expect(routine.description).not.toBe(123);
+    });
+  });
+
+  describe('changeActive()', () => {
+    it('should change active status successfully', async () => {
+      const routine = createTestRoutine();
+      const result = routine.changeActive(false);
+      expect(result.success).toBe(true);
+      expect(result.success && result.data).toBe(null);
+      expect(routine.active).toBe(false);
+    });
+
+    it('should return failure when active is not a boolean', async () => {
+      const routine = createTestRoutine();
+      const result = routine.changeActive('true' as never);
+      expect(result.success).toBe(false);
+      expect(routine.active).not.toBe('true');
+    });
+  });
+
+  describe('changeDays()', () => {
+    it('should change days successfully', async () => {
+      const routine = createTestRoutine();
+      const result = routine.changeDays(5);
+      expect(result.success).toBe(true);
+      expect(result.success && result.data).toBe(null);
+      expect(routine.days).toBe(5);
+    });
+
+    it('should return failure when days is not a number', async () => {
+      const routine = createTestRoutine();
+      const result = routine.changeDays('5' as never);
+      expect(result.success).toBe(false);
+      expect(routine.days).not.toBe('5');
+    });
+  });
+
+  describe('changeInitialDate()', () => {
+    it('should change initial date successfully', async () => {
+      const newDate = new Date('2025-01-01');
+      const routine = createTestRoutine();
+      const result = routine.changeInitialDate(newDate);
+      expect(result.success).toBe(true);
+      expect(result.success && result.data).toBe(null);
+      expect(routine.initialDate).toBe(newDate);
+    });
+
+    it('should return failure when initialDate is not a Date', async () => {
+      const routine = createTestRoutine();
+      const result = routine.changeInitialDate('2024-01-01' as never);
+      expect(result.success).toBe(false);
+      expect(routine.initialDate).not.toBe('2024-01-01');
+    });
+  });
+
+  describe('changeCycle()', () => {
+    it('should change cycle successfully', async () => {
+      const routine = createTestRoutine();
+      const result = routine.changeCycle('custom');
+      expect(result.success).toBe(true);
+      expect(result.success && result.data).toBe(null);
+      expect(routine.cycle.id).toBe('custom');
+    });
+
+    it('should return failure when cycleId is not valid', async () => {
+      const routine = createTestRoutine();
+      const result = routine.changeCycle('invalid-cycle' as never);
+      expect(result.success).toBe(false);
+      expect(!result.success && result.error.code).toBe('INVALID_ROUTINE_DATA.CYCLE');
+      expect(routine.cycle.id).not.toBe('invalid-cycle');
+    });
+  });
+
+  describe('changeRoutineDays()', () => {
+    it('should change routine days successfully', async () => {
+      const routine = createTestRoutine();
+      const newRoutineDays = [
+        { id: '1df38173-6fae-4abb-8cb2-ce33b6c24da1', name: 'Day 1', day: 1, session: null },
+        { id: '1df38173-6fae-4abb-8cb2-ce33b6c24da2', name: 'Day 2', day: 2, session: null },
+      ];
+      const result = routine.changeRoutineDays(newRoutineDays);
+      expect(result.success).toBe(true);
+      expect(result.success && result.data).toBe(null);
+      expect(routine.routineDays).toEqual(newRoutineDays);
+      expect(routine.days).toBe(2);
+    });
+
+    it('should return failure when routineDays is not an array', async () => {
+      const routine = createTestRoutine();
+      const result = routine.changeRoutineDays('not-an-array' as never);
+      expect(result.success).toBe(false);
+      expect(routine.routineDays).not.toBe('not-an-array');
+    });
+
+    it('should return failure when routineDays are invalid objects', async () => {
+      const routine = createTestRoutine();
+      const newRoutineDays = [
+        { id: '15', name: 'Day 1', day: 0, session: null },
+        { id: '1df38173-6fae-4abb-8cb2-ce33b6c24da2', name: 'Day 2', day: 2, session: null },
+      ];
+      const result = routine.changeRoutineDays(newRoutineDays);
+      expect(result.success).toBe(false);
+      expect(routine.routineDays).not.toEqual(newRoutineDays);
+    });
+  });
+});

--- a/src/modules/routine/domain/routine.entity.ts
+++ b/src/modules/routine/domain/routine.entity.ts
@@ -1,6 +1,7 @@
 import { Failure, Success } from '@/shared/domain/result';
 import { InvalidRoutineData } from '@/modules/routine/domain/errors/routine.errors';
 import { CYCLE_TYPES } from '@/modules/routine/domain/constants/routine.constants.cycle-types';
+import { validateRoutine } from '@/modules/routine/domain/validation/routine.validation';
 import type { Result } from '@/shared/domain/result';
 import type { DomainError } from '@/shared/domain/errors/domain.errors';
 import type { RoutineFactoryData, RoutineProps } from '@/modules/routine/domain/routine.types';
@@ -75,21 +76,13 @@ export class Routine {
     return Success(null);
   }
   static create(id: RoutineProps['id'], data: RoutineFactoryData): Result<Routine, DomainError> {
-    if (!data.routineDays || data.routineDays.length !== data.days) {
-      return Failure(new InvalidRoutineData('ROUTINE_DAYS_LENGTH'));
-    }
+    const routineValidationResult = validateRoutine({
+      ...data,
+      id,
+    });
 
-    const cycle = Object.values(CYCLE_TYPES).find((c) => c.id === data.cycleId);
-    if (!cycle) return Failure(new InvalidRoutineData('CYCLE'));
-
-    return Success(
-      new Routine({
-        ...data,
-        id,
-        cycle,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      })
-    );
+    if (!routineValidationResult.success) return routineValidationResult;
+    const routine = routineValidationResult.data;
+    return Success(routine);
   }
 }

--- a/src/modules/routine/domain/routine.entity.ts
+++ b/src/modules/routine/domain/routine.entity.ts
@@ -1,7 +1,10 @@
 import { Failure, Success } from '@/shared/domain/result';
 import { InvalidRoutineData } from '@/modules/routine/domain/errors/routine.errors';
 import { CYCLE_TYPES } from '@/modules/routine/domain/constants/routine.constants.cycle-types';
-import { validateRoutine } from '@/modules/routine/domain/validation/routine.validation';
+import {
+  routineValidators,
+  validateRoutine,
+} from '@/modules/routine/domain/validation/routine.validation';
 import type { Result } from '@/shared/domain/result';
 import type { DomainError } from '@/shared/domain/errors/domain.errors';
 import type { RoutineFactoryData, RoutineProps } from '@/modules/routine/domain/routine.types';
@@ -43,22 +46,29 @@ export class Routine {
     return this.data.routineDays;
   }
   changeName(name: RoutineProps['name']): Result<null, DomainError> {
+    if (!routineValidators.name.validate(name)) return Failure(routineValidators.name.error);
     this.data.name = name;
     return Success(null);
   }
   changeDescription(description: RoutineProps['description']): Result<null, DomainError> {
+    if (!routineValidators.description.validate(description))
+      return Failure(routineValidators.description.error);
     this.data.description = description;
     return Success(null);
   }
   changeActive(active: RoutineProps['active']): Result<null, DomainError> {
+    if (!routineValidators.active.validate(active)) return Failure(routineValidators.active.error);
     this.data.active = active;
     return Success(null);
   }
   changeDays(days: RoutineProps['days']): Result<null, DomainError> {
+    if (!routineValidators.days.validate(days)) return Failure(routineValidators.days.error);
     this.data.days = days;
     return Success(null);
   }
   changeInitialDate(initialDate: RoutineProps['initialDate']): Result<null, DomainError> {
+    if (!routineValidators.initialDate.validate(initialDate))
+      return Failure(routineValidators.initialDate.error);
     this.data.initialDate = initialDate;
     return Success(null);
   }
@@ -69,9 +79,11 @@ export class Routine {
     return Success(null);
   }
   changeRoutineDays(routineDays: RoutineProps['routineDays']): Result<null, DomainError> {
-    if (!routineDays || routineDays.length !== this.data.days) {
-      return Failure(new InvalidRoutineData('ROUTINE_DAYS_LENGTH'));
-    }
+    if (!routineValidators.routineDays.validate(routineDays))
+      return Failure(routineValidators.routineDays.error);
+    const daysResult = this.changeDays(routineDays.length);
+    if (!daysResult.success) return daysResult;
+
     this.data.routineDays = routineDays;
     return Success(null);
   }

--- a/src/modules/routine/domain/routine.types.ts
+++ b/src/modules/routine/domain/routine.types.ts
@@ -4,6 +4,13 @@ import type { Session } from '@/modules/session/domain/session.entity';
 import type { RoutineCycleId } from '@/modules/routine/domain/constants/routine.constants.cycle-types';
 import type { Routine } from '@/modules/routine/domain/routine.entity';
 
+export type RoutineDay = {
+  id: string;
+  name: string;
+  day: number;
+  session: Session | null;
+};
+
 export type RoutineProps = {
   readonly id: string;
   name: string;
@@ -18,12 +25,7 @@ export type RoutineProps = {
   readonly createdAt: Date;
   readonly updatedAt: Date;
   readonly userId: UserProps['id'];
-  routineDays: {
-    id: string;
-    name: string;
-    day: number;
-    session: Session | null;
-  }[];
+  routineDays: RoutineDay[];
 };
 
 export type RoutineFactoryData = Omit<RoutineProps, 'id' | 'createdAt' | 'updatedAt' | 'cycle'> & {

--- a/src/modules/routine/domain/routine.types.ts
+++ b/src/modules/routine/domain/routine.types.ts
@@ -1,6 +1,8 @@
-import type { Session } from '@/modules/session/domain/session.entity';
+import type { ClassMethods } from '@/shared/shared.types';
 import type { UserProps } from '@/modules/user/domain/user.types';
+import type { Session } from '@/modules/session/domain/session.entity';
 import type { RoutineCycleId } from '@/modules/routine/domain/constants/routine.constants.cycle-types';
+import type { Routine } from '@/modules/routine/domain/routine.entity';
 
 export type RoutineProps = {
   readonly id: string;
@@ -28,3 +30,4 @@ export type RoutineFactoryData = Omit<RoutineProps, 'id' | 'createdAt' | 'update
   cycleId: string;
 };
 
+export type RoutineMethods = ClassMethods<Routine>;

--- a/src/modules/routine/domain/validation/routine.routine-day.validation.ts
+++ b/src/modules/routine/domain/validation/routine.routine-day.validation.ts
@@ -1,0 +1,47 @@
+import { isKeyOf, isObject, isString, isValidUuid } from '@/shared/domain/validation.utils';
+import { Session } from '@/modules/session/domain/session.entity';
+import { isValidRoutineDays } from '@/modules/routine/domain/validation/routine.validation.utils';
+import type { ValidationFunction } from '@/shared/shared.types';
+import type { RoutineDay } from '@/modules/routine/domain/routine.types';
+
+const isValidRoutineDayId: ValidationFunction = (id: unknown) => {
+  return isValidUuid(id);
+};
+
+const isValidRoutineDayDay: ValidationFunction = (day: unknown) => {
+  return isValidRoutineDays(day);
+};
+
+const isValidRoutineDaySession: ValidationFunction = (session: unknown) => {
+  if (session === null) return true;
+  return session instanceof Session;
+};
+
+const isValidRoutineDayName: ValidationFunction = (name: unknown) => {
+  return isString(name);
+};
+
+type RoutineDaysValidations = {
+  [K in keyof RoutineDay]: ValidationFunction;
+};
+
+const routineDaysValidation: RoutineDaysValidations = {
+  id: isValidRoutineDayId,
+  day: isValidRoutineDayDay,
+  name: isValidRoutineDayName,
+  session: isValidRoutineDaySession,
+};
+
+export const isValidRoutineRoutineDay: ValidationFunction = (routineDay: unknown) => {
+  if (!isObject(routineDay)) return true;
+  const routineDayKeys = Object.keys(routineDaysValidation) as (keyof RoutineDay)[];
+
+  for (const key of routineDayKeys) {
+    if (!isKeyOf(key, routineDay)) return false;
+
+    const value = routineDay[key];
+    const validate = routineDaysValidation[key] as ValidationFunction;
+    if (!validate(value)) return false;
+  }
+  return true;
+};

--- a/src/modules/routine/domain/validation/routine.validation.constants.ts
+++ b/src/modules/routine/domain/validation/routine.validation.constants.ts
@@ -1,0 +1,14 @@
+export const ROUTINE_NAME_LENGTH = {
+  min: 4,
+  max: 30,
+} as const;
+
+export const ROUTINE_DAYS_LENGTH = {
+  min: 1,
+  max: 14,
+} as const;
+
+export const ROUTINE_DESCRIPTION_LENGTH = {
+  min: 0,
+  max: 100,
+} as const;

--- a/src/modules/routine/domain/validation/routine.validation.test.ts
+++ b/src/modules/routine/domain/validation/routine.validation.test.ts
@@ -1,0 +1,318 @@
+import '@testing-library/jest-dom';
+import { MockIdGenerator } from '@/shared/test/mocks/id-generator.repository.mock';
+import { validateRoutine } from './routine.validation';
+import { Routine } from '../routine.entity';
+
+describe('validateRoutine', () => {
+  describe('Happy path', () => {
+    it('should validate and return routine successfully', () => {
+      const idGeneratorMock = new MockIdGenerator();
+      const id = idGeneratorMock.id;
+
+      const validation = validateRoutine({
+        id,
+        name: 'Routine',
+        description: null,
+        active: true,
+        cycleId: 'week',
+        days: 1,
+        initialDate: new Date(),
+        routineDays: [
+          {
+            id,
+            day: 1,
+            name: 'Day 1',
+            session: null,
+          },
+        ],
+        userId: id,
+      });
+
+      expect(validation.success).toBe(true);
+      expect(validation.success && validation.data instanceof Routine).toBe(true);
+    });
+  });
+
+  describe('Exceptions', () => {
+    const idGeneratorMock = new MockIdGenerator();
+    const validId = idGeneratorMock.id;
+
+    const validRoutineData = {
+      id: validId,
+      name: 'Routine',
+      description: null,
+      active: true,
+      cycleId: 'week',
+      days: 1,
+      initialDate: new Date(),
+      routineDays: [
+        {
+          id: validId,
+          day: 1,
+          name: 'Day 1',
+          session: null,
+        },
+      ],
+      userId: validId,
+    };
+
+    describe('Input', () => {
+      it('should fail when invalid input', () => {
+        expect(() =>
+          validateRoutine(null as unknown as Parameters<typeof validateRoutine>[0])
+        ).toThrow();
+      });
+
+      it('should fail when any required key is missing', () => {
+        const { id: _, ...rest } = validRoutineData;
+        const validation = validateRoutine(rest as never);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe('INVALID_ROUTINE_DATA');
+      });
+    });
+
+    describe('ID field', () => {
+      it('should fail when is not a valid UUID', () => {
+        const validation = validateRoutine({
+          ...validRoutineData,
+          id: 'invalid-uuid',
+        } as unknown as Parameters<typeof validateRoutine>[0]);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe('INVALID_ROUTINE_DATA');
+      });
+
+      it('should fail when is not a string', () => {
+        const validation = validateRoutine({
+          ...validRoutineData,
+          id: 123,
+        } as unknown as Parameters<typeof validateRoutine>[0]);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe('INVALID_ROUTINE_DATA');
+      });
+    });
+
+    describe('NAME field', () => {
+      it('should fail is too short (less than 4 chars)', () => {
+        const validation = validateRoutine({
+          ...validRoutineData,
+          name: 'abc',
+        } as unknown as Parameters<typeof validateRoutine>[0]);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe(
+          'INVALID_ROUTINE_DATA.NAME'
+        );
+      });
+
+      it('should fail when is too long (more than 30 chars)', () => {
+        const validation = validateRoutine({
+          ...validRoutineData,
+          name: 'a'.repeat(31),
+        } as unknown as Parameters<typeof validateRoutine>[0]);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe(
+          'INVALID_ROUTINE_DATA.NAME'
+        );
+      });
+
+      it('should fail when is not a string', () => {
+        const validation = validateRoutine({
+          ...validRoutineData,
+          name: 123,
+        } as unknown as Parameters<typeof validateRoutine>[0]);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe(
+          'INVALID_ROUTINE_DATA.NAME'
+        );
+      });
+    });
+
+    describe('DESCRIPTION field', () => {
+      it('should fail when is not a string or null', () => {
+        const validation = validateRoutine({
+          ...validRoutineData,
+          description: 123,
+        } as unknown as Parameters<typeof validateRoutine>[0]);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe(
+          'INVALID_ROUTINE_DATA.DESCRIPTION'
+        );
+      });
+
+      it('should fail when is too long (more than 100 chars)', () => {
+        const validation = validateRoutine({
+          ...validRoutineData,
+          description: 'a'.repeat(101),
+        } as unknown as Parameters<typeof validateRoutine>[0]);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe(
+          'INVALID_ROUTINE_DATA.DESCRIPTION'
+        );
+      });
+    });
+
+    describe('ACTIVE field', () => {
+      it('should fail when is not a boolean', () => {
+        const validation = validateRoutine({
+          ...validRoutineData,
+          active: 'true',
+        } as unknown as Parameters<typeof validateRoutine>[0]);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe(
+          'INVALID_ROUTINE_DATA.ACTIVE'
+        );
+      });
+    });
+
+    describe('DAYS field', () => {
+      it('should fail when is not an integer', () => {
+        const validation = validateRoutine({
+          ...validRoutineData,
+          days: 1.5,
+        } as unknown as Parameters<typeof validateRoutine>[0]);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe(
+          'INVALID_ROUTINE_DATA.DAYS'
+        );
+      });
+
+      it('should fail when is out of range (less than 1)', () => {
+        const validation = validateRoutine({
+          ...validRoutineData,
+          days: 0,
+        } as unknown as Parameters<typeof validateRoutine>[0]);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe(
+          'INVALID_ROUTINE_DATA.DAYS'
+        );
+      });
+
+      it('should fail when is out of range (greater than 14)', () => {
+        const validation = validateRoutine({
+          ...validRoutineData,
+          days: 15,
+        } as unknown as Parameters<typeof validateRoutine>[0]);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe(
+          'INVALID_ROUTINE_DATA.DAYS'
+        );
+      });
+
+      it('should fail when is not a number', () => {
+        const validation = validateRoutine({
+          ...validRoutineData,
+          days: '1',
+        } as unknown as Parameters<typeof validateRoutine>[0]);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe(
+          'INVALID_ROUTINE_DATA.DAYS'
+        );
+      });
+
+      it('should fail when is not equal to routineDays length', () => {
+        const validation = validateRoutine({
+          ...validRoutineData,
+          days: 2,
+        } as unknown as Parameters<typeof validateRoutine>[0]);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe(
+          'INVALID_ROUTINE_DATA.ROUTINE_DAYS_LENGTH'
+        );
+      });
+    });
+
+    describe('INITIAL DATE field', () => {
+      it('should fail when is not a Date', () => {
+        const validation = validateRoutine({
+          ...validRoutineData,
+          initialDate: '2024-01-01',
+        } as unknown as Parameters<typeof validateRoutine>[0]);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe(
+          'INVALID_ROUTINE_DATA.INITIAL_DATE'
+        );
+      });
+    });
+
+    describe('ROUTINE DAYS field', () => {
+      it('should fail when is not an array', () => {
+        const validation = validateRoutine({
+          ...validRoutineData,
+          routineDays: 'not-an-array',
+        } as unknown as Parameters<typeof validateRoutine>[0]);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe(
+          'INVALID_ROUTINE_DATA.ROUTINE_DAYS'
+        );
+      });
+
+      describe("ROUTINE DAYS' fields", () => {
+        it('should fail missing a key', () => {
+          const validation = validateRoutine({
+            ...validRoutineData,
+            routineDays: [{ day: 1, name: 'Day 1', session: null }],
+          } as unknown as Parameters<typeof validateRoutine>[0]);
+          expect(validation.success).toBe(false);
+          expect(validation.success === false && validation.error.code).toBe(
+            'INVALID_ROUTINE_DATA.ROUTINE_DAYS'
+          );
+        });
+
+        it('should fail when has invalid day', () => {
+          const validation = validateRoutine({
+            ...validRoutineData,
+            routineDays: [{ id: validId, day: -1, name: 'Day 1', session: null }],
+          } as unknown as Parameters<typeof validateRoutine>[0]);
+          expect(validation.success).toBe(false);
+          expect(validation.success === false && validation.error.code).toBe(
+            'INVALID_ROUTINE_DATA.ROUTINE_DAYS'
+          );
+        });
+
+        it('should fail when has invalid name', () => {
+          const validation = validateRoutine({
+            ...validRoutineData,
+            routineDays: [{ id: validId, day: 1, session: null }],
+          } as unknown as Parameters<typeof validateRoutine>[0]);
+          expect(validation.success).toBe(false);
+          expect(validation.success === false && validation.error.code).toBe(
+            'INVALID_ROUTINE_DATA.ROUTINE_DAYS'
+          );
+        });
+      });
+    });
+
+    describe('CYCLE ID field', () => {
+      it('should fail when is not a valid cycle type', () => {
+        const validation = validateRoutine({
+          ...validRoutineData,
+          cycleId: 'invalid-cycle',
+        } as unknown as Parameters<typeof validateRoutine>[0]);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe(
+          'INVALID_ROUTINE_DATA.CYCLE'
+        );
+      });
+
+      it('should fail when is not a string', () => {
+        const validation = validateRoutine({
+          ...validRoutineData,
+          cycleId: null,
+        } as unknown as Parameters<typeof validateRoutine>[0]);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe(
+          'INVALID_ROUTINE_DATA.CYCLE'
+        );
+      });
+    });
+
+    describe('Extra non-existing keys', () => {
+      it('should pass when extra key exists in input', () => {
+        const validation = validateRoutine({
+          ...validRoutineData,
+          extraKey: 'value',
+        } as unknown as Parameters<typeof validateRoutine>[0]);
+        expect(validation.success).toBe(true);
+      });
+    });
+  });
+});

--- a/src/modules/routine/domain/validation/routine.validation.ts
+++ b/src/modules/routine/domain/validation/routine.validation.ts
@@ -27,7 +27,7 @@ type RoutineValidators = Record<
   }
 >;
 
-const routineValidators: RoutineValidators = {
+export const routineValidators: RoutineValidators = {
   id: { validate: isValidRoutineId, error: new InvalidRoutineData() },
   name: { validate: isValidRoutineName, error: new InvalidRoutineData('NAME') },
   description: {

--- a/src/modules/routine/domain/validation/routine.validation.ts
+++ b/src/modules/routine/domain/validation/routine.validation.ts
@@ -62,6 +62,9 @@ export function validateRoutine(routine: RoutineMiminumProps): Result<Routine, D
     if (!validator.validate(value)) return Failure(validator.error);
   }
 
+  if (routine.days !== routine.routineDays.length)
+    return Failure(new InvalidRoutineData('ROUTINE_DAYS_LENGTH'));
+
   const cycle = Object.values(CYCLE_TYPES).find((c) => c.id === routine.cycleId);
   if (!cycle) return Failure(new InvalidRoutineData('CYCLE'));
 

--- a/src/modules/routine/domain/validation/routine.validation.ts
+++ b/src/modules/routine/domain/validation/routine.validation.ts
@@ -1,0 +1,83 @@
+import { InvalidRoutineData } from '@/modules/routine/domain/errors/routine.errors';
+import { Failure, Success } from '@/shared/domain/result';
+import { Routine } from '@/modules/routine/domain/routine.entity';
+import { isKeyOf, isObject } from '@/shared/domain/validation.utils';
+import { CYCLE_TYPES } from '@/modules/routine/domain/constants/routine.constants.cycle-types';
+import {
+  areValidRoutineRoutineDays,
+  isValidRoutineActive,
+  isValidRoutineDays,
+  isValidRoutineDescription,
+  isValidRoutineId,
+  isValidRoutineInitialDate,
+  isValidRoutineName,
+} from '@/modules/routine/domain/validation/routine.validation.utils';
+import type { ValidationFunction } from '@/shared/shared.types';
+import type { Result } from '@/shared/domain/result';
+import type { DomainError } from '@/shared/domain/errors/domain.errors';
+import type { RoutineFactoryData, RoutineProps } from '@/modules/routine/domain/routine.types';
+
+type RoutineValidationKeys = Omit<RoutineProps, 'createdAt' | 'updatedAt' | 'cycle' | 'userId'>;
+
+type RoutineValidators = Record<
+  keyof RoutineValidationKeys,
+  {
+    validate: ValidationFunction;
+    error: DomainError;
+  }
+>;
+
+const routineValidators: RoutineValidators = {
+  id: { validate: isValidRoutineId, error: new InvalidRoutineData() },
+  name: { validate: isValidRoutineName, error: new InvalidRoutineData('NAME') },
+  description: {
+    validate: isValidRoutineDescription,
+    error: new InvalidRoutineData('DESCRIPTION'),
+  },
+  active: { validate: isValidRoutineActive, error: new InvalidRoutineData('ACTIVE') },
+  days: { validate: isValidRoutineDays, error: new InvalidRoutineData('DAYS') },
+  initialDate: {
+    validate: isValidRoutineInitialDate,
+    error: new InvalidRoutineData('INITIAL_DATE'),
+  },
+  routineDays: {
+    validate: areValidRoutineRoutineDays,
+    error: new InvalidRoutineData('ROUTINE_DAYS'),
+  },
+};
+
+type RoutineMiminumProps = RoutineFactoryData & {
+  id: RoutineProps['id'];
+};
+
+export function validateRoutine(routine: RoutineMiminumProps): Result<Routine, DomainError> {
+  if (!isObject(routine)) return Failure(new InvalidRoutineData());
+  const routineValidatorKeys = Object.keys(routineValidators) as (keyof RoutineValidationKeys)[];
+
+  for (const key of routineValidatorKeys) {
+    if (!isKeyOf(key, routineValidators)) return Failure(new InvalidRoutineData());
+    if (!isKeyOf(key, routine)) return Failure(new InvalidRoutineData());
+    const value = routine[key];
+    const validator = routineValidators[key];
+    if (!validator.validate(value)) return Failure(validator.error);
+  }
+
+  const cycle = Object.values(CYCLE_TYPES).find((c) => c.id === routine.cycleId);
+  if (!cycle) return Failure(new InvalidRoutineData('CYCLE'));
+
+  const domainRoutine = new Routine({
+    id: routine.id,
+    name: routine.name,
+    description: routine.description,
+    active: routine.active,
+    initialDate: routine.initialDate,
+    routineDays: routine.routineDays,
+    cycle,
+    days: routine.days,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    userId: routine.userId,
+  });
+
+  return Success(domainRoutine);
+}

--- a/src/modules/routine/domain/validation/routine.validation.utils.ts
+++ b/src/modules/routine/domain/validation/routine.validation.utils.ts
@@ -1,0 +1,56 @@
+import {
+  isArray,
+  isBoolean,
+  isDate,
+  isIntegerNumber,
+  isString,
+  isValidUuid,
+} from '@/shared/domain/validation.utils';
+import {
+  ROUTINE_DAYS_LENGTH,
+  ROUTINE_DESCRIPTION_LENGTH,
+  ROUTINE_NAME_LENGTH,
+} from '@/modules/routine/domain/validation/routine.validation.constants';
+import { isValidRoutineRoutineDay } from '@/modules/routine/domain/validation/routine.routine-day.validation';
+import type { ValidationFunction } from '@/shared/shared.types';
+
+export const isValidRoutineId: ValidationFunction = (id: unknown) => {
+  return isValidUuid(id);
+};
+
+export const isValidRoutineName: ValidationFunction = (name: unknown) => {
+  if (!isString(name)) return false;
+  const trimName = name.trim();
+  if (trimName.length < ROUTINE_NAME_LENGTH.min) return false;
+  return trimName.length <= ROUTINE_NAME_LENGTH.max;
+};
+
+export const isValidRoutineDescription: ValidationFunction = (description: unknown) => {
+  if (description === null) return true;
+  if (!isString(description)) return false;
+  const trimDescription = description.trim();
+  if (trimDescription.length < ROUTINE_DESCRIPTION_LENGTH.min) return false;
+  return trimDescription.length <= ROUTINE_DESCRIPTION_LENGTH.max;
+};
+
+export const isValidRoutineInitialDate: ValidationFunction = (initialDate: unknown) => {
+  return isDate(initialDate);
+};
+
+export const isValidRoutineActive: ValidationFunction = (active: unknown) => {
+  return isBoolean(active);
+};
+
+export const isValidRoutineDays: ValidationFunction = (days: unknown) => {
+  if (!isIntegerNumber(days)) return false;
+  if (days < ROUTINE_DAYS_LENGTH.min) return false;
+  return days <= ROUTINE_DAYS_LENGTH.max;
+};
+
+export const areValidRoutineRoutineDays: ValidationFunction = (routineDays: unknown) => {
+  if (!isArray(routineDays)) return false;
+  for (const routineDay of routineDays) {
+    if (!isValidRoutineRoutineDay(routineDay)) return false;
+  }
+  return true;
+};

--- a/src/modules/routine/domain/validation/routine.validation.utils.ts
+++ b/src/modules/routine/domain/validation/routine.validation.utils.ts
@@ -49,6 +49,7 @@ export const isValidRoutineDays: ValidationFunction = (days: unknown) => {
 
 export const areValidRoutineRoutineDays: ValidationFunction = (routineDays: unknown) => {
   if (!isArray(routineDays)) return false;
+  if (!isValidRoutineDays(routineDays.length)) return false;
   for (const routineDay of routineDays) {
     if (!isValidRoutineRoutineDay(routineDay)) return false;
   }


### PR DESCRIPTION
## New Feature: Routine Entity Validation Utilities

### Overview

- Ticket: #164 
- Main Goal: Add centralized validation utilities for routine entity fields following the chain of responsibility pattern.
- User Impact: N/A

### Architectural Impact

- [x] Domain: Validation utilities created in src/modules/routine/domain/validation/ folder; Routine entity uses validators for all mutator methods (changeName, changeDescription, changeActive, changeDays, changeInitialDate, changeRoutineDays)
- [ ] Application: (Use Cases, Port Definitions)
- [ ] Infrastructure: (Prisma Repositories, External APIs, Mappers)
- [ ] Presentation: (Next.js Pages, Server/Client Components, Server Actions)

### Technical Implementation Details

- Logic Placement: Validation utilities placed in dedicated validation folder within routine domain. Each field uses ValidationFunction type from @/shared/shared.types. The validateRoutine function implements chain of responsibility pattern - each field validates sequentially and stops on first failure.
- State Management: N/A
- Data Fetching: N/A

### Verification & Quality

- [x] Unit Tests: Business logic in Domain and Application layers is 100% tested.
- [ ] Integration: N/A
- [x] Types: No any used. All Prisma models are correctly mapped to Domain Entities.
- [ ] Performance: N/A
- [ ] Accessibility: N/A

### Checklist

- [x] My code follows the project's style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally.

---