### PR TITLE
feat(UpdateExercise): add fields update helper logic

### DIFF
--- a/src/modules/exercise/application/helpers/update-exercise.helper.ts
+++ b/src/modules/exercise/application/helpers/update-exercise.helper.ts
@@ -1,0 +1,42 @@
+import type { Result } from '@/shared/domain/result';
+import type { ExerciseMethods } from '@/modules/exercise/domain/exercise.types';
+import type { DomainError } from '@/shared/domain/errors/domain.errors';
+import type { Exercise } from '@/modules/exercise/domain/exercise.entity';
+import type { UpdateExerciseInput } from '@/modules/exercise/application/dtos/update-exercise.dto';
+import { Failure, Success } from '@/shared/domain/result';
+import { isKeyOf, isObject } from '@/shared/domain/validation.utils';
+import { InvalidExerciseData } from '@/modules/exercise/domain/errors/exercise.errors';
+
+type UpdateExerciseKeys = Omit<UpdateExerciseInput, 'muscleIds'>;
+
+type UpdateOperations = {
+  [K in keyof UpdateExerciseKeys]: keyof ExerciseMethods;
+};
+
+const updateOperations: UpdateOperations = {
+  name: 'changeName',
+  description: 'changeDescription',
+  sets: 'changeSets',
+  reps: 'changeReps',
+  weight: 'changeWeight',
+};
+
+export function updateExercise(
+  data: UpdateExerciseInput,
+  exercise: Exercise
+): Result<Exercise, DomainError> {
+  if (!isObject(data)) return Failure(new InvalidExerciseData());
+  const dataKeys = Object.keys(data) as (keyof UpdateExerciseInput)[];
+
+  for (const key of dataKeys) {
+    if (!isKeyOf(key, updateOperations)) continue;
+    if (!isKeyOf(key, data)) continue;
+
+    const value = data[key] as never;
+    const method = updateOperations[key] as keyof ExerciseMethods;
+    const updateResult = exercise[method](value);
+    if (!updateResult.success) return updateResult;
+  }
+
+  return Success(exercise);
+}

