### PR TITLE
feat(session): Add SessionMethods type and validation helpers for UpdateUser

### DIFF
--- a/src/modules/session/application/helpers/update-session.use-case.helpers.ts
+++ b/src/modules/session/application/helpers/update-session.use-case.helpers.ts
@@ -1,0 +1,30 @@
+import type { Result } from '@/shared/domain/result';
+import type { DomainError } from '@/shared/domain/errors/domain.errors';
+import type { SessionMethods } from '@/modules/session/domain/session.types';
+import type { UpdateSessionInput } from '@/modules/session/application/dtos/update-session.dto';
+import type { Session } from '@/modules/session/domain/session.entity';
+import { Success } from '@/shared/domain/result';
+
+type UpdateOperations = {
+  [K in keyof UpdateSessionInput]: keyof SessionMethods;
+};
+
+const updateOperations: UpdateOperations = {
+  name: 'changeName',
+  description: 'changeDescription',
+};
+
+export function updateSessionProperties(
+  data: UpdateSessionInput,
+  routine: Session
+): Result<null, DomainError> {
+  const dataKeys = Object.keys(data) as (keyof UpdateSessionInput)[];
+  for (const key of dataKeys) {
+    const methodKey = updateOperations[key];
+    if (!methodKey || !data[key]) continue;
+    const newValue = data[key] as never;
+    const updateResult = routine[methodKey](newValue);
+    if (!updateResult.success) return updateResult;
+  }
+  return Success(null);
+}

--- a/src/modules/session/application/use-cases/update-session.ts
+++ b/src/modules/session/application/use-cases/update-session.ts
@@ -1,10 +1,12 @@
+import type { Result } from '@/shared/domain/result';
+import type { DomainError } from '@/shared/domain/errors/domain.errors';
 import type { IExerciseRepository } from '@/modules/exercise/domain/exercise.repository';
 import type { ISessionRepository } from '@/modules/session/domain/session.repository';
 import type { SessionProps } from '@/modules/session/domain/session.types';
 import type { UpdateSessionInput } from '@/modules/session/application/dtos/update-session.dto';
 import type { UseCase } from '@/shared/application/shared.use-case';
 import type { Exercise } from '@/modules/exercise/domain/exercise.entity';
