### PR TITLE
feat(session): Add domain validation constants and utilities with tests

### DIFF
--- a/src/modules/session/domain/validation/session.validation.constants.ts
+++ b/src/modules/session/domain/validation/session.validation.constants.ts
@@ -1,0 +1,9 @@
+export const SESSION_NAME_LENGTH = {
+  min: 3,
+  max: 30,
+};
+
+export const SESSION_DESCRIPTION_LENGTH = {
+  min: 0,
+  max: 100,
+};

--- a/src/modules/session/domain/validation/session.validation.test.ts
+++ b/src/modules/session/domain/validation/session.validation.test.ts
@@ -1,0 +1,131 @@
+import '@testing-library/jest-dom';
+import { MockIdGenerator } from '@/shared/test/mocks/id-generator.repository.mock';
+import { validateSession } from './session.validation';
+import { Session } from '../session.entity';
+
+describe('validateSession', () => {
+  describe('Happy path', () => {
+    it('should validate and return session successfully', () => {
+      const idGeneratorMock = new MockIdGenerator();
+      const id = idGeneratorMock.id;
+
+      const validation = validateSession({
+        id,
+        name: 'Session',
+        description: null,
+        exercises: [],
+        userId: id,
+      });
+
+      expect(validation.success).toBe(true);
+      expect(validation.success && validation.data instanceof Session).toBe(true);
+    });
+  });
+
+  describe('Exceptions', () => {
+    const idGeneratorMock = new MockIdGenerator();
+    const validId = idGeneratorMock.id;
+
+    const validSessionData = {
+      id: validId,
+      name: 'Session',
+      description: null,
+      exercises: [],
+      userId: validId,
+    };
+
+    describe('Input', () => {
+      it('should fail when invalid input', () => {
+        const validation = validateSession(null as never);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe('TECHNICAL_ERROR');
+      });
+
+      it('should fail when any required key is missing', () => {
+        const { id: _, ...rest } = validSessionData;
+        const validation = validateSession(rest as never);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe('TECHNICAL_ERROR');
+      });
+    });
+
+    describe('ID field', () => {
+      it('should fail when is not a valid UUID', () => {
+        const validation = validateSession({
+          ...validSessionData,
+          id: 'invalid-uuid',
+        } as unknown as Parameters<typeof validateSession>[0]);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe('TECHNICAL_ERROR');
+      });
+
+      it('should fail when is not a string', () => {
+        const validation = validateSession({
+          ...validSessionData,
+          id: 123,
+        } as unknown as Parameters<typeof validateSession>[0]);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe('TECHNICAL_ERROR');
+      });
+    });
+
+    describe('NAME field', () => {
+      it('should fail is too short (less than 3 chars)', () => {
+        const validation = validateSession({
+          ...validSessionData,
+          name: 'ab',
+        } as unknown as Parameters<typeof validateSession>[0]);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe('TECHNICAL_ERROR');
+      });
+
+      it('should fail when is too long (more than 30 chars)', () => {
+        const validation = validateSession({
+          ...validSessionData,
+          name: 'a'.repeat(31),
+        } as unknown as Parameters<typeof validateSession>[0]);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe('TECHNICAL_ERROR');
+      });
+
+      it('should fail when is not a string', () => {
+        const validation = validateSession({
+          ...validSessionData,
+          name: 123,
+        } as unknown as Parameters<typeof validateSession>[0]);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe('TECHNICAL_ERROR');
+      });
+    });
+
+    describe('DESCRIPTION field', () => {
+      it('should fail when is not a string or null', () => {
+        const validation = validateSession({
+          ...validSessionData,
+          description: 123,
+        } as unknown as Parameters<typeof validateSession>[0]);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe('TECHNICAL_ERROR');
+      });
+
+      it('should fail when is too long (more than 100 chars)', () => {
+        const validation = validateSession({
+          ...validSessionData,
+          description: 'a'.repeat(101),
+        } as unknown as Parameters<typeof validateSession>[0]);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe('TECHNICAL_ERROR');
+      });
+    });
+
+    describe('Extra non-existing keys', () => {
+      it('should pass when extra key exists in input', () => {
+        const validation = validateSession({
+          ...validSessionData,
+          extraKey: 'value',
+        } as unknown as Parameters<typeof validateSession>[0]);
+        expect(validation.success).toBe(true);
+      });
+    });
+  });
+});