--- a/src/modules/exercise/application/use-cases/create-exercise.test.ts
+++ b/src/modules/exercise/application/use-cases/create-exercise.test.ts
@@ -1,0 +1,224 @@
+import '@testing-library/jest-dom';
+import { Failure } from '@/shared/domain/result';
+import { TechnicalError } from '@/shared/domain/errors/domain.errors';
+import { CreateExercise } from '@/modules/exercise/application/use-cases/create-exercise';
+import { InMemoryExerciseRepository } from '@/modules/exercise/mocks/exercise.mocks.repository';
+import { InMemoryMuscleRepository } from '@/modules/exercise/mocks/muscle.mocks.repository';
+import { MockIdGenerator } from '@/shared/test/mocks/id-generator.repository.mock';
+import type { CreateExerciseInput } from '@/modules/exercise/application/dtos/create-exercise.dto';
+
+describe('CreateExercise use case', () => {
+  describe('Happy Path', () => {
+    it('should create exercise successfully and persist it', async () => {
+      const exerciseRepoMock = new InMemoryExerciseRepository();
+      const muscleRepoMock = new InMemoryMuscleRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new CreateExercise(exerciseRepoMock, muscleRepoMock, idGeneratorMock);
+
+      const exerciseData: CreateExerciseInput = {
+        name: 'Bench Press',
+        description: 'Chest exercise',
+        sets: 3,
+        reps: 10,
+        weight: 80,
+        muscleIds: [1],
+        userId: 'user-123',
+      };
+
+      idGeneratorMock.id = '1df38173-6fae-4abb-8cb2-ce33b6c24da4';
+
+      const createExerciseResult = await useCase.execute(exerciseData);
+
+      expect(createExerciseResult.success).toBe(true);
+      expect(createExerciseResult.success && createExerciseResult.data.id).toBe(
+        '1df38173-6fae-4abb-8cb2-ce33b6c24da4'
+      );
+      expect(createExerciseResult.success && createExerciseResult.data.name).toBe('Bench Press');
+
+      expect(exerciseRepoMock.exercises).toHaveLength(1);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should succeed even when muscles not found (empty array)', async () => {
+      const exerciseRepoMock = new InMemoryExerciseRepository();
+      const muscleRepoMock = new InMemoryMuscleRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new CreateExercise(exerciseRepoMock, muscleRepoMock, idGeneratorMock);
+
+      const exerciseData: CreateExerciseInput = {
+        name: 'Bench Press',
+        description: 'Chest exercise',
+        sets: 3,
+        reps: 10,
+        weight: 80,
+        muscleIds: [999],
+        userId: 'user-123',
+      };
+
+      idGeneratorMock.id = '1df38173-6fae-4abb-8cb2-ce33b6c24da4';
+
+      const createExerciseResult = await useCase.execute(exerciseData);
+
+      expect(createExerciseResult.success).toBe(true);
+
+      expect(exerciseRepoMock.exercises).toHaveLength(1);
+    });
+
+    it('should return failure when muscle repository findByIds operation fails', async () => {
+      const exerciseRepoMock = new InMemoryExerciseRepository();
+      const muscleRepoMock = new InMemoryMuscleRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new CreateExercise(exerciseRepoMock, muscleRepoMock, idGeneratorMock);
+
+      jest
+        .spyOn(muscleRepoMock, 'findByIds')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+
+      const exerciseData: CreateExerciseInput = {
+        name: 'Bench Press',
+        description: 'Chest exercise',
+        sets: 3,
+        reps: 10,
+        weight: 80,
+        muscleIds: [1],
+        userId: 'user-123',
+      };
+
+      idGeneratorMock.id = '1df38173-6fae-4abb-8cb2-ce33b6c24da4';
+
+      const createExerciseResult = await useCase.execute(exerciseData);
+
+      expect(createExerciseResult.success).toBe(false);
+      expect(!createExerciseResult.success && createExerciseResult.error.code).toBe(
+        'MUSCLE_NOT_FOUND'
+      );
+
+      expect(exerciseRepoMock.exercises).toHaveLength(0);
+    });
+
+    it('should return failure when exercise name is invalid', async () => {
+      const exerciseRepoMock = new InMemoryExerciseRepository();
+      const muscleRepoMock = new InMemoryMuscleRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new CreateExercise(exerciseRepoMock, muscleRepoMock, idGeneratorMock);
+
+      const exerciseData: CreateExerciseInput = {
+        name: 'AB',
+        description: 'Chest exercise',
+        sets: 3,
+        reps: 10,
+        weight: 80,
+        muscleIds: [1],
+        userId: 'user-123',
+      };
+
+      idGeneratorMock.id = '1df38173-6fae-4abb-8cb2-ce33b6c24da4';
+
+      const createExerciseResult = await useCase.execute(exerciseData);
+
+      expect(createExerciseResult.success).toBe(false);
+      expect(!createExerciseResult.success && createExerciseResult.error.code).toBe(
+        'INVALID_EXERCISE_DATA.NAME'
+      );
+
+      expect(exerciseRepoMock.exercises).toHaveLength(0);
+    });
+  });
+
+  describe('Dependency Interaction', () => {
+    it('should return failure when repository create operation fails', async () => {
+      const exerciseRepoMock = new InMemoryExerciseRepository();
+      const muscleRepoMock = new InMemoryMuscleRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new CreateExercise(exerciseRepoMock, muscleRepoMock, idGeneratorMock);
+
+      jest
+        .spyOn(exerciseRepoMock, 'create')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+
+      const exerciseData: CreateExerciseInput = {
+        name: 'Bench Press',
+        description: 'Chest exercise',
+        sets: 3,
+        reps: 10,
+        weight: 80,
+        muscleIds: [1],
+        userId: 'user-123',
+      };
+
+      idGeneratorMock.id = '1df38173-6fae-4abb-8cb2-ce33b6c24da4';
+
+      const createExerciseResult = await useCase.execute(exerciseData);
+
+      expect(createExerciseResult.success).toBe(false);
+      expect(!createExerciseResult.success && createExerciseResult.error.code).toBe(
+        'TECHNICAL_ERROR'
+      );
+
+      expect(exerciseRepoMock.exercises).toHaveLength(0);
+    });
+
+    it('should return failure when idGenerator generate operation fails', async () => {
+      const exerciseRepoMock = new InMemoryExerciseRepository();
+      const muscleRepoMock = new InMemoryMuscleRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new CreateExercise(exerciseRepoMock, muscleRepoMock, idGeneratorMock);
+
+      jest
+        .spyOn(idGeneratorMock, 'generate')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+
+      const exerciseData: CreateExerciseInput = {
+        name: 'Bench Press',
+        description: 'Chest exercise',
+        sets: 3,
+        reps: 10,
+        weight: 80,
+        muscleIds: [1],
+        userId: 'user-123',
+      };
+
+      const createExerciseResult = await useCase.execute(exerciseData);
+
+      expect(createExerciseResult.success).toBe(false);
+      expect(!createExerciseResult.success && createExerciseResult.error.code).toBe(
+        'TECHNICAL_ERROR'
+      );
+
+      expect(exerciseRepoMock.exercises).toHaveLength(0);
+    });
+
+    it('should return failure when muscle repository findByIds operation fails', async () => {
+      const exerciseRepoMock = new InMemoryExerciseRepository();
+      const muscleRepoMock = new InMemoryMuscleRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new CreateExercise(exerciseRepoMock, muscleRepoMock, idGeneratorMock);
+
+      jest
+        .spyOn(muscleRepoMock, 'findByIds')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+
+      const exerciseData: CreateExerciseInput = {
+        name: 'Bench Press',
+        description: 'Chest exercise',
+        sets: 3,
+        reps: 10,
+        weight: 80,
+        muscleIds: [1],
+        userId: 'user-123',
+      };
+
+      idGeneratorMock.id = '1df38173-6fae-4abb-8cb2-ce33b6c24da4';
+
+      const createExerciseResult = await useCase.execute(exerciseData);
+
+      expect(createExerciseResult.success).toBe(false);
+      expect(!createExerciseResult.success && createExerciseResult.error.code).toBe(
+        'MUSCLE_NOT_FOUND'
+      );
+
+      expect(exerciseRepoMock.exercises).toHaveLength(0);
+    });
+  });
+});

