### PR TITLE
feat(routine): add CreateRoutine, UpdateRoutine unit tests

### DIFF
--- a/src/modules/routine/application/use-cases/create-routine.test.ts
+++ b/src/modules/routine/application/use-cases/create-routine.test.ts
@@ -1,0 +1,223 @@
+import '@testing-library/jest-dom';
+import { Failure } from '@/shared/domain/result';
+import { TechnicalError } from '@/shared/domain/errors/domain.errors';
+import { CreateRoutine } from '@/modules/routine/application/use-cases/create-routine';
+import { InMemoryRoutineRepository } from '@/modules/routine/mocks/routine.mocks.repository';
+import { InMemorySessionRepository } from '@/modules/session/mocks/session.mocks.repository';
+import { MockIdGenerator } from '@/shared/test/mocks/id-generator.repository.mock';
+import type { CreateRoutineInput } from '@/modules/routine/application/dtos/create-routine.dto';
+
+describe('CreateRoutine use case', () => {
+  describe('Happy Path', () => {
+    it('should create routine successfully with sessions', async () => {
+      const routineRepoMock = new InMemoryRoutineRepository();
+      const sessionRepoMock = new InMemorySessionRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new CreateRoutine(routineRepoMock, sessionRepoMock, idGeneratorMock);
+
+      const routineData: CreateRoutineInput = {
+        name: 'Push Pull Legs',
+        description: '3 day split',
+        active: true,
+        days: 3,
+        initialDate: new Date(),
+        cycleId: 'week',
+        userId: 'user-123',
+        routineDays: [
+          { name: 'Day 1', day: 1, sessionId: '1df38173-6fae-4abb-8cb2-ce33b6c24da4' },
+          { name: 'Day 2', day: 2, sessionId: '2df38173-6fae-4abb-8cb2-ce33b6c24da4' },
+          { name: 'Day 3', day: 3, sessionId: null },
+        ],
+      };
+
+      idGeneratorMock.id = '1df38173-6fae-4abb-8cb2-ce33b6c24da4';
+
+      const createResult = await useCase.execute(routineData);
+
+      expect(createResult.success).toBe(true);
+      expect(createResult.success && createResult.data.id).toBe(
+        '1df38173-6fae-4abb-8cb2-ce33b6c24da4'
+      );
+      expect(createResult.success && createResult.data.name).toBe('Push Pull Legs');
+      expect(routineRepoMock.routines).toHaveLength(1);
+    });
+
+    it('should create routine successfully with null sessions', async () => {
+      const routineRepoMock = new InMemoryRoutineRepository();
+      const sessionRepoMock = new InMemorySessionRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new CreateRoutine(routineRepoMock, sessionRepoMock, idGeneratorMock);
+
+      const routineData: CreateRoutineInput = {
+        name: 'Full Body',
+        description: null,
+        active: false,
+        days: 2,
+        initialDate: new Date(),
+        cycleId: 'custom',
+        userId: 'user-123',
+        routineDays: [
+          { name: 'Day 1', day: 1, sessionId: null },
+          { name: 'Day 2', day: 2, sessionId: null },
+        ],
+      };
+
+      idGeneratorMock.id = '1df38173-6fae-4abb-8cb2-ce33b6c24da5';
+
+      const createResult = await useCase.execute(routineData);
+
+      expect(createResult.success).toBe(true);
+      expect(createResult.success && createResult.data.id).toBe(
+        '1df38173-6fae-4abb-8cb2-ce33b6c24da5'
+      );
+      expect(createResult.success && createResult.data.days).toBe(2);
+      expect(routineRepoMock.routines).toHaveLength(1);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should return failure when session not found', async () => {
+      const routineRepoMock = new InMemoryRoutineRepository();
+      const sessionRepoMock = new InMemorySessionRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new CreateRoutine(routineRepoMock, sessionRepoMock, idGeneratorMock);
+
+      const routineData: CreateRoutineInput = {
+        name: 'Invalid Routine',
+        description: null,
+        active: true,
+        days: 1,
+        initialDate: new Date(),
+        cycleId: 'week',
+        userId: 'user-123',
+        routineDays: [{ name: 'Day 1', day: 1, sessionId: 'non-existent-session' }],
+      };
+
+      idGeneratorMock.id = '1df38173-6fae-4abb-8cb2-ce33b6c24da6';
+
+      const createResult = await useCase.execute(routineData);
+
+      expect(createResult.success).toBe(false);
+      expect(!createResult.success && createResult.error.code).toBe('SESSION_NOT_FOUND');
+      expect(routineRepoMock.routines).toHaveLength(0);
+    });
+
+    it('should return failure when invalid routine data', async () => {
+      const routineRepoMock = new InMemoryRoutineRepository();
+      const sessionRepoMock = new InMemorySessionRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new CreateRoutine(routineRepoMock, sessionRepoMock, idGeneratorMock);
+
+      const routineData: CreateRoutineInput = {
+        name: 'AB',
+        description: null,
+        active: true,
+        days: 1,
+        initialDate: new Date(),
+        cycleId: 'week',
+        userId: 'user-123',
+        routineDays: [{ name: 'Day 1', day: 1, sessionId: null }],
+      };
+
+      idGeneratorMock.id = '1df38173-6fae-4abb-8cb2-ce33b6c24da7';
+
+      const createResult = await useCase.execute(routineData);
+
+      expect(createResult.success).toBe(false);
+      expect(
+        !createResult.success && createResult.error.code.startsWith('INVALID_ROUTINE_DATA')
+      ).toBe(true);
+      expect(routineRepoMock.routines).toHaveLength(0);
+    });
+  });
+
+  describe('Dependency Interaction', () => {
+    it('should return failure when repository create operation fails', async () => {
+      const routineRepoMock = new InMemoryRoutineRepository();
+      const sessionRepoMock = new InMemorySessionRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new CreateRoutine(routineRepoMock, sessionRepoMock, idGeneratorMock);
+
+      jest
+        .spyOn(routineRepoMock, 'create')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+
+      const routineData: CreateRoutineInput = {
+        name: 'Test Routine',
+        description: null,
+        active: true,
+        days: 1,
+        initialDate: new Date(),
+        cycleId: 'week',
+        userId: 'user-123',
+        routineDays: [{ name: 'Day 1', day: 1, sessionId: null }],
+      };
+
+      idGeneratorMock.id = '1df38173-6fae-4abb-8cb2-ce33b6c24da8';
+
+      const createResult = await useCase.execute(routineData);
+
+      expect(createResult.success).toBe(false);
+      expect(!createResult.success && createResult.error.code).toBe('TECHNICAL_ERROR');
+      expect(routineRepoMock.routines).toHaveLength(0);
+    });
+
+    it('should return failure when idGenerator generate operation fails', async () => {
+      const routineRepoMock = new InMemoryRoutineRepository();
+      const sessionRepoMock = new InMemorySessionRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new CreateRoutine(routineRepoMock, sessionRepoMock, idGeneratorMock);
+
+      jest
+        .spyOn(idGeneratorMock, 'generate')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+
+      const routineData: CreateRoutineInput = {
+        name: 'Test Routine',
+        description: null,
+        active: true,
+        days: 1,
+        initialDate: new Date(),
+        cycleId: 'week',
+        userId: 'user-123',
+        routineDays: [{ name: 'Day 1', day: 1, sessionId: null }],
+      };
+
+      const createResult = await useCase.execute(routineData);
+
+      expect(createResult.success).toBe(false);
+      expect(!createResult.success && createResult.error.code).toBe('TECHNICAL_ERROR');
+      expect(routineRepoMock.routines).toHaveLength(0);
+    });
+
+    it('should return failure when session repository findById fails', async () => {
+      const routineRepoMock = new InMemoryRoutineRepository();
+      const sessionRepoMock = new InMemorySessionRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new CreateRoutine(routineRepoMock, sessionRepoMock, idGeneratorMock);
+
+      jest
+        .spyOn(sessionRepoMock, 'findById')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+
+      const routineData: CreateRoutineInput = {
+        name: 'Test Routine',
+        description: null,
+        active: true,
+        days: 1,
+        initialDate: new Date(),
+        cycleId: 'week',
+        userId: 'user-123',
+        routineDays: [{ name: 'Day 1', day: 1, sessionId: 'session-1' }],
+      };
+
+      idGeneratorMock.id = '1df38173-6fae-4abb-8cb2-ce33b6c24d10';
+
+      const createResult = await useCase.execute(routineData);
+
+      expect(createResult.success).toBe(false);
+      expect(!createResult.success && createResult.error.code).toBe('TECHNICAL_ERROR');
+      expect(routineRepoMock.routines).toHaveLength(0);
+    });
+  });
+});

