### PR TITLE
refactor(tests): remove unnecessary tests that make test fragile

### DIFF
--- a/src/modules/exercise/application/use-cases/create-exercise.test.ts
+++ b/src/modules/exercise/application/use-cases/create-exercise.test.ts
@@ -40,48 +40,18 @@ describe('CreateExercise use case', () => {
   });
 
   describe('Error Handling', () => {
-    it('should succeed even when muscles not found (empty array)', async () => {
+    it('should return failure when muscle not found', async () => {
       const exerciseRepoMock = new InMemoryExerciseRepository();
       const muscleRepoMock = new InMemoryMuscleRepository();
       const idGeneratorMock = new MockIdGenerator();
       const useCase = new CreateExercise(exerciseRepoMock, muscleRepoMock, idGeneratorMock);
-
       const exerciseData: CreateExerciseInput = {
         name: 'Bench Press',
         description: 'Chest exercise',
         sets: 3,
         reps: 10,
         weight: 80,
-        muscleIds: [999],
-        userId: 'user-123',
-      };
-
-      idGeneratorMock.id = '1df38173-6fae-4abb-8cb2-ce33b6c24da4';
-
-      const createExerciseResult = await useCase.execute(exerciseData);
-
-      expect(createExerciseResult.success).toBe(true);
-
-      expect(exerciseRepoMock.exercises).toHaveLength(1);
-    });
-
-    it('should return failure when muscle repository findByIds operation fails', async () => {
-      const exerciseRepoMock = new InMemoryExerciseRepository();
-      const muscleRepoMock = new InMemoryMuscleRepository();
-      const idGeneratorMock = new MockIdGenerator();
-      const useCase = new CreateExercise(exerciseRepoMock, muscleRepoMock, idGeneratorMock);
-
-      jest
-        .spyOn(muscleRepoMock, 'findByIds')
-        .mockResolvedValue(Failure(new TechnicalError() as never));
-
-      const exerciseData: CreateExerciseInput = {
-        name: 'Bench Press',
-        description: 'Chest exercise',
-        sets: 3,
-        reps: 10,
-        weight: 80,
-        muscleIds: [1],
+        muscleIds: [1, 2, 3],
         userId: 'user-123',
       };
 
@@ -97,19 +67,19 @@ describe('CreateExercise use case', () => {
       expect(exerciseRepoMock.exercises).toHaveLength(0);
     });
 
-    it('should return failure when exercise name is invalid', async () => {
+    it('should return failure when invalid exercise data', async () => {
       const exerciseRepoMock = new InMemoryExerciseRepository();
       const muscleRepoMock = new InMemoryMuscleRepository();
       const idGeneratorMock = new MockIdGenerator();
       const useCase = new CreateExercise(exerciseRepoMock, muscleRepoMock, idGeneratorMock);
 
       const exerciseData: CreateExerciseInput = {
-        name: 'AB',
+        name: 'Bench Press',
         description: 'Chest exercise',
-        sets: 3,
+        sets: -1,
         reps: 10,
         weight: 80,
-        muscleIds: [1],
+        muscleIds: [1, 2],
         userId: 'user-123',
       };
 
@@ -118,9 +88,10 @@ describe('CreateExercise use case', () => {
       const createExerciseResult = await useCase.execute(exerciseData);
 
       expect(createExerciseResult.success).toBe(false);
-      expect(!createExerciseResult.success && createExerciseResult.error.code).toBe(
-        'INVALID_EXERCISE_DATA.NAME'
-      );
+      expect(
+        !createExerciseResult.success &&
+          createExerciseResult.error.code.startsWith('INVALID_EXERCISE_DATA')
+      ).toBe(true);
 
       expect(exerciseRepoMock.exercises).toHaveLength(0);
     });
@@ -215,7 +186,7 @@ describe('CreateExercise use case', () => {
 
       expect(createExerciseResult.success).toBe(false);
       expect(!createExerciseResult.success && createExerciseResult.error.code).toBe(
-        'MUSCLE_NOT_FOUND'
+        'TECHNICAL_ERROR'
       );
 
       expect(exerciseRepoMock.exercises).toHaveLength(0);

--- a/src/modules/exercise/application/use-cases/create-exercise.ts
+++ b/src/modules/exercise/application/use-cases/create-exercise.ts
@@ -20,14 +20,16 @@ export class CreateExercise implements UseCase {
 
     const exerciseId = idResult.data;
 
-    const muscles = await this.muscleRepository.findByIds(exerciseData.muscleIds);
-    if (!muscles.success) return Failure(new MuscleNotFoundError());
+    const musclesResult = await this.muscleRepository.findByIds(exerciseData.muscleIds);
+    if (!musclesResult.success) return musclesResult;
+    if (musclesResult.data.length !== exerciseData.muscleIds.length)
+      return Failure(new MuscleNotFoundError());
 
     const { muscleIds, ...createExerciseData } = exerciseData;
 
     const newExerciseResult = Exercise.create(exerciseId, {
       ...createExerciseData,
-      muscles: muscles.data,
+      muscles: musclesResult.data,
     });
 
     if (!newExerciseResult.success) return newExerciseResult;

--- a/src/modules/exercise/application/use-cases/update-exercise.test.ts
+++ b/src/modules/exercise/application/use-cases/update-exercise.test.ts
@@ -84,7 +84,7 @@ describe('UpdateExercise use case', () => {
       expect(!updateResult.success && updateResult.error.code).toBe('EXERCISE_NOT_FOUND');
     });
 
-    it('should return failure when invalid name provided', async () => {
+    it('should return failure when invalid data provided', async () => {
       const exerciseRepoMock = new InMemoryExerciseRepository();
       const muscleRepoMock = new InMemoryMuscleRepository();
       const useCase = new UpdateExercise(exerciseRepoMock, muscleRepoMock);
@@ -101,37 +101,13 @@ describe('UpdateExercise use case', () => {
       if (!exercise.success) throw new Error('Failed to create exercise');
       await exerciseRepoMock.create(exercise.data);
 
-      const updateResult = await useCase.execute('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
-        name: 'AB',
-      });
+      const updateResult = await useCase.execute(
+        '1df38173-6fae-4abb-8cb2-ce33b6c24da4',
+        null as never
+      );
 
       expect(updateResult.success).toBe(false);
       expect(!updateResult.success && updateResult.error.code).toBe('INVALID_EXERCISE_DATA.NAME');
-    });
-
-    it('should return failure when invalid sets provided', async () => {
-      const exerciseRepoMock = new InMemoryExerciseRepository();
-      const muscleRepoMock = new InMemoryMuscleRepository();
-      const useCase = new UpdateExercise(exerciseRepoMock, muscleRepoMock);
-
-      const exercise = Exercise.create('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
-        name: 'Bench Press',
-        description: 'Chest exercise',
-        sets: 3,
-        reps: 10,
-        weight: 80,
-        muscles: [],
-        userId: 'user-123',
-      });
-      if (!exercise.success) throw new Error('Failed to create exercise');
-      await exerciseRepoMock.create(exercise.data);
-
-      const updateResult = await useCase.execute('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
-        sets: -1,
-      });
-
-      expect(updateResult.success).toBe(false);
-      expect(!updateResult.success && updateResult.error.code).toBe('INVALID_EXERCISE_DATA.SETS');
     });
 
     it('should return failure when muscles not found', async () => {

--- a/src/modules/exercise/application/use-cases/update-exercise.test.ts
+++ b/src/modules/exercise/application/use-cases/update-exercise.test.ts
@@ -107,7 +107,7 @@ describe('UpdateExercise use case', () => {
       );
 
       expect(updateResult.success).toBe(false);
-      expect(!updateResult.success && updateResult.error.code).toBe('INVALID_EXERCISE_DATA.NAME');
+      expect(!updateResult.success && updateResult.error.code).toBe('INVALID_EXERCISE_DATA');
     });
 
     it('should return failure when muscles not found', async () => {

--- a/src/modules/exercise/domain/exercise.entity.test.ts
+++ b/src/modules/exercise/domain/exercise.entity.test.ts
@@ -32,11 +32,11 @@ describe('Exercise entity', () => {
       expect(exerciseResult.success && exerciseResult.data instanceof Exercise).toBe(true);
     });
 
-    it('should return failure when invalid id provided', () => {
+    it('should return failure when invalid data provided', () => {
       const exerciseResult = Exercise.create('invalid-id', {
         name: 'Squat',
         description: 'Leg exercise',
-        sets: 4,
+        sets: -1,
         reps: 8,
         weight: 100,
         muscles: [],
@@ -56,18 +56,11 @@ describe('Exercise entity', () => {
       expect(exercise.name).toBe('New Bench Press');
     });
 
-    it('should return failure when name is not a string', () => {
+    it('should return failure when name is invalid', () => {
       const exercise = createTestExercise();
       const result = exercise.changeName(123 as never);
       expect(result.success).toBe(false);
       expect(exercise.name).not.toBe(123);
-    });
-
-    it('should trim whitespace from name', () => {
-      const exercise = createTestExercise();
-      const result = exercise.changeName('  Trimmed Name  ');
-      expect(result.success).toBe(true);
-      expect(exercise.name).toBe('Trimmed Name');
     });
   });
 
@@ -80,25 +73,11 @@ describe('Exercise entity', () => {
       expect(exercise.description).toBe('New description');
     });
 
-    it('should return failure when description is not a string or null', () => {
+    it('should return failure when description is invalid', () => {
       const exercise = createTestExercise();
       const result = exercise.changeDescription(123 as never);
       expect(result.success).toBe(false);
       expect(exercise.description).not.toBe(123);
-    });
-
-    it('should allow null description', () => {
-      const exercise = createTestExercise();
-      const result = exercise.changeDescription(null);
-      expect(result.success).toBe(true);
-      expect(exercise.description).toBe(null);
-    });
-
-    it('should trim whitespace from description', () => {
-      const exercise = createTestExercise();
-      const result = exercise.changeDescription('  Trimmed Description  ');
-      expect(result.success).toBe(true);
-      expect(exercise.description).toBe('Trimmed Description');
     });
   });
 
@@ -111,24 +90,11 @@ describe('Exercise entity', () => {
       expect(exercise.sets).toBe(5);
     });
 
-    it('should return failure when sets is not a number', () => {
+    it('should return failure when sets is invalid', () => {
       const exercise = createTestExercise();
       const result = exercise.changeSets('5' as never);
       expect(result.success).toBe(false);
       expect(exercise.sets).not.toBe('5');
-    });
-
-    it('should return failure when sets is not an integer', () => {
-      const exercise = createTestExercise();
-      const result = exercise.changeSets(3.5);
-      expect(result.success).toBe(false);
-      expect(exercise.sets).not.toBe(3.5);
-    });
-
-    it('should return failure when sets is less than 1', () => {
-      const exercise = createTestExercise();
-      const result = exercise.changeSets(0);
-      expect(result.success).toBe(false);
     });
   });
 
@@ -141,24 +107,11 @@ describe('Exercise entity', () => {
       expect(exercise.reps).toBe(12);
     });
 
-    it('should return failure when reps is not a number', () => {
+    it('should return failure when reps is invalid', () => {
       const exercise = createTestExercise();
       const result = exercise.changeReps('10' as never);
       expect(result.success).toBe(false);
       expect(exercise.reps).not.toBe('10');
-    });
-
-    it('should return failure when reps is not an integer', () => {
-      const exercise = createTestExercise();
-      const result = exercise.changeReps(10.5);
-      expect(result.success).toBe(false);
-      expect(exercise.reps).not.toBe(10.5);
-    });
-
-    it('should return failure when reps is less than 1', () => {
-      const exercise = createTestExercise();
-      const result = exercise.changeReps(0);
-      expect(result.success).toBe(false);
     });
   });
 
@@ -171,23 +124,11 @@ describe('Exercise entity', () => {
       expect(exercise.weight).toBe(90);
     });
 
-    it('should return failure when weight is not a number', () => {
+    it('should return failure when weight is invalid', () => {
       const exercise = createTestExercise();
       const result = exercise.changeWeight('80' as never);
       expect(result.success).toBe(false);
       expect(exercise.weight).not.toBe('80');
-    });
-
-    it('should return failure when weight is negative', () => {
-      const exercise = createTestExercise();
-      const result = exercise.changeWeight(-10);
-      expect(result.success).toBe(false);
-    });
-
-    it('should return failure when weight is 0', () => {
-      const exercise = createTestExercise();
-      const result = exercise.changeWeight(0);
-      expect(result.success).toBe(false);
     });
   });
 

--- a/src/modules/exercise/domain/validation/exercise.validation.test.ts
+++ b/src/modules/exercise/domain/validation/exercise.validation.test.ts
@@ -60,10 +60,10 @@ describe('validateExercise', () => {
     };
 
     describe('Input', () => {
-      it('should fail when invalid input', () => {
-        expect(() =>
-          validateExercise(null as unknown as Parameters<typeof validateExercise>[0])
-        ).toThrow();
+      it('should fail when invalid input provided', () => {
+        const validation = validateExercise(null as never);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe('INVALID_EXERCISE_DATA');
       });
 
       it('should fail when any required key is missing', () => {

--- a/src/modules/routine/domain/routine.entity.test.ts
+++ b/src/modules/routine/domain/routine.entity.test.ts
@@ -42,7 +42,7 @@ describe('Routine entity', () => {
       expect(routineResult.success && routineResult.data instanceof Routine).toBe(true);
     });
 
-    it('should return failure when invalid id provided', async () => {
+    it('should return failure when routine data is invalid', async () => {
       const routineResult = Routine.create('invalid-id', {
         name: 'My Routine',
         description: 'Test description',
@@ -72,7 +72,7 @@ describe('Routine entity', () => {
       expect(routine.name).toBe('New Name');
     });
 
-    it('should return failure when name is not a string', async () => {
+    it('should return failure when name is invalid', async () => {
       const routine = createTestRoutine();
       const result = routine.changeName(123 as never);
       expect(result.success).toBe(false);
@@ -90,7 +90,7 @@ describe('Routine entity', () => {
       expect(routine.description).toBe('New description');
     });
 
-    it('should return failure when description is not a string or null', async () => {
+    it('should return failure when description is invalid', async () => {
       const routine = createTestRoutine();
       const result = routine.changeDescription(123 as never);
       expect(result.success).toBe(false);
@@ -159,7 +159,7 @@ describe('Routine entity', () => {
       expect(routine.cycle.id).toBe('custom');
     });
 
-    it('should return failure when cycleId is not valid', async () => {
+    it('should return failure when cycleId is invalid', async () => {
       const routine = createTestRoutine();
       const result = routine.changeCycle('invalid-cycle' as never);
       expect(result.success).toBe(false);
@@ -182,14 +182,7 @@ describe('Routine entity', () => {
       expect(routine.days).toBe(2);
     });
 
-    it('should return failure when routineDays is not an array', async () => {
-      const routine = createTestRoutine();
-      const result = routine.changeRoutineDays('not-an-array' as never);
-      expect(result.success).toBe(false);
-      expect(routine.routineDays).not.toBe('not-an-array');
-    });
-
-    it('should return failure when routineDays are invalid objects', async () => {
+    it('should return failure when routineDays is invalid', async () => {
       const routine = createTestRoutine();
       const newRoutineDays = [
         { id: '15', name: 'Day 1', day: 0, session: null },

--- a/src/modules/routine/domain/validation/routine.validation.test.ts
+++ b/src/modules/routine/domain/validation/routine.validation.test.ts
@@ -58,9 +58,9 @@ describe('validateRoutine', () => {
 
     describe('Input', () => {
       it('should fail when invalid input', () => {
-        expect(() =>
-          validateRoutine(null as unknown as Parameters<typeof validateRoutine>[0])
-        ).toThrow();
+        const validation = validateRoutine(null as never);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe('INVALID_ROUTINE_DATA');
       });
 
       it('should fail when any required key is missing', () => {

--- a/src/modules/user/application/use-cases/create-user.test.ts
+++ b/src/modules/user/application/use-cases/create-user.test.ts
@@ -68,7 +68,7 @@ describe('CreateUser use case', () => {
       expect(userRepoMock2.users).toHaveLength(10); // no users added
     });
 
-    it('should return failure result when user role not exists', async () => {
+    it('should return failure result when invalid user data provided', async () => {
       // Set up
       const userRepoMock2 = new InMemoryUserRepository();
       const idGeneratorMock = new MockIdGenerator();
@@ -79,34 +79,7 @@ describe('CreateUser use case', () => {
 
       // Data
       const userData: CreateUserInput = {
-        email: 'angel1234@gmail.com',
-        name: 'Angel 1234',
-        roleId: 'notExistingRole',
-      };
-
-      // Execute
-      const createUserResult = await useCase.execute(userData);
-
-      // Assert result pattern
-      expect(createUserResult.success).toBe(false);
-      expect(!createUserResult.success && createUserResult.error.code).toBe('ROLE_NOT_FOUND');
-
-      // Verify DB state
-      expect(userRepoMock2.users).toHaveLength(10); // no users added
-    });
-
-    it('should return failure result when user name is invalid', async () => {
-      // Set up
-      const userRepoMock2 = new InMemoryUserRepository();
-      const idGeneratorMock = new MockIdGenerator();
-      const useCase = new CreateUser(userRepoMock2, idGeneratorMock);
-
-      // Config
-      idGeneratorMock.id = '1df38173-6fae-4abb-8cb2-ce33b6c24da4';
-
-      // Data
-      const userData: CreateUserInput = {
-        email: 'angel1234@gmail.com',
+        email: 'angel1234@email.com',
         name: 'Angel',
         roleId: 'base',
       };
@@ -116,38 +89,9 @@ describe('CreateUser use case', () => {
 
       // Assert result pattern
       expect(createUserResult.success).toBe(false);
-      expect(!createUserResult.success && createUserResult.error.code).toBe(
-        'INVALID_USER_DATA.NAME'
-      );
-
-      // Verify DB state
-      expect(userRepoMock2.users).toHaveLength(10); // no users added
-    });
-
-    it('should return failure result when user email is invalid', async () => {
-      // Set up
-      const userRepoMock2 = new InMemoryUserRepository();
-      const idGeneratorMock = new MockIdGenerator();
-      const useCase = new CreateUser(userRepoMock2, idGeneratorMock);
-
-      // Config
-      idGeneratorMock.id = '1df38173-6fae-4abb-8cb2-ce33b6c24da4';
-
-      // Data
-      const userData: CreateUserInput = {
-        email: 'angel1234@not.valid.email.com',
-        name: 'Angel 1234',
-        roleId: 'base',
-      };
-
-      // Execute
-      const createUserResult = await useCase.execute(userData);
-
-      // Assert result pattern
-      expect(createUserResult.success).toBe(false);
-      expect(!createUserResult.success && createUserResult.error.code).toBe(
-        'INVALID_USER_DATA.EMAIL'
-      );
+      expect(
+        !createUserResult.success && createUserResult.error.code.startsWith('INVALID_USER_DATA')
+      ).toBe(true);
 
       // Verify DB state
       expect(userRepoMock2.users).toHaveLength(10); // no users added

--- a/src/modules/user/application/use-cases/update-user.test.ts
+++ b/src/modules/user/application/use-cases/update-user.test.ts
@@ -54,7 +54,7 @@ describe('UpdateUser use case', () => {
       expect(!updateUserResult.success && updateUserResult.error.code).toBe('USER_NOT_FOUND');
     });
 
-    it('should return failure result when invalid email provided', async () => {
+    it('should return failure result when invalid user data provided', async () => {
       // Set up
       const userRepoMock = new InMemoryUserRepository();
       const useCase = new UpdateUser(userRepoMock);
@@ -70,31 +70,9 @@ describe('UpdateUser use case', () => {
 
       // Assert result pattern
       expect(updateUserResult.success).toBe(false);
-      expect(!updateUserResult.success && updateUserResult.error.code).toBe(
-        'INVALID_USER_DATA.EMAIL'
-      );
-    });
-
-    it('should return failure result when invalid name provided', async () => {
-      // Set up
-      const userRepoMock = new InMemoryUserRepository();
-      const useCase = new UpdateUser(userRepoMock);
-
-      // Data
-      const user = userRepoMock.users[0] as User;
-      const userData: UpdateUserInput = {
-        invalidKey: 'Skipped',
-        name: 'New',
-      } as UpdateUserInput;
-
-      // Execute
-      const updateUserResult = await useCase.execute(user.id, userData);
-
-      // Assert result pattern
-      expect(updateUserResult.success).toBe(false);
-      expect(!updateUserResult.success && updateUserResult.error.code).toBe(
-        'INVALID_USER_DATA.NAME'
-      );
+      expect(
+        !updateUserResult.success && updateUserResult.error.code.startsWith('INVALID_USER_DATA')
+      ).toBe(true);
     });
   });
 

--- a/src/modules/user/domain/user.entity.test.ts
+++ b/src/modules/user/domain/user.entity.test.ts
@@ -15,7 +15,7 @@ describe('User entity', () => {
       expect(userResult.success && userResult.data instanceof User).toBe(true);
     });
 
-    it('should return failure when invalid id provided', async () => {
+    it('should return failure when invalid data provided', async () => {
       const userResult = User.create('invalid-id', {
         email: 'new@gmail.com',
         name: 'New User',
@@ -25,30 +25,6 @@ describe('User entity', () => {
       // Assert result pattern
       expect(userResult.success).toBe(false);
       expect(!userResult.success && userResult.error.code).toBe('INVALID_USER_DATA');
-    });
-
-    it('should return failure when invalid email provided', async () => {
-      const newUserResult = User.create('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
-        email: 'new$email.com',
-        name: 'New User',
-        roleId: 'base',
-      });
-
-      // Assert result pattern
-      expect(newUserResult.success).toBe(false);
-      expect(!newUserResult.success && newUserResult.error.code).toBe('INVALID_USER_DATA.EMAIL');
-    });
-
-    it('should return failure when invalid roleId provided', async () => {
-      const newUserResult = User.create('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
-        email: 'new@gmail.com',
-        name: 'New User',
-        roleId: 'notValidRole',
-      });
-
-      // Assert result pattern
-      expect(newUserResult.success).toBe(false);
-      expect(!newUserResult.success && newUserResult.error.code).toBe('ROLE_NOT_FOUND');
     });
   });
 
@@ -72,7 +48,7 @@ describe('User entity', () => {
       expect(user.name).toBe('New Name');
     });
 
-    it('should return failure when name provided has invalid minimum length', async () => {
+    it('should return failure when name provided is invalid', async () => {
       const userResult = User.create('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
         email: 'new@gmail.com',
         name: 'New User',
@@ -89,25 +65,6 @@ describe('User entity', () => {
 
       // Assert no property changes
       expect(user.name).not.toBe('123');
-    });
-
-    it('should return failure when name provided has invalid maximum length', async () => {
-      const userResult = User.create('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
-        email: 'new@gmail.com',
-        name: 'New User',
-        roleId: 'base',
-      });
-
-      const user = (userResult.success && userResult.data) as User;
-
-      const nameResult = user.changeName('New User With A Lot Of Characters Lenght');
-
-      // Assert result pattern
-      expect(nameResult.success).toBe(false);
-      expect(!nameResult.success && nameResult.error.code).toBe('INVALID_USER_DATA.NAME');
-
-      // Assert no property changes
-      expect(user.name).not.toBe('New User With A Lot Of Characters Lenght');
     });
   });
   describe('changeEmail()', () => {
@@ -130,7 +87,7 @@ describe('User entity', () => {
       expect(user.email).toBe('new.user.email@gmail.com');
     });
 
-    it('should return failure when email provided has invalid format', async () => {
+    it('should return failure when email provided is invalid', async () => {
       const userResult = User.create('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
         email: 'new@gmail.com',
         name: 'New User',
@@ -147,25 +104,6 @@ describe('User entity', () => {
 
       // Assert no property changes
       expect(user.email).not.toBe('not.a.valid.user.email@xs$gmail.com');
-    });
-
-    it('should return failure when email provided has invalid service provider', async () => {
-      const userResult = User.create('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
-        email: 'new@gmail.com',
-        name: 'New User',
-        roleId: 'base',
-      });
-
-      const user = (userResult.success && userResult.data) as User;
-
-      const nameResult = user.changeEmail('not.valid@service.com');
-
-      // Assert result pattern
-      expect(nameResult.success).toBe(false);
-      expect(!nameResult.success && nameResult.error.code).toBe('INVALID_USER_DATA.EMAIL');
-
-      // Assert no property changes
-      expect(user.name).not.toBe('not.valid@service.com');
     });
   });
 });

--- a/src/shared/domain/validation.utils.ts
+++ b/src/shared/domain/validation.utils.ts
@@ -25,7 +25,7 @@ export function isArray(value: unknown): value is Array<unknown> {
 }
 
 export function isObject(value: unknown): value is object {
-  return typeof value === 'object';
+  return value?.constructor === Object;
 }
 
 export function isDate(value: unknown): value is Date {


### PR DESCRIPTION
## Domain & Application Logic

### 1. The "What" and "Why"

**Intent:** Refactor
**Related Issue:** N/A

**Description:** Avoiding have fragile test. There are been removed those irrelevant tests that verify more than once a branch entrance
>

### 2. Clean Architecture Alignment

- [x] **Domain Layer:**
  - Improve `Routine` and `User` entity unit tests
  - Fix `Routine` and `User` validations unit tests
  - Fix `Domain` validation utilities bug
- [x] **Application Layer:** 
  -  Improve `CreateUser`, `UpdateUser` and `User` entity unit tests
  - Improve `CreateExercise`, `UpdateExercise` and `User` entity unit tests
- [x] **Dependency Rule:** I confirm that no Infrastructure or UI-specific code has leaked into this PR.

### 3. Verification Checklist

- [x] **Type Safety:** `pnpm typecheck` passes without errors.
- [x] **Code Health:** `pnpm safe-fixes` has been run and resolved linting/formatting.
- [x] **Logic Integrity:** `pnpm test` passes with modified tests.

### 4. Technical Nuances
Testing every possible permutation makes unit testing fragile. Update test to only test the behavior of the part they are testing. Keeping consistence of testing and making a non-fragile unit tests that would be updated every time the tested part changes.
-

### 5. Automated Check Confirmation

| Command           | Status  |
| :---------------- | :------ |
| `pnpm typecheck`  | ✅ |
| `pnpm safe-fixes` | ✅ |
| `pnpm test`       | ✅ |
---