--- a/src/modules/exercise/application/use-cases/update-exercise.test.ts
+++ b/src/modules/exercise/application/use-cases/update-exercise.test.ts
@@ -1,0 +1,242 @@
+import '@testing-library/jest-dom';
+import { Failure } from '@/shared/domain/result';
+import { TechnicalError } from '@/shared/domain/errors/domain.errors';
+import { UpdateExercise } from '@/modules/exercise/application/use-cases/update-exercise';
+import { InMemoryExerciseRepository } from '@/modules/exercise/mocks/exercise.mocks.repository';
+import { InMemoryMuscleRepository } from '@/modules/exercise/mocks/muscle.mocks.repository';
+import { Exercise } from '@/modules/exercise/domain/exercise.entity';
+
+describe('UpdateExercise use case', () => {
+  describe('Happy Path', () => {
+    it('should update exercise successfully and persist changes', async () => {
+      const exerciseRepoMock = new InMemoryExerciseRepository();
+      const muscleRepoMock = new InMemoryMuscleRepository();
+      const useCase = new UpdateExercise(exerciseRepoMock, muscleRepoMock);
+
+      const exercise = Exercise.create('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
+        name: 'Bench Press',
+        description: 'Chest exercise',
+        sets: 3,
+        reps: 10,
+        weight: 80,
+        muscles: [],
+        userId: 'user-123',
+      });
+      if (!exercise.success) throw new Error('Failed to create exercise');
+      await exerciseRepoMock.create(exercise.data);
+
+      expect(exerciseRepoMock.exercises[0]?.name).not.toBe('Updated Bench Press');
+
+      const updateResult = await useCase.execute('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
+        name: 'Updated Bench Press',
+      });
+
+      expect(updateResult.success).toBe(true);
+      expect(updateResult.success && updateResult.data.id).toBe(
+        '1df38173-6fae-4abb-8cb2-ce33b6c24da4'
+      );
+      expect(updateResult.success && updateResult.data.name).toBe('Updated Bench Press');
+
+      expect(exerciseRepoMock.exercises[0]?.name).toBe('Updated Bench Press');
+    });
+
+    it('should update multiple fields', async () => {
+      const exerciseRepoMock = new InMemoryExerciseRepository();
+      const muscleRepoMock = new InMemoryMuscleRepository();
+      const useCase = new UpdateExercise(exerciseRepoMock, muscleRepoMock);
+
+      const exercise = Exercise.create('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
+        name: 'Bench Press',
+        description: 'Chest exercise',
+        sets: 3,
+        reps: 10,
+        weight: 80,
+        muscles: [],
+        userId: 'user-123',
+      });
+      if (!exercise.success) throw new Error('Failed to create exercise');
+      await exerciseRepoMock.create(exercise.data);
+
+      const updateResult = await useCase.execute('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
+        name: 'Updated Name',
+        sets: 5,
+        reps: 8,
+      });
+
+      expect(updateResult.success).toBe(true);
+      expect(updateResult.success && updateResult.data.name).toBe('Updated Name');
+      expect(updateResult.success && updateResult.data.sets).toBe(5);
+      expect(updateResult.success && updateResult.data.reps).toBe(8);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should return failure when exercise not found', async () => {
+      const exerciseRepoMock = new InMemoryExerciseRepository();
+      const muscleRepoMock = new InMemoryMuscleRepository();
+      const useCase = new UpdateExercise(exerciseRepoMock, muscleRepoMock);
+
+      const updateResult = await useCase.execute('non-existent-id', {
+        name: 'Updated Name',
+      });
+
+      expect(updateResult.success).toBe(false);
+      expect(!updateResult.success && updateResult.error.code).toBe('EXERCISE_NOT_FOUND');
+    });
+
+    it('should return failure when invalid name provided', async () => {
+      const exerciseRepoMock = new InMemoryExerciseRepository();
+      const muscleRepoMock = new InMemoryMuscleRepository();
+      const useCase = new UpdateExercise(exerciseRepoMock, muscleRepoMock);
+
+      const exercise = Exercise.create('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
+        name: 'Bench Press',
+        description: 'Chest exercise',
+        sets: 3,
+        reps: 10,
+        weight: 80,
+        muscles: [],
+        userId: 'user-123',
+      });
+      if (!exercise.success) throw new Error('Failed to create exercise');
+      await exerciseRepoMock.create(exercise.data);
+
+      const updateResult = await useCase.execute('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
+        name: 'AB',
+      });
+
+      expect(updateResult.success).toBe(false);
+      expect(!updateResult.success && updateResult.error.code).toBe('INVALID_EXERCISE_DATA.NAME');
+    });
+
+    it('should return failure when invalid sets provided', async () => {
+      const exerciseRepoMock = new InMemoryExerciseRepository();
+      const muscleRepoMock = new InMemoryMuscleRepository();
+      const useCase = new UpdateExercise(exerciseRepoMock, muscleRepoMock);
+
+      const exercise = Exercise.create('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
+        name: 'Bench Press',
+        description: 'Chest exercise',
+        sets: 3,
+        reps: 10,
+        weight: 80,
+        muscles: [],
+        userId: 'user-123',
+      });
+      if (!exercise.success) throw new Error('Failed to create exercise');
+      await exerciseRepoMock.create(exercise.data);
+
+      const updateResult = await useCase.execute('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
+        sets: -1,
+      });
+
+      expect(updateResult.success).toBe(false);
+      expect(!updateResult.success && updateResult.error.code).toBe('INVALID_EXERCISE_DATA.SETS');
+    });
+
+    it('should return failure when muscles not found', async () => {
+      const exerciseRepoMock = new InMemoryExerciseRepository();
+      const muscleRepoMock = new InMemoryMuscleRepository();
+      const useCase = new UpdateExercise(exerciseRepoMock, muscleRepoMock);
+
+      const exercise = Exercise.create('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
+        name: 'Bench Press',
+        description: 'Chest exercise',
+        sets: 3,
+        reps: 10,
+        weight: 80,
+        muscles: [],
+        userId: 'user-123',
+      });
+      if (!exercise.success) throw new Error('Failed to create exercise');
+      await exerciseRepoMock.create(exercise.data);
+
+      const updateResult = await useCase.execute('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
+        muscleIds: [999],
+      });
+
+      expect(updateResult.success).toBe(false);
+      expect(!updateResult.success && updateResult.error.code).toBe('MUSCLE_NOT_FOUND');
+    });
+  });
+
+  describe('Dependency Interaction', () => {
+    it('should return failure when repository update operation fails', async () => {
+      const exerciseRepoMock = new InMemoryExerciseRepository();
+      const muscleRepoMock = new InMemoryMuscleRepository();
+      const useCase = new UpdateExercise(exerciseRepoMock, muscleRepoMock);
+
+      const exercise = Exercise.create('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
+        name: 'Bench Press',
+        description: 'Chest exercise',
+        sets: 3,
+        reps: 10,
+        weight: 80,
+        muscles: [],
+        userId: 'user-123',
+      });
+      if (!exercise.success) throw new Error('Failed to create exercise');
+      await exerciseRepoMock.create(exercise.data);
+
+      jest
+        .spyOn(exerciseRepoMock, 'update')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+
+      const updateResult = await useCase.execute('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
+        name: 'Updated Name',
+      });
+
+      expect(updateResult.success).toBe(false);
+      expect(!updateResult.success && updateResult.error.code).toBe('TECHNICAL_ERROR');
+
+      expect(exerciseRepoMock.exercises[0]?.name).not.toBe('Updated Name');
+    });
+
+    it('should return failure when repository findById operation fails', async () => {
+      const exerciseRepoMock = new InMemoryExerciseRepository();
+      const muscleRepoMock = new InMemoryMuscleRepository();
+      const useCase = new UpdateExercise(exerciseRepoMock, muscleRepoMock);
+
+      jest
+        .spyOn(exerciseRepoMock, 'findById')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+
+      const updateResult = await useCase.execute('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
+        name: 'Updated Name',
+      });
+
+      expect(updateResult.success).toBe(false);
+      expect(!updateResult.success && updateResult.error.code).toBe('TECHNICAL_ERROR');
+    });
+
+    it('should return failure when muscle repository findByIds operation fails', async () => {
+      const exerciseRepoMock = new InMemoryExerciseRepository();
+      const muscleRepoMock = new InMemoryMuscleRepository();
+      const useCase = new UpdateExercise(exerciseRepoMock, muscleRepoMock);
+
+      const exercise = Exercise.create('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
+        name: 'Bench Press',
+        description: 'Chest exercise',
+        sets: 3,
+        reps: 10,
+        weight: 80,
+        muscles: [],
+        userId: 'user-123',
+      });
+
+      if (!exercise.success) throw new Error('Failed to create exercise');
+      await exerciseRepoMock.create(exercise.data);
+
+      jest
+        .spyOn(muscleRepoMock, 'findByIds')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+
+      const updateResult = await useCase.execute('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
+        muscleIds: [666],
+      });
+
+      expect(updateResult.success).toBe(false);
+      expect(!updateResult.success && updateResult.error.code).toBe('TECHNICAL_ERROR');
+    });
+  });
+});