-import { Failure } from '@/shared/domain/result';
+import { Failure, Success } from '@/shared/domain/result';
 import { SessionNotFoundError } from '@/modules/session/domain/errors/session.errors';
 import {
   ExerciseNotFoundError,
@@ -12,6 +14,7 @@ import {
 } from '@/modules/exercise/domain/errors/exercise.errors';
 import { isArray } from '@/shared/domain/validation/validation.non-primitives';
 import { isArrayOf } from '@/shared/domain/validation/validation.utils';
+import { updateSessionProperties } from '@/modules/session/application/helpers/update-session.use-case.helpers';
 
 export class UpdateSession implements UseCase {
   constructor(
@@ -26,30 +29,30 @@ export class UpdateSession implements UseCase {
 
     const session = sessionResult.data;
 
-    if (data.name) {
-      const nameResult = session.changeName(data.name);
-      if (!nameResult.success) return nameResult;
-    }
+    const updatePropsResult = updateSessionProperties(data, session);
+    if (!updatePropsResult.success) return updatePropsResult;
 
-    if (data.description) {
-      const descriptionName = session.changeDescription(data.description);
-      if (!descriptionName.success) return descriptionName;
-    }
-
-    const exercises: Exercise[] = [];
-    if (data.exerciseIds) {
-      if (!isArray(data.exerciseIds)) return Failure(new InvalidExerciseData());
-      if (!isArrayOf(data.exerciseIds, 'string')) return Failure(new InvalidExerciseData());
-      const exercisesFindById = data.exerciseIds.map((id) => this.exerciseRepository.findById(id));
-      const exercisesResults = await Promise.all(exercisesFindById);
-      for (const exerciseResult of exercisesResults) {
-        if (!exerciseResult.success) return exerciseResult;
-        if (!exerciseResult.data) return Failure(new ExerciseNotFoundError());
-        exercises.push(exerciseResult.data);
-      }
-      session.changeExercises(exercises);
-    }
+    const exercisesResult = await this.prepareExercises(data.exerciseIds);
+    if (!exercisesResult.success) return exercisesResult;
+    if (exercisesResult.data) session.changeExercises(exercisesResult.data);
 
     return await this.sessionRepository.update(session);
+  }
+
+  private async prepareExercises(
+    exerciseIds?: UpdateSessionInput['exerciseIds']
+  ): Promise<Result<Exercise[] | null, DomainError>> {
+    if (!exerciseIds) return Success(null);
+    if (!isArray(exerciseIds) || !isArrayOf(exerciseIds, 'string'))
+      return Failure(new InvalidExerciseData());
+    const exercises: Exercise[] = [];
+    const exercisesFindById = exerciseIds.map((id) => this.exerciseRepository.findById(id));
+    const exercisesResults = await Promise.all(exercisesFindById);
+    for (const exerciseResult of exercisesResults) {
+      if (!exerciseResult.success) return exerciseResult;
+      if (!exerciseResult.data) return Failure(new ExerciseNotFoundError());
+      exercises.push(exerciseResult.data);
+    }
+    return Success(exercises);
   }
 }

--- a/src/modules/session/domain/session.types.ts
+++ b/src/modules/session/domain/session.types.ts
@@ -1,5 +1,7 @@
+import type { ClassMethods } from '@/shared/shared.types';
 import type { Exercise } from '@/modules/exercise/domain/exercise.entity';
 import type { UserProps } from '@/modules/user/domain/user.types';
+import type { Session } from '@/modules/session/domain/session.entity';
 
 export type SessionProps = {
   readonly id: string;
@@ -12,3 +14,5 @@ export type SessionProps = {
 };
 
 export type SessionFactoryData = Omit<SessionProps, 'id' | 'createdAt' | 'updatedAt'>;
+
+export type SessionMethods = ClassMethods<Session>;


### PR DESCRIPTION
## Domain & Application Logic

### 1. The "What" and "Why"

**Intent:** [Feature]
**Related Issue:** N/A

**Description:** Create helper to update independent `Session` properties in `UpdateSession` use case and improve logic of dependent data property update.

>

### 2. Clean Architecture Alignment

- [x] **Domain Layer:** No changes made.
  - Add `SessionMethods` type.
- [x] **Application Layer:** 
  - Add `UpdateSession` use case helper to update independent `Session` properties
  - Add improvement to `UpdateSession` logic on dependent `Session` properties update
- [x] **Dependency Rule:** I confirm that no Infrastructure or UI-specific code has leaked into this PR.

### 3. Verification Checklist

These commands **must** pass locally before marking the PR as "Ready for Review."

- [x] **Type Safety:** `pnpm typecheck` passes without errors.
- [x] **Code Health:** `pnpm safe-fixes` has been run and resolved linting/formatting.
- [x] **Logic Integrity:** `pnpm test` passes.

### 4. Technical Nuances
- **Open-closed issues:** `UpdateSession` had `if`s in each single updateable property. This represents a problem when `Session` updateable props be modified because we will need to touch the use case every time this happens.
- **Design patterns:** `Chain of Responsibility` solves the open-closed issues in `UpdateSession` when updating independent properties. If `Session` independent-updatable properties change It's only need to modify a single part of the code outside the main use case logic, having a `Single Responsibility` for the use case.
- **Dependent properties** For the dependent property that needs `Exercise` entity, It's been applied other solution. As use cases are the `Orchestrators` of domain logic, it was improved to make it more readable creating a private methods to handle repository resources
---

_Note: If this PR touches UI or Database schemas, please use the **Infrastructure** or **Presentation** templates instead._