--- a/src/modules/routine/application/use-cases/create-routine.ts
+++ b/src/modules/routine/application/use-cases/create-routine.ts
@@ -1,9 +1,6 @@
 import { Failure } from '@/shared/domain/result';
 import { Routine } from '@/modules/routine/domain/routine.entity';
-import {
-  InvalidRoutineDays,
-  RoutineNotFoundError,
-} from '@/modules/routine/domain/errors/routine.errors';
+import { InvalidRoutineData } from '@/modules/routine/domain/errors/routine.errors';
 import type { CreateRoutineInput } from '@/modules/routine/application/dtos/create-routine.dto';
 import type { IdGeneratorRepository } from '@/shared/application/id-generator.repository';
 import type { IRoutineRepository } from '@/modules/routine/domain/routine.repository';
@@ -11,6 +8,7 @@ import type { ISessionRepository } from '@/modules/session/domain/session.reposi
 import type { RoutineProps } from '@/modules/routine/domain/routine.types';
 import type { Session } from '@/modules/session/domain/session.entity';
 import type { UseCase } from '@/shared/application/shared.use-case';
+import { SessionNotFoundError } from '@/modules/auth/domain/errors/auth.errors';
 
 export class CreateRoutine implements UseCase {
   constructor(
@@ -34,17 +32,15 @@ export class CreateRoutine implements UseCase {
       }
       const sessionResult = await this.sessionRepository.findById(routineDay.sessionId);
       if (!sessionResult.success) return sessionResult;
+      if (!sessionResult.data) return Failure(new SessionNotFoundError());
       sessions.push(sessionResult.data);
     }
-
-    if (sessions.length !== routineData.routineDays.length)
-      return Failure(new RoutineNotFoundError());
 
     const routineDays: RoutineProps['routineDays'] = [];
 
     for (let i = 0; i < routineData.routineDays.length; i++) {
       const routineDay = routineData.routineDays[i];
-      if (!routineDay) return Failure(new InvalidRoutineDays());
+      if (!routineDay) return Failure(new InvalidRoutineData('ROUTINE_DAYS'));
 
       const sessionIdResult = await this.generator.generate();
       if (!sessionIdResult.success) return sessionIdResult;

--- a/src/modules/routine/application/use-cases/update-routine.test.ts
+++ b/src/modules/routine/application/use-cases/update-routine.test.ts
@@ -1,0 +1,271 @@
+import '@testing-library/jest-dom';
+import { Failure } from '@/shared/domain/result';
+import { TechnicalError } from '@/shared/domain/errors/domain.errors';
+import { UpdateRoutine } from '@/modules/routine/application/use-cases/update-routine';
+import { InMemoryRoutineRepository } from '@/modules/routine/mocks/routine.mocks.repository';
+import { InMemorySessionRepository } from '@/modules/session/mocks/session.mocks.repository';
+import { Routine } from '@/modules/routine/domain/routine.entity';
+import { MockIdGenerator } from '@/shared/test/mocks/id-generator.repository.mock';
+
+describe('UpdateRoutine use case', () => {
+  describe('Happy Path', () => {
+    it('should update routine successfully', async () => {
+      const routineRepoMock = new InMemoryRoutineRepository();
+      const sessionRepoMock = new InMemorySessionRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new UpdateRoutine(routineRepoMock, sessionRepoMock, idGeneratorMock);
+
+      const routineId = '1df38173-6fae-4abb-8cb2-ce33b6c24da1';
+      const routine = Routine.create(routineId, {
+        name: 'Original Name',
+        description: null,
+        active: true,
+        days: 1,
+        initialDate: new Date(),
+        cycleId: 'week',
+        routineDays: [
+          { id: '1df38173-6fae-4abb-8cb2-ce33b6c24d01', day: 1, name: 'Day 1', session: null },
+        ],
+        userId: 'user-123',
+      });
+      if (!routine.success) throw new Error('Failed to create routine');
+      await routineRepoMock.create(routine.data);
+
+      expect(routineRepoMock.routines[0]?.name).not.toBe('Updated Routine');
+
+      const updateResult = await useCase.execute(routineId, { name: 'Updated Routine' });
+
+      expect(updateResult.success).toBe(true);
+      expect(updateResult.success && updateResult.data.id).toBe(routineId);
+      expect(updateResult.success && updateResult.data.name).toBe('Updated Routine');
+      expect(routineRepoMock.routines[0]?.name).toBe('Updated Routine');
+    });
+
+    it('should update multiple fields including routineDays', async () => {
+      const routineRepoMock = new InMemoryRoutineRepository();
+      const sessionRepoMock = new InMemorySessionRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new UpdateRoutine(routineRepoMock, sessionRepoMock, idGeneratorMock);
+
+      const routineId = '1df38173-6fae-4abb-8cb2-ce33b6c24da2';
+      const routine = Routine.create(routineId, {
+        name: 'Original',
+        description: null,
+        active: false,
+        days: 1,
+        initialDate: new Date(),
+        cycleId: 'week',
+        routineDays: [
+          { id: '1df38173-6fae-4abb-8cb2-ce33b6c24d02', day: 1, name: 'Day 1', session: null },
+        ],
+        userId: 'user-123',
+      });
+      if (!routine.success) throw new Error('Failed to create routine');
+      await routineRepoMock.create(routine.data);
+
+      idGeneratorMock.id = '1df38173-6fae-4abb-8cb2-ce33b6c24d03';
+      const updateResult = await useCase.execute(routineId, {
+        name: 'Updated',
+        active: true,
+        days: 2,
+        routineDays: [
+          { name: 'Day 1', day: 1, sessionId: '1df38173-6fae-4abb-8cb2-ce33b6c24da4' },
+          { name: 'Day 2', day: 2, sessionId: null },
+        ],
+      });
+
+      expect(updateResult.success).toBe(true);
+      expect(updateResult.success && updateResult.data.name).toBe('Updated');
+      expect(updateResult.success && updateResult.data.active).toBe(true);
+      expect(updateResult.success && updateResult.data.days).toBe(2);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should return failure when routine not found', async () => {
+      const routineRepoMock = new InMemoryRoutineRepository();
+      const sessionRepoMock = new InMemorySessionRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new UpdateRoutine(routineRepoMock, sessionRepoMock, idGeneratorMock);
+
+      const updateResult = await useCase.execute('1df38173-6fae-4abb-8cb2-ce33b6c24d99', {
+        name: 'New Name',
+      });
+
+      expect(updateResult.success).toBe(false);
+      expect(!updateResult.success && updateResult.error.code).toBe('ROUTINE_NOT_FOUND');
+    });
+
+    it('should return failure when session not found', async () => {
+      const routineRepoMock = new InMemoryRoutineRepository();
+      const sessionRepoMock = new InMemorySessionRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new UpdateRoutine(routineRepoMock, sessionRepoMock, idGeneratorMock);
+
+      const updateResult = await useCase.execute('1df38173-6fae-4abb-8cb2-ce33b6c24d99', {
+        name: 'New Name',
+        routineDays: [
+          {
+            day: 1,
+            name: 'Day 1',
+            sessionId: 'not-existing-session',
+          },
+        ],
+      });
+
+      expect(updateResult.success).toBe(false);
+      expect(!updateResult.success && updateResult.error.code).toBe('ROUTINE_NOT_FOUND');
+    });
+
+    it('should return failure when invalid data provided', async () => {
+      const routineRepoMock = new InMemoryRoutineRepository();
+      const sessionRepoMock = new InMemorySessionRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new UpdateRoutine(routineRepoMock, sessionRepoMock, idGeneratorMock);
+
+      const routineId = '1df38173-6fae-4abb-8cb2-ce33b6c24da3';
+      const routine = Routine.create(routineId, {
+        name: 'Valid Name',
+        description: null,
+        active: true,
+        days: 1,
+        initialDate: new Date(),
+        cycleId: 'week',
+        routineDays: [
+          { id: '1df38173-6fae-4abb-8cb2-ce33b6c24d04', day: 1, name: 'Day 1', session: null },
+        ],
+        userId: 'user-123',
+      });
+      if (!routine.success) throw new Error('Failed to create routine');
+      await routineRepoMock.create(routine.data);
+
+      const updateResult = await useCase.execute(routineId, { name: 'AB' });
+
+      expect(updateResult.success).toBe(false);
+      expect(
+        !updateResult.success && updateResult.error.code.startsWith('INVALID_ROUTINE_DATA')
+      ).toBe(true);
+    });
+  });
+
+  describe('Dependency Interaction', () => {
+    it('should return failure when repository update operation fails', async () => {
+      const routineRepoMock = new InMemoryRoutineRepository();
+      const sessionRepoMock = new InMemorySessionRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new UpdateRoutine(routineRepoMock, sessionRepoMock, idGeneratorMock);
+
+      const routineId = '1df38173-6fae-4abb-8cb2-ce33b6c24da5';
+      const routine = Routine.create(routineId, {
+        name: 'Test',
+        description: null,
+        active: true,
+        days: 1,
+        initialDate: new Date(),
+        cycleId: 'week',
+        routineDays: [
+          { id: '1df38173-6fae-4abb-8cb2-ce33b6c24d06', day: 1, name: 'Day 1', session: null },
+        ],
+        userId: 'user-123',
+      });
+      if (!routine.success) throw new Error('Failed to create routine');
+      await routineRepoMock.create(routine.data);
+
+      jest
+        .spyOn(routineRepoMock, 'update')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+
+      const updateResult = await useCase.execute(routineId, { name: 'Updated' });
+
+      expect(updateResult.success).toBe(false);
+      expect(!updateResult.success && updateResult.error.code).toBe('TECHNICAL_ERROR');
+      expect(routineRepoMock.routines[0]?.name).not.toBe('Updated');
+    });
+
+    it('should return failure when repository findById operation fails', async () => {
+      const routineRepoMock = new InMemoryRoutineRepository();
+      const sessionRepoMock = new InMemorySessionRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new UpdateRoutine(routineRepoMock, sessionRepoMock, idGeneratorMock);
+
+      jest
+        .spyOn(routineRepoMock, 'findById')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+
+      const updateResult = await useCase.execute('1df38173-6fae-4abb-8cb2-ce33b6c24da6', {
+        name: 'Updated',
+      });
+
+      expect(updateResult.success).toBe(false);
+      expect(!updateResult.success && updateResult.error.code).toBe('TECHNICAL_ERROR');
+    });
+
+    it('should return failure when idGenerator fails during routineDays update', async () => {
+      const routineRepoMock = new InMemoryRoutineRepository();
+      const sessionRepoMock = new InMemorySessionRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new UpdateRoutine(routineRepoMock, sessionRepoMock, idGeneratorMock);
+
+      const routineId = '1df38173-6fae-4abb-8cb2-ce33b6c24da7';
+      const routine = Routine.create(routineId, {
+        name: 'Test',
+        description: null,
+        active: true,
+        days: 1,
+        initialDate: new Date(),
+        cycleId: 'week',
+        routineDays: [
+          { id: '1df38173-6fae-4abb-8cb2-ce33b6c24d07', day: 1, name: 'Day 1', session: null },
+        ],
+        userId: 'user-123',
+      });
+      if (!routine.success) throw new Error('Failed to create routine');
+      await routineRepoMock.create(routine.data);
+
+      jest
+        .spyOn(idGeneratorMock, 'generate')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+
+      const updateResult = await useCase.execute(routineId, {
+        routineDays: [{ name: 'Day 1', day: 1, sessionId: null }],
+      });
+
+      expect(updateResult.success).toBe(false);
+      expect(!updateResult.success && updateResult.error.code).toBe('TECHNICAL_ERROR');
+    });
+
+    it('should return failure when session operation findById fails', async () => {
+      const routineRepoMock = new InMemoryRoutineRepository();
+      const sessionRepoMock = new InMemorySessionRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new UpdateRoutine(routineRepoMock, sessionRepoMock, idGeneratorMock);
+
+      jest
+        .spyOn(sessionRepoMock, 'findById')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+
+      const routineId = '1df38173-6fae-4abb-8cb2-ce33b6c24da4';
+      const routine = Routine.create(routineId, {
+        name: 'Test',
+        description: null,
+        active: true,
+        days: 1,
+        initialDate: new Date(),
+        cycleId: 'week',
+        routineDays: [
+          { id: '1df38173-6fae-4abb-8cb2-ce33b6c24d05', day: 1, name: 'Day 1', session: null },
+        ],
+        userId: 'user-123',
+      });
+      if (!routine.success) throw new Error('Failed to create routine');
+      await routineRepoMock.create(routine.data);
+
+      const updateResult = await useCase.execute(routineId, {
+        routineDays: [{ name: 'Day 1', day: 1, sessionId: '1df38173-6fae-4abb-8cb2-ce33b6c24da4' }],
+      });
+
+      expect(updateResult.success).toBe(false);
+      expect(!updateResult.success && updateResult.error.code).toBe('TECHNICAL_ERROR');
+    });
+  });
+});

--- a/src/modules/routine/application/use-cases/update-routine.ts
+++ b/src/modules/routine/application/use-cases/update-routine.ts
@@ -6,6 +6,7 @@ import type { IRoutineRepository } from '@/modules/routine/domain/routine.reposi
 import type { ISessionRepository } from '@/modules/session/domain/session.repository';
 import type { UpdateRoutineInput } from '@/modules/routine/application/dtos/update-routine.dto';
 import type { IdGeneratorRepository } from '@/shared/application/id-generator.repository';
+import { SessionNotFoundError } from '@/modules/session/domain/errors/session.errors';
 
 export class UpdateRoutine implements UseCase {
   constructor(
@@ -69,6 +70,7 @@ export class UpdateRoutine implements UseCase {
         }
         const sessionResult = await this.sessionRepository.findById(routineDay.sessionId);
         if (!sessionResult.success) return sessionResult;
+        if (!sessionResult.data) return Failure(new SessionNotFoundError());
         routineDays.push({
           ...routineDayBaseProps,
           session: sessionResult.data,

--- a/src/modules/routine/mocks/routine.mocks.repository.ts
+++ b/src/modules/routine/mocks/routine.mocks.repository.ts
@@ -1,0 +1,68 @@
+import { Success } from '@/shared/domain/result';
+import { Routine } from '@/modules/routine/domain/routine.entity';
+import type { RoutineProps } from '@/modules/routine/domain/routine.types';
+import type { IRoutineRepository } from '@/modules/routine/domain/routine.repository';
+
+export class InMemoryRoutineRepository implements IRoutineRepository {
+  public routines: Routine[] = [];
+  async create(data: Routine) {
+    this.routines.push(data);
+    return Success(this.getCopy(data));
+  }
+  async update(data: Routine) {
+    const index = this.routines.findIndex((r) => r.id === data.id);
+    if (index !== -1) this.routines[index] = data;
+    return Success(this.getCopy(data));
+  }
+  async findaAll() {
+    return Success(this.getCopies(this.routines));
+  }
+  async findById(id: RoutineProps['id']) {
+    const routine = this.routines.find((r) => r.id === id);
+    if (!routine) return Success(null);
+    return Success(this.getCopy(routine));
+  }
+  async delete(id: RoutineProps['id']) {
+    const routine = this.routines.find((r) => r.id === id);
+    if (!routine)
+      return Success(
+        routine ??
+          new Routine({
+            id: '',
+            name: '',
+            description: null,
+            active: false,
+            days: 0,
+            initialDate: new Date(),
+            cycle: { id: 'week', name: 'Week' },
+            routineDays: [],
+            userId: '',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          })
+      );
+    this.routines = this.routines.filter((r) => r.id !== id);
+    return Success(this.getCopy(routine));
+  }
+
+  private getCopy(routine: Routine): Routine {
+    const props: RoutineProps = {
+      id: routine.id,
+      name: routine.name,
+      description: routine.description,
+      active: routine.active,
+      days: routine.days,
+      initialDate: routine.initialDate,
+      cycle: routine.cycle,
+      routineDays: routine.routineDays,
+      userId: routine.userId,
+      createdAt: routine.createdAt,
+      updatedAt: routine.updatedAt,
+    };
+    return new Routine(props);
+  }
+
+  private getCopies(routines: Routine[]): Routine[] {
+    return routines.map((r) => this.getCopy(r));
+  }
+}

--- a/src/modules/session/mocks/session.mocks.repository.ts
+++ b/src/modules/session/mocks/session.mocks.repository.ts
@@ -1,0 +1,68 @@
+import { Success } from '@/shared/domain/result';
+import { Session } from '@/modules/session/domain/session.entity';
+import type { SessionProps } from '@/modules/session/domain/session.types';
+import type { ISessionRepository } from '@/modules/session/domain/session.repository';
+
+const MOCK_SESSIONS: SessionProps[] = [
+  {
+    id: '1df38173-6fae-4abb-8cb2-ce33b6c24da4',
+    name: 'Push Day',
+    description: 'Chest and triceps workout',
+    userId: 'user-123',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    exercises: [],
+  },
+  {
+    id: '2df38173-6fae-4abb-8cb2-ce33b6c24da4',
+    name: 'Pull Day',
+    description: 'Back and biceps workout',
+    userId: 'user-123',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    exercises: [],
+  },
+];
+
+export class InMemorySessionRepository implements ISessionRepository {
+  public sessions: Session[] = MOCK_SESSIONS.map((s) => new Session(s));
+  async create(data: Session) {
+    this.sessions.push(data);
+    return Success(data);
+  }
+  async update(data: Session) {
+    const index = this.sessions.findIndex((s) => s.id === data.id);
+    if (index !== -1) this.sessions[index] = data;
+    return Success(data);
+  }
+  async findAll() {
+    return Success([...this.sessions]);
+  }
+  async findById(id: SessionProps['id']) {
+    const session = this.sessions.find((s) => s.id === id);
+    if (!session) return Success(null);
+    return Success(session);
+  }
+  async findByIds(ids: SessionProps['id'][]) {
+    const sessions = this.sessions.filter((s) => ids.includes(s.id));
+    return Success([...sessions]);
+  }
+  async delete(id: SessionProps['id']) {
+    const session = this.sessions.find((s) => s.id === id);
+    if (!session)
+      return Success(
+        session ??
+          new Session({
+            id: '',
+            name: '',
+            description: null,
+            exercises: [],
+            userId: '',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          })
+      );
+    this.sessions = this.sessions.filter((s) => s.id !== id);
+    return Success(session);
+  }
+}


### PR DESCRIPTION
## Domain & Application Logic

### 1. The "What" and "Why"

**Intent:** Feature
**Related Issue:** N/A

**Description:** Add unit test for `Routine`'s `CreateRoutine` and `UpdateRoutine` use case.

>

### 2. Clean Architecture Alignment

- [x] **Domain Layer:** Add `Routine` and `Session` in memory mocks
- [x] **Application Layer:** 
  - Add `CreateRoutine` new errors handling and unit tests
  - Add `UpdateRoutine` new errors handling and unit tests
- [x] **Dependency Rule:** I confirm that no Infrastructure or UI-specific code has leaked into this PR.

### 3. Verification Checklist

These commands **must** pass locally before marking the PR as "Ready for Review."

- [x] **Type Safety:** `pnpm typecheck` passes without errors.
- [x] **Code Health:** `pnpm safe-fixes` has been run and resolved linting/formatting.
- [x] **Logic Integrity:** `pnpm test` passes with new ones.

### 4. Technical Nuances
To keep code safety it is added unit testing for data writing use cases `CreateRoutine` and `UpdateRoutine`.


-

### 5. Automated Check Confirmation

| Command           | Status  |
| :---------------- | :------ |
| `pnpm typecheck`  | ✅ |
| `pnpm safe-fixes` | ✅ |
| `pnpm test`       | ✅ |

---

_Note: If this PR touches UI or Database schemas, please use the **Infrastructure** or **Presentation** templates instead._