--- a/src/modules/exercise/application/use-cases/update-exercise.ts
+++ b/src/modules/exercise/application/use-cases/update-exercise.ts
@@ -5,6 +5,7 @@ import type { IExerciseRepository } from '@/modules/exercise/domain/exercise.rep
 import type { IMuscleRepository } from '@/modules/muscle/domain/muscle.repository';
 import type { UpdateExerciseInput } from '@/modules/exercise/application/dtos/update-exercise.dto';
 import type { UseCase } from '@/shared/application/shared.use-case';
+import { MuscleNotFoundError } from '@/modules/muscle/domain/errors/muscle.errors';
 
 export class UpdateExercise implements UseCase {
   constructor(
@@ -14,8 +15,8 @@ export class UpdateExercise implements UseCase {
 
   async execute(id: Exercise['id'], data: UpdateExerciseInput) {
     const exerciseResult = await this.exerciseRepository.findById(id);
-    if (!exerciseResult.success || !exerciseResult.data)
-      return Failure(new ExerciseNotFoundError());
+    if (!exerciseResult.success) return exerciseResult;
+    if (!exerciseResult.data) return Failure(new ExerciseNotFoundError());
 
     const exercise = exerciseResult.data;
 
@@ -24,7 +25,7 @@ export class UpdateExercise implements UseCase {
       if (!nameResult.success) return nameResult;
     }
 
-    if (data.description) {
+    if (data.description !== undefined) {
       const descriptionResult = exercise.changeDescription(data.description);
       if (!descriptionResult.success) return descriptionResult;
     }
@@ -47,6 +48,8 @@ export class UpdateExercise implements UseCase {
     if (data.muscleIds) {
       const musclesResult = await this.muscleRepository.findByIds(data.muscleIds);
       if (!musclesResult.success) return musclesResult;
+      if (data.muscleIds.length !== musclesResult.data.length)
+        return Failure(new MuscleNotFoundError());
       exercise.changeMuscles(musclesResult.data);
     }
 

--- a/src/modules/exercise/application/use-cases/update-exercise.ts
+++ b/src/modules/exercise/application/use-cases/update-exercise.ts
@@ -6,6 +6,7 @@ import type { IMuscleRepository } from '@/modules/muscle/domain/muscle.repositor
 import type { UpdateExerciseInput } from '@/modules/exercise/application/dtos/update-exercise.dto';
 import type { UseCase } from '@/shared/application/shared.use-case';
 import { MuscleNotFoundError } from '@/modules/muscle/domain/errors/muscle.errors';
+import { updateExercise } from '@/modules/exercise/application/helpers/update-exercise.helper';
 
 export class UpdateExercise implements UseCase {
   constructor(
@@ -20,30 +21,8 @@ export class UpdateExercise implements UseCase {
 
     const exercise = exerciseResult.data;
 
-    if (data.name) {
-      const nameResult = exercise.changeName(data.name);
-      if (!nameResult.success) return nameResult;
-    }
-
-    if (data.description !== undefined) {
-      const descriptionResult = exercise.changeDescription(data.description);
-      if (!descriptionResult.success) return descriptionResult;
-    }
-
-    if (data.sets) {
-      const setsResult = exercise.changeSets(data.sets);
-      if (!setsResult.success) return setsResult;
-    }
-
-    if (data.reps) {
-      const repsResult = exercise.changeReps(data.reps);
-      if (!repsResult.success) return repsResult;
-    }
-
-    if (data.weight) {
-      const weightResult = exercise.changeWeight(data.weight);
-      if (!weightResult.success) return weightResult;
-    }
+    const updateResult = updateExercise(data, exercise);
+    if (!updateResult.success) return updateResult;
 
     if (data.muscleIds) {
       const musclesResult = await this.muscleRepository.findByIds(data.muscleIds);

--- a/src/modules/exercise/domain/exercise.types.ts
+++ b/src/modules/exercise/domain/exercise.types.ts
@@ -1,5 +1,7 @@
+import type { ClassMethods } from '@/shared/shared.types';
 import type { Muscle } from '@/modules/muscle/domain/muscle.entity';
 import type { UserProps } from '@/modules/user/domain/user.types';
+import type { Exercise } from '@/modules/exercise/domain/exercise.entity';
 
 export type ExerciseProps = {
   readonly id: string;
@@ -15,3 +17,5 @@ export type ExerciseProps = {
 };
 
 export type ExerciseFactoryData = Omit<ExerciseProps, 'id' | 'createdAt' | 'updatedAt'>;
+
+export type ExerciseMethods = ClassMethods<Exercise>;

--- a/src/modules/exercise/domain/validation/exercise.validation.ts
+++ b/src/modules/exercise/domain/validation/exercise.validation.ts
@@ -63,7 +63,7 @@ export function validateExercise(exercise: ExerciseMinimumProps): Result<Exercis
 
   const domainExercise = new Exercise({
     id: exercise.id,
-    name: exercise.id,
+    name: exercise.name,
     description: exercise.description,
     sets: exercise.sets,
     reps: exercise.reps,

--- a/src/modules/exercise/mocks/exercise.mocks.repository.ts
+++ b/src/modules/exercise/mocks/exercise.mocks.repository.ts
@@ -1,0 +1,64 @@
+import { Failure, Success } from '@/shared/domain/result';
+import { Exercise } from '@/modules/exercise/domain/exercise.entity';
+import type { ExerciseProps } from '@/modules/exercise/domain/exercise.types';
+import type { IExerciseRepository } from '@/modules/exercise/domain/exercise.repository';
+import { ExerciseNotFoundError } from '../domain/errors/exercise.errors';
+
+export class InMemoryExerciseRepository implements IExerciseRepository {
+  public exercises: Exercise[] = [];
+  async create(data: Exercise) {
+    this.exercises.push(data);
+    const copy = this.getCopy(data);
+    return Success(copy);
+  }
+  async update(data: Exercise) {
+    const index = this.exercises.findIndex((e) => e.id === data.id);
+    if (index !== -1) {
+      this.exercises[index] = data;
+    }
+    const copy = this.getCopy(data);
+    return Success(copy);
+  }
+  async findAll() {
+    return Success(this.getCopies(this.exercises));
+  }
+  async findById(id: Exercise['id']) {
+    const exercise = this.exercises.find((e) => e.id === id);
+    if (!exercise) return Success(null);
+    return Success(this.getCopy(exercise));
+  }
+  async findByIds(ids: Exercise['id'][]) {
+    const exercises = this.exercises.filter((e) => ids.includes(e.id));
+    return Success(this.getCopies(exercises));
+  }
+  async findAllByUserId(userId: Exercise['userId']) {
+    const exercises = this.exercises.filter((e) => e.userId === userId);
+    return Success(this.getCopies(exercises));
+  }
+  async delete(id: Exercise['id']) {
+    const exercise = this.exercises.find((e) => e.id === id);
+    if (!exercise) return Failure(new ExerciseNotFoundError());
+    this.exercises = this.exercises.filter((e) => e.id !== id);
+    return Success(this.getCopy(exercise));
+  }
+
+  private getCopy(exercise: Exercise): Exercise {
+    const props: ExerciseProps = {
+      id: exercise.id,
+      name: exercise.name,
+      description: exercise.description,
+      sets: exercise.sets,
+      reps: exercise.reps,
+      weight: exercise.weight,
+      muscles: exercise.muscles,
+      userId: exercise.userId,
+      createdAt: exercise.createdAt,
+      updatedAt: exercise.updatedAt,
+    };
+    return new Exercise(props);
+  }
+
+  private getCopies(exercises: Exercise[]): Exercise[] {
+    return exercises.map((e) => this.getCopy(e));
+  }
+}

--- a/src/modules/exercise/mocks/muscle.mocks.repository.ts
+++ b/src/modules/exercise/mocks/muscle.mocks.repository.ts
@@ -1,0 +1,63 @@
+import { Success } from '@/shared/domain/result';
+import { Muscle } from '@/modules/muscle/domain/muscle.entity';
+import type { MuscleProps } from '@/modules/muscle/domain/muscle.types';
+import type { IMuscleRepository } from '@/modules/muscle/domain/muscle.repository';
+
+const MOCK_MUSCLES: MuscleProps[] = [
+  {
+    id: 1,
+    name: 'Pectoral',
+    description: 'Chest muscle',
+    userId: 'user-123',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    group: {
+      id: 1,
+      name: 'Chest',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      section: {
+        id: 1,
+        name: 'Upper Body',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    },
+  },
+  {
+    id: 2,
+    name: 'Biceps',
+    description: 'Arm muscle',
+    userId: 'user-123',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    group: {
+      id: 2,
+      name: 'Arms',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      section: {
+        id: 1,
+        name: 'Upper Body',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    },
+  },
+];
+
+export class InMemoryMuscleRepository implements IMuscleRepository {
+  public muscles: Muscle[] = MOCK_MUSCLES.map((m) => new Muscle(m));
+  async findAll() {
+    return Success([...this.muscles]);
+  }
+  async findById(id: MuscleProps['id']) {
+    const muscle = this.muscles.find((m) => m.id === id);
+    if (!muscle) return Success(null);
+    return Success(muscle);
+  }
+  async findByIds(ids: MuscleProps['id'][]) {
+    const muscles = this.muscles.filter((m) => ids.includes(m.id));
+    return Success([...muscles]);
+  }
+}


### PR DESCRIPTION
## Domain & Application Logic

### 1. The "What" and "Why"

**Intent:** Refactor
**Related Issue:** N/A

**Description:** 

>

### 2. Clean Architecture Alignment

- [x] **Domain Layer:** 
  - Add `ExerciseMethods` type.
  - Fix `Domain` validation bug. It was assigning id to name field.
- [x] **Application Layer:** 
  - Add `CreateUser` and `UpdateUser` unit tests.
  - Add update fields helper to `UpdateUser` use case.
- [x] **Dependency Rule:** I confirm that no Infrastructure or UI-specific code has leaked into this PR.

### 3. Verification Checklist

- [x] **Type Safety:** `pnpm typecheck` passes without errors.
- [x] **Code Health:** `pnpm safe-fixes` has been run and resolved linting/formatting.
- [x] **Logic Integrity:** `pnpm test` passes (specifically for the new unit test for `CreateUser` and `UpdateUser` use cases).

### 4. Technical Nuances
It is improved the update use case for field updates. By using `Chain of Responsibility` pattern to avoid touching `UpdateUser` use case when `Exercise` fields updates change. This keeps `Single Responsibility` principle by separating the update logic from use case and make it readable and expandable.
-

### 5. Automated Check Confirmation

| Command           | Status  |
| :---------------- | :------ |
| `pnpm typecheck`  | ✅ |
| `pnpm safe-fixes` | ✅ |
| `pnpm test`       | ✅ |

---