--- a/src/modules/session/domain/validation/session.validation.ts
+++ b/src/modules/session/domain/validation/session.validation.ts
@@ -1,0 +1,62 @@
+import type { Result } from '@/shared/domain/result';
+import type { ValidationFunction } from '@/shared/shared.types';
+import type { SessionProps } from '../session.types';
+import type { DomainError } from '@/shared/domain/errors/domain.errors';
+import {
+  isValidSessionDescription,
+  isValidSessionId,
+  isValidSessionName,
+} from './session.validation.utils';
+import { TechnicalError } from '@/shared/domain/errors/domain.errors';
+import { Session } from '../session.entity';
+import { Failure, Success } from '@/shared/domain/result';
+import { isKeyOf, isObject } from '@/shared/domain/validation.utils';
+
+type SessionFactoryData = Omit<SessionProps, 'createdAt' | 'updatedAt' | 'userId' | 'exercises'>;
+
+type SessionValidators = {
+  [K in keyof SessionFactoryData]: {
+    validate: ValidationFunction;
+    error: DomainError;
+  };
+};
+
+export const sessionValidators: SessionValidators = {
+  id: {
+    validate: isValidSessionId,
+    error: new TechnicalError(),
+  },
+  name: {
+    validate: isValidSessionName,
+    error: new TechnicalError(),
+  },
+  description: {
+    validate: isValidSessionDescription,
+    error: new TechnicalError(),
+  },
+};
+
+export function validateSession(
+  session: Omit<SessionProps, 'createdAt' | 'updatedAt'>
+): Result<Session, DomainError> {
+  if (!isObject(session)) return Failure(new TechnicalError());
+  const validatorKeys = Object.keys(sessionValidators) as (keyof SessionFactoryData)[];
+  for (const key of validatorKeys) {
+    if (!isKeyOf(key, session)) return Failure(new TechnicalError());
+    const validate = sessionValidators[key].validate;
+    const value = session[key];
+    if (!validate(value)) return Failure(sessionValidators[key].error);
+  }
+
+  const newSession = new Session({
+    id: session.id,
+    name: session.name,
+    description: session.description,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    userId: session.userId,
+    exercises: session.exercises,
+  });
+
+  return Success(newSession);
+}

--- a/src/modules/session/domain/validation/session.validation.utils.ts
+++ b/src/modules/session/domain/validation/session.validation.utils.ts
@@ -1,0 +1,20 @@
+import { isString, isValidUuid } from '@/shared/domain/validation.utils';
+import { SESSION_DESCRIPTION_LENGTH, SESSION_NAME_LENGTH } from './session.validation.constants';
+
+export function isValidSessionId(id: unknown) {
+  return isValidUuid(id);
+}
+
+export function isValidSessionName(name: unknown) {
+  if (name === null) return true;
+  if (!isString(name)) return false;
+  if (name.length < SESSION_NAME_LENGTH.min) return false;
+  return name.length <= SESSION_NAME_LENGTH.max;
+}
+
+export function isValidSessionDescription(description: unknown) {
+  if (description === null) return true;
+  if (!isString(description)) return false;
+  if (description.length < SESSION_DESCRIPTION_LENGTH.min) return false;
+  return description.length <= SESSION_DESCRIPTION_LENGTH.max;
+}


### PR DESCRIPTION
## Domain & Application Logic

### 1. The "What" and "Why"

**Intent:** Feature
**Related Issue:** N/A

**Description:** Add domain validation system for `Session` domain data

>

### 2. Clean Architecture Alignment

- [x] **Domain Layer:**
  - Add validation constants and utilities for `Session` domain data
- [ ] **Application Layer:** No changes made
- [x] **Dependency Rule:** I confirm that no Infrastructure or UI-specific code has leaked into this PR.

### 3. Verification Checklist

- [x] **Type Safety:** `pnpm typecheck` passes without errors.
- [x] **Code Health:** `pnpm safe-fixes` has been run and resolved linting/formatting.
- [x] **Logic Integrity:** `pnpm test` passes with new one.

### 4. Technical Nuances
With the main goal of use result pattern in `Session` entity methods. It is added a validation system for non-controlled fields of `Session`. the validation system is not integrated yet.


### 5. Automated Check Confirmation

| Command           | Status  |
| :---------------- | :------ |
| `pnpm typecheck`  | ✅ |
| `pnpm safe-fixes` | ✅ |
| `pnpm test`       | ✅ |

---
