### PR TITLE
feat: Add domain validation services and refactor affected/related logic

### DIFF
--- a/src/modules/exercise/application/helpers/update-exercise.helper.ts
+++ b/src/modules/exercise/application/helpers/update-exercise.helper.ts
@@ -28,10 +28,8 @@ export function updateExercise(
 ): Result<Exercise, DomainError> {
   if (!isObject(data)) return Failure(new InvalidExerciseData());
   const dataKeys = Object.keys(data) as (keyof UpdateExerciseInput)[];
-
   for (const key of dataKeys) {
-    if (!isKeyOf(key, updateOperations)) continue;
-    if (!isKeyOf(key, data)) continue;
+    if (!isKeyOf(key, updateOperations) || !isKeyOf(key, data)) continue;
 
     const value = data[key] as never;
     const method = updateOperations[key] as keyof ExerciseMethods;

--- a/src/modules/exercise/application/helpers/update-exercise.helpers.test.ts
+++ b/src/modules/exercise/application/helpers/update-exercise.helpers.test.ts
@@ -1,0 +1,68 @@
+import '@testing-library/jest-dom';
+import type { UpdateExerciseInput } from '@/modules/exercise/application/dtos/update-exercise.dto';
+import { Exercise } from '@/modules/exercise/domain/exercise.entity';
+import { updateExercise } from '@/modules/exercise/application/helpers/update-exercise.helper';
+
+const createExercise = () => {
+  const exercise = Exercise.create('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
+    name: 'Exercise',
+    description: null,
+    muscles: [],
+    sets: 4,
+    reps: 16,
+    weight: 60.5,
+    userId: '1df38173-6fae-4abb-8cb2-ce33b6c24da4',
+  });
+
+  if (!exercise.success) throw exercise.error;
+
+  return exercise.data;
+};
+
+describe('UpdateExercise updateExercise helper', () => {
+  describe('Happy Path', () => {
+    it('should update exercise successfully and persist changes', () => {
+      const exercise = createExercise();
+      const newData: UpdateExerciseInput = {
+        description: 'New description',
+      };
+      const updateResult = updateExercise(newData, exercise);
+      expect(updateResult.success).toBe(true);
+      expect(exercise.description).toBe('New description');
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should return failure when invalid data', () => {
+      const exercise = createExercise();
+      const newData: UpdateExerciseInput = null as never;
+      const updateResult = updateExercise(newData, exercise);
+      expect(updateResult.success).toBe(false);
+      expect(
+        !updateResult.success && updateResult.error.code.startsWith('INVALID_EXERCISE_DATA')
+      ).toBe(true);
+    });
+
+    it('should skip property update when not-existing keys', () => {
+      const exercise = createExercise();
+      const newData: UpdateExerciseInput = {
+        restTime: 180,
+      } as never;
+      const updateResult = updateExercise(newData, exercise);
+      expect(updateResult.success).toBe(true);
+      expect('restTime' in exercise).toBe(false);
+    });
+
+    it('should return failure when invalid property data', () => {
+      const exercise = createExercise();
+      const newData: UpdateExerciseInput = {
+        sets: -1,
+      };
+      const updateResult = updateExercise(newData, exercise);
+      expect(updateResult.success).toBe(false);
+      expect(
+        !updateResult.success && updateResult.error.code.startsWith('INVALID_EXERCISE_DATA')
+      ).toBe(true);
+    });
+  });
+});

--- a/src/modules/exercise/application/use-cases/create-exercise.test.ts
+++ b/src/modules/exercise/application/use-cases/create-exercise.test.ts
@@ -1,11 +1,11 @@
 import '@testing-library/jest-dom';
+import type { CreateExerciseInput } from '@/modules/exercise/application/dtos/create-exercise.dto';
 import { Failure } from '@/shared/domain/result';
 import { TechnicalError } from '@/shared/domain/errors/domain.errors';
 import { CreateExercise } from '@/modules/exercise/application/use-cases/create-exercise';
 import { InMemoryExerciseRepository } from '@/modules/exercise/mocks/exercise.mocks.repository';
 import { InMemoryMuscleRepository } from '@/modules/muscle/mocks/muscle.mocks.repository';
 import { MockIdGenerator } from '@/shared/test/mocks/id-generator.repository.mock';
-import type { CreateExerciseInput } from '@/modules/exercise/application/dtos/create-exercise.dto';
 
 describe('CreateExercise use case', () => {
   describe('Happy Path', () => {
@@ -24,6 +24,34 @@ describe('CreateExercise use case', () => {
         muscleIds: [1],
         userId: 'user-123',
       };
+
+      idGeneratorMock.id = '1df38173-6fae-4abb-8cb2-ce33b6c24da4';
+
+      const createExerciseResult = await useCase.execute(exerciseData);
+
+      expect(createExerciseResult.success).toBe(true);
+      expect(createExerciseResult.success && createExerciseResult.data.id).toBe(
+        '1df38173-6fae-4abb-8cb2-ce33b6c24da4'
+      );
+      expect(createExerciseResult.success && createExerciseResult.data.name).toBe('Bench Press');
+
+      expect(exerciseRepoMock.exercises).toHaveLength(1);
+    });
+
+    it('should create exercise successfully and persist it wihtout muscle ids', async () => {
+      const exerciseRepoMock = new InMemoryExerciseRepository();
+      const muscleRepoMock = new InMemoryMuscleRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new CreateExercise(exerciseRepoMock, muscleRepoMock, idGeneratorMock);
+
+      const exerciseData: CreateExerciseInput = {
+        name: 'Bench Press',
+        description: 'Chest exercise',
+        sets: 3,
+        reps: 10,
+        weight: 80,
+        userId: 'user-123',
+      } as never;
 
       idGeneratorMock.id = '1df38173-6fae-4abb-8cb2-ce33b6c24da4';
 
@@ -160,14 +188,14 @@ describe('CreateExercise use case', () => {
       expect(exerciseRepoMock.exercises).toHaveLength(0);
     });
 
-    it('should return failure when muscle repository findByIds operation fails', async () => {
+    it('should return failure when muscle repository findById operation fails', async () => {
       const exerciseRepoMock = new InMemoryExerciseRepository();
       const muscleRepoMock = new InMemoryMuscleRepository();
       const idGeneratorMock = new MockIdGenerator();
       const useCase = new CreateExercise(exerciseRepoMock, muscleRepoMock, idGeneratorMock);
 
       jest
-        .spyOn(muscleRepoMock, 'findByIds')
+        .spyOn(muscleRepoMock, 'findById')
         .mockResolvedValue(Failure(new TechnicalError() as never));
 
       const exerciseData: CreateExerciseInput = {

--- a/src/modules/exercise/application/use-cases/create-exercise.ts
+++ b/src/modules/exercise/application/use-cases/create-exercise.ts
@@ -1,11 +1,10 @@
-import { Exercise } from '@/modules/exercise/domain/exercise.entity';
-import { Failure } from '@/shared/domain/result';
-import { MuscleNotFoundError } from '@/modules/muscle/domain/errors/muscle.errors';
 import type { CreateExerciseInput } from '@/modules/exercise/application/dtos/create-exercise.dto';
 import type { IdGeneratorRepository } from '@/shared/application/id-generator.repository';
 import type { IExerciseRepository } from '@/modules/exercise/domain/exercise.repository';
 import type { IMuscleRepository } from '@/modules/muscle/domain/muscle.repository';
 import type { UseCase } from '@/shared/application/shared.use-case';
+import { Exercise } from '@/modules/exercise/domain/exercise.entity';
+import { MuscleValidationService } from '@/modules/muscle/domain/services/muscle.validation.service';
 
 export class CreateExercise implements UseCase {
   constructor(
@@ -15,21 +14,19 @@ export class CreateExercise implements UseCase {
   ) {}
 
   async execute(exerciseData: CreateExerciseInput) {
-    const idResult = await this.generator.generate();
+    const idResult = this.generator.generate();
     if (!idResult.success) return idResult;
 
     const exerciseId = idResult.data;
 
-    const musclesResult = await this.muscleRepository.findByIds(exerciseData.muscleIds);
+    const muscleValidationService = new MuscleValidationService(this.muscleRepository);
+    const musclesResult = await muscleValidationService.validateAndFetch(exerciseData.muscleIds);
     if (!musclesResult.success) return musclesResult;
-    if (musclesResult.data.length !== exerciseData.muscleIds.length)
-      return Failure(new MuscleNotFoundError());
-
-    const { muscleIds, ...createExerciseData } = exerciseData;
+    const muscles = musclesResult.data ?? [];
 
     const newExerciseResult = Exercise.create(exerciseId, {
-      ...createExerciseData,
-      muscles: musclesResult.data,
+      ...exerciseData,
+      muscles,
     });
 
     if (!newExerciseResult.success) return newExerciseResult;

--- a/src/modules/exercise/application/use-cases/update-exercise.test.ts
+++ b/src/modules/exercise/application/use-cases/update-exercise.test.ts
@@ -6,6 +6,21 @@ import { InMemoryExerciseRepository } from '@/modules/exercise/mocks/exercise.mo
 import { InMemoryMuscleRepository } from '@/modules/muscle/mocks/muscle.mocks.repository';
 import { Exercise } from '@/modules/exercise/domain/exercise.entity';
 
+function createExercise(id: string): Exercise {
+  const exercise = Exercise.create(id, {
+    name: 'Bench Press',
+    description: 'Chest exercise',
+    sets: 3,
+    reps: 10,
+    weight: 80,
+    muscles: [],
+    userId: 'user-123',
+  });
+
+  if (!exercise.success) throw new Error('Failed to create exercise');
+  return exercise.data;
+}
+
 describe('UpdateExercise use case', () => {
   describe('Happy Path', () => {
     it('should update exercise successfully and persist changes', async () => {
@@ -13,22 +28,14 @@ describe('UpdateExercise use case', () => {
       const muscleRepoMock = new InMemoryMuscleRepository();
       const useCase = new UpdateExercise(exerciseRepoMock, muscleRepoMock);
 
-      const exercise = Exercise.create('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
-        name: 'Bench Press',
-        description: 'Chest exercise',
-        sets: 3,
-        reps: 10,
-        weight: 80,
-        muscles: [],
-        userId: 'user-123',
-      });
-      if (!exercise.success) throw new Error('Failed to create exercise');
-      await exerciseRepoMock.create(exercise.data);
+      const exercise = createExercise('1df38173-6fae-4abb-8cb2-ce33b6c24da4');
+      exerciseRepoMock.exercises.push(exercise);
 
       expect(exerciseRepoMock.exercises[0]?.name).not.toBe('Updated Bench Press');
 
       const updateResult = await useCase.execute('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
         name: 'Updated Bench Press',
+        muscleIds: [1],
       });
 
       expect(updateResult.success).toBe(true);
@@ -38,6 +45,7 @@ describe('UpdateExercise use case', () => {
       expect(updateResult.success && updateResult.data.name).toBe('Updated Bench Press');
 
       expect(exerciseRepoMock.exercises[0]?.name).toBe('Updated Bench Press');
+      expect(exerciseRepoMock.exercises[0]?.muscles).toHaveLength(1);
     });
 
     it('should update multiple fields', async () => {
@@ -45,17 +53,8 @@ describe('UpdateExercise use case', () => {
       const muscleRepoMock = new InMemoryMuscleRepository();
       const useCase = new UpdateExercise(exerciseRepoMock, muscleRepoMock);
 
-      const exercise = Exercise.create('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
-        name: 'Bench Press',
-        description: 'Chest exercise',
-        sets: 3,
-        reps: 10,
-        weight: 80,
-        muscles: [],
-        userId: 'user-123',
-      });
-      if (!exercise.success) throw new Error('Failed to create exercise');
-      await exerciseRepoMock.create(exercise.data);
+      const exercise = createExercise('1df38173-6fae-4abb-8cb2-ce33b6c24da4');
+      exerciseRepoMock.exercises.push(exercise);
 
       const updateResult = await useCase.execute('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
         name: 'Updated Name',
@@ -89,17 +88,8 @@ describe('UpdateExercise use case', () => {
       const muscleRepoMock = new InMemoryMuscleRepository();
       const useCase = new UpdateExercise(exerciseRepoMock, muscleRepoMock);
 
-      const exercise = Exercise.create('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
-        name: 'Bench Press',
-        description: 'Chest exercise',
-        sets: 3,
-        reps: 10,
-        weight: 80,
-        muscles: [],
-        userId: 'user-123',
-      });
-      if (!exercise.success) throw new Error('Failed to create exercise');
-      await exerciseRepoMock.create(exercise.data);
+      const exercise = createExercise('1df38173-6fae-4abb-8cb2-ce33b6c24da4');
+      exerciseRepoMock.exercises.push(exercise);
 
       const updateResult = await useCase.execute(
         '1df38173-6fae-4abb-8cb2-ce33b6c24da4',
@@ -115,17 +105,8 @@ describe('UpdateExercise use case', () => {
       const muscleRepoMock = new InMemoryMuscleRepository();
       const useCase = new UpdateExercise(exerciseRepoMock, muscleRepoMock);
 
-      const exercise = Exercise.create('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
-        name: 'Bench Press',
-        description: 'Chest exercise',
-        sets: 3,
-        reps: 10,
-        weight: 80,
-        muscles: [],
-        userId: 'user-123',
-      });
-      if (!exercise.success) throw new Error('Failed to create exercise');
-      await exerciseRepoMock.create(exercise.data);
+      const exercise = createExercise('1df38173-6fae-4abb-8cb2-ce33b6c24da4');
+      exerciseRepoMock.exercises.push(exercise);
 
       const updateResult = await useCase.execute('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
         muscleIds: [999],
@@ -142,17 +123,8 @@ describe('UpdateExercise use case', () => {
       const muscleRepoMock = new InMemoryMuscleRepository();
       const useCase = new UpdateExercise(exerciseRepoMock, muscleRepoMock);
 
-      const exercise = Exercise.create('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
-        name: 'Bench Press',
-        description: 'Chest exercise',
-        sets: 3,
-        reps: 10,
-        weight: 80,
-        muscles: [],
-        userId: 'user-123',
-      });
-      if (!exercise.success) throw new Error('Failed to create exercise');
-      await exerciseRepoMock.create(exercise.data);
+      const exercise = createExercise('1df38173-6fae-4abb-8cb2-ce33b6c24da4');
+      exerciseRepoMock.exercises.push(exercise);
 
       jest
         .spyOn(exerciseRepoMock, 'update')
@@ -173,6 +145,9 @@ describe('UpdateExercise use case', () => {
       const muscleRepoMock = new InMemoryMuscleRepository();
       const useCase = new UpdateExercise(exerciseRepoMock, muscleRepoMock);
 
+      const exercise = createExercise('1df38173-6fae-4abb-8cb2-ce33b6c24da4');
+      exerciseRepoMock.exercises.push(exercise);
+
       jest
         .spyOn(exerciseRepoMock, 'findById')
         .mockResolvedValue(Failure(new TechnicalError() as never));
@@ -185,26 +160,16 @@ describe('UpdateExercise use case', () => {
       expect(!updateResult.success && updateResult.error.code).toBe('TECHNICAL_ERROR');
     });
 
-    it('should return failure when muscle repository findByIds operation fails', async () => {
+    it('should return failure when muscle repository findById operation fails', async () => {
       const exerciseRepoMock = new InMemoryExerciseRepository();
       const muscleRepoMock = new InMemoryMuscleRepository();
       const useCase = new UpdateExercise(exerciseRepoMock, muscleRepoMock);
 
-      const exercise = Exercise.create('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {
-        name: 'Bench Press',
-        description: 'Chest exercise',
-        sets: 3,
-        reps: 10,
-        weight: 80,
-        muscles: [],
-        userId: 'user-123',
-      });
-
-      if (!exercise.success) throw new Error('Failed to create exercise');
-      await exerciseRepoMock.create(exercise.data);
+      const exercise = createExercise('1df38173-6fae-4abb-8cb2-ce33b6c24da4');
+      exerciseRepoMock.exercises.push(exercise);
 
       jest
-        .spyOn(muscleRepoMock, 'findByIds')
+        .spyOn(muscleRepoMock, 'findById')
         .mockResolvedValue(Failure(new TechnicalError() as never));
 
       const updateResult = await useCase.execute('1df38173-6fae-4abb-8cb2-ce33b6c24da4', {

--- a/src/modules/exercise/application/use-cases/update-exercise.ts
+++ b/src/modules/exercise/application/use-cases/update-exercise.ts
@@ -1,12 +1,12 @@
-import { ExerciseNotFoundError } from '@/modules/exercise/domain/errors/exercise.errors';
-import { Failure } from '@/shared/domain/result';
 import type { Exercise } from '@/modules/exercise/domain/exercise.entity';
 import type { IExerciseRepository } from '@/modules/exercise/domain/exercise.repository';
 import type { IMuscleRepository } from '@/modules/muscle/domain/muscle.repository';
 import type { UpdateExerciseInput } from '@/modules/exercise/application/dtos/update-exercise.dto';
 import type { UseCase } from '@/shared/application/shared.use-case';
-import { MuscleNotFoundError } from '@/modules/muscle/domain/errors/muscle.errors';
+import { ExerciseNotFoundError } from '@/modules/exercise/domain/errors/exercise.errors';
+import { Failure } from '@/shared/domain/result';
 import { updateExercise } from '@/modules/exercise/application/helpers/update-exercise.helper';
+import { MuscleValidationService } from '@/modules/muscle/domain/services/muscle.validation.service';
 
 export class UpdateExercise implements UseCase {
   constructor(
@@ -24,13 +24,10 @@ export class UpdateExercise implements UseCase {
     const updateResult = updateExercise(data, exercise);
     if (!updateResult.success) return updateResult;
 
-    if (data.muscleIds) {
-      const musclesResult = await this.muscleRepository.findByIds(data.muscleIds);
-      if (!musclesResult.success) return musclesResult;
-      if (data.muscleIds.length !== musclesResult.data.length)
-        return Failure(new MuscleNotFoundError());
-      exercise.changeMuscles(musclesResult.data);
-    }
+    const muscleValidationService = new MuscleValidationService(this.muscleRepository);
+    const musclesResult = await muscleValidationService.validateAndFetch(data.muscleIds);
+    if (!musclesResult.success) return musclesResult;
+    if (musclesResult.data) exercise.changeMuscles(musclesResult.data);
 
     return await this.exerciseRepository.update(exercise);
   }

--- a/src/modules/exercise/domain/errors/exercise.errors.ts
+++ b/src/modules/exercise/domain/errors/exercise.errors.ts
@@ -15,10 +15,6 @@ export class ExerciseOwnershipError extends DomainError {
 
 export class InvalidExerciseData extends DomainError {
   constructor(readonly error_code: ExerciseInvalidDataErrorCodes | undefined = undefined) {
-    if (!error_code) {
-      super('INVALID_EXERCISE_DATA');
-    } else {
-      super(`INVALID_EXERCISE_DATA.${error_code}`);
-    }
+    super(error_code ? `INVALID_EXERCISE_DATA.${error_code}` : 'INVALID_EXERCISE_DATA');
   }
 }

--- a/src/modules/exercise/domain/exercise.entity.test.ts
+++ b/src/modules/exercise/domain/exercise.entity.test.ts
@@ -52,7 +52,6 @@ describe('Exercise entity', () => {
       const exercise = createTestExercise();
       const result = exercise.changeName('New Bench Press');
       expect(result.success).toBe(true);
-      expect(result.success && result.data).toBe(null);
       expect(exercise.name).toBe('New Bench Press');
     });
 
@@ -65,12 +64,18 @@ describe('Exercise entity', () => {
   });
 
   describe('changeDescription()', () => {
-    it('should change exercise description successfully', () => {
+    it('should change exercise description with string successfully', () => {
       const exercise = createTestExercise();
-      const result = exercise.changeDescription('New description');
-      expect(result.success).toBe(true);
-      expect(result.success && result.data).toBe(null);
+      const changeResult = exercise.changeDescription('New description');
+      expect(changeResult.success).toBe(true);
       expect(exercise.description).toBe('New description');
+    });
+
+    it('should change exercise description with null successfully', () => {
+      const exercise = createTestExercise();
+      const changeResult = exercise.changeDescription(null);
+      expect(changeResult.success).toBe(true);
+      expect(exercise.description).toBe(null);
     });
 
     it('should return failure when description is invalid', () => {
@@ -86,7 +91,6 @@ describe('Exercise entity', () => {
       const exercise = createTestExercise();
       const result = exercise.changeSets(5);
       expect(result.success).toBe(true);
-      expect(result.success && result.data).toBe(null);
       expect(exercise.sets).toBe(5);
     });
 
@@ -103,7 +107,6 @@ describe('Exercise entity', () => {
       const exercise = createTestExercise();
       const result = exercise.changeReps(12);
       expect(result.success).toBe(true);
-      expect(result.success && result.data).toBe(null);
       expect(exercise.reps).toBe(12);
     });
 
@@ -120,7 +123,6 @@ describe('Exercise entity', () => {
       const exercise = createTestExercise();
       const result = exercise.changeWeight(90);
       expect(result.success).toBe(true);
-      expect(result.success && result.data).toBe(null);
       expect(exercise.weight).toBe(90);
     });
 
@@ -140,7 +142,6 @@ describe('Exercise entity', () => {
         newMuscles as Parameters<typeof exercise.changeMuscles>[0]
       );
       expect(result.success).toBe(true);
-      expect(result.success && result.data).toBe(null);
       expect(exercise.muscles).toEqual(newMuscles);
     });
   });

--- a/src/modules/exercise/domain/services/exercise.validation.service.test.ts
+++ b/src/modules/exercise/domain/services/exercise.validation.service.test.ts
@@ -1,0 +1,119 @@
+import '@testing-library/jest-dom';
+import { Failure } from '@/shared/domain/result';
+import { TechnicalError } from '@/shared/domain/errors/domain.errors';
+import { Exercise } from '@/modules/exercise/domain/exercise.entity';
+import { InMemoryExerciseRepository } from '@/modules/exercise/mocks/exercise.mocks.repository';
+import { ExerciseValidationService } from '@/modules/exercise/domain/services/exercise.validation.service';
+
+function createExercise(id: string): Exercise {
+  const exerciseResult = Exercise.create(id, {
+    name: 'Exercise',
+    sets: 4,
+    reps: 8,
+    weight: 40.5,
+    description: null,
+    muscles: [],
+    userId: '1df38173-6fae-4abb-8cb2-ce33b6c24da4',
+  });
+
+  if (!exerciseResult.success) throw exerciseResult.error;
+  return exerciseResult.data;
+}
+
+describe('ExerciseValidationService', () => {
+  describe('Happy Path', () => {
+    it('should return exercises list successfully', async () => {
+      const exerciseRepoMock = new InMemoryExerciseRepository();
+      const service = new ExerciseValidationService(exerciseRepoMock);
+
+      const exercise = createExercise('1df38173-6fae-4abb-8cb2-ce33b6c24da4');
+      exerciseRepoMock.exercises.push(exercise);
+
+      const exerciseResult = await service.validateAndFetch([
+        '1df38173-6fae-4abb-8cb2-ce33b6c24da4',
+      ]);
+
+      expect(exerciseResult.success).toBe(true);
+      expect(exerciseResult.success && exerciseResult.data).toHaveLength(1);
+      expect(exerciseResult.success && exerciseResult.data?.[0] instanceof Exercise).toBe(true);
+    });
+
+    it('should return null successfully when provided undefined input', async () => {
+      const exerciseRepoMock = new InMemoryExerciseRepository();
+      const service = new ExerciseValidationService(exerciseRepoMock);
+
+      const exerciseResult = await service.validateAndFetch(undefined);
+
+      expect(exerciseResult.success).toBe(true);
+      expect(exerciseResult.success && exerciseResult.data).toBe(null);
+    });
+
+    it('should return ampty array successfully when empty array input', async () => {
+      const exerciseRepoMock = new InMemoryExerciseRepository();
+      const service = new ExerciseValidationService(exerciseRepoMock);
+
+      const exerciseResult = await service.validateAndFetch([]);
+
+      expect(exerciseResult.success).toBe(true);
+      expect(exerciseResult.success && exerciseResult.data).toHaveLength(0);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should return failure when input not array nor nullish', async () => {
+      const exerciseRepoMock = new InMemoryExerciseRepository();
+      const service = new ExerciseValidationService(exerciseRepoMock);
+
+      const exercise = createExercise('1df38173-6fae-4abb-8cb2-ce33b6c24da4');
+      exerciseRepoMock.exercises.push(exercise);
+
+      const exerciseResult = await service.validateAndFetch({} as never);
+
+      expect(exerciseResult.success).toBe(false);
+    });
+
+    it('should return failure when input not string array ', async () => {
+      const exerciseRepoMock = new InMemoryExerciseRepository();
+      const service = new ExerciseValidationService(exerciseRepoMock);
+
+      const exercise = createExercise('1df38173-6fae-4abb-8cb2-ce33b6c24da4');
+      exerciseRepoMock.exercises.push(exercise);
+
+      const exerciseResult = await service.validateAndFetch([1, 2] as never);
+
+      expect(exerciseResult.success).toBe(false);
+    });
+
+    it('should return failure when exercise not found ', async () => {
+      const exerciseRepoMock = new InMemoryExerciseRepository();
+      const service = new ExerciseValidationService(exerciseRepoMock);
+
+      const exerciseResult = await service.validateAndFetch([
+        '1df38173-6fae-4abb-8cb2-ce33b6c24da4',
+      ]);
+
+      expect(exerciseResult.success).toBe(false);
+    });
+  });
+
+  describe('Dependency Interaction', () => {
+    it('should return failure when exercise findById operation fails', async () => {
+      const exerciseRepoMock = new InMemoryExerciseRepository();
+      const service = new ExerciseValidationService(exerciseRepoMock);
+
+      jest
+        .spyOn(exerciseRepoMock, 'findById')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+
+      const exercise = createExercise('1df38173-6fae-4abb-8cb2-ce33b6c24da4');
+      exerciseRepoMock.exercises.push(exercise);
+
+      const exercisesResult = await service.validateAndFetch([
+        '1df38173-6fae-4abb-8cb2-ce33b6c24da4',
+      ]);
+
+      expect(exercisesResult.success).toBe(false);
+      expect(!exercisesResult.success && exercisesResult.error.code).toBe('TECHNICAL_ERROR');
+    });
+  });
+});

--- a/src/modules/exercise/domain/services/exercise.validation.service.ts
+++ b/src/modules/exercise/domain/services/exercise.validation.service.ts
@@ -1,0 +1,37 @@
+import type { Result } from '@/shared/domain/result';
+import type { DomainError } from '@/shared/domain/errors/domain.errors';
+import type { IExerciseRepository } from '@/modules/exercise/domain/exercise.repository';
+import type { Exercise } from '@/modules/exercise/domain/exercise.entity';
+import { Failure, Success } from '@/shared/domain/result';
+import { isArray } from '@/shared/domain/validation/validation.non-primitives';
+import { isArrayOf } from '@/shared/domain/validation/validation.utils';
+import {
+  ExerciseNotFoundError,
+  InvalidExerciseData,
+} from '@/modules/exercise/domain/errors/exercise.errors';
+
+export class ExerciseValidationService {
+  constructor(private readonly exerciseRepository: IExerciseRepository) {}
+  async validateAndFetch(exerciseIds?: string[]): Promise<Result<Exercise[] | null, DomainError>> {
+    if (!exerciseIds) return Success(null);
+    if (!isArray(exerciseIds)) return Failure(new InvalidExerciseData());
+    if (exerciseIds.length > 0 && !isArrayOf(exerciseIds, 'string'))
+      return Failure(new InvalidExerciseData());
+
+    if (exerciseIds.length === 0) return Success([]);
+
+    const distinctExerciseIds = Array.from(new Set(exerciseIds));
+    const exercises: Exercise[] = [];
+
+    const findMuscles = distinctExerciseIds.map((m) => this.exerciseRepository.findById(m));
+    const muscleResults = await Promise.all(findMuscles);
+    for (const muscleResult of muscleResults) {
+      if (!muscleResult.success) return muscleResult;
+      if (!muscleResult.data) return Failure(new ExerciseNotFoundError());
+
+      exercises.push(muscleResult.data);
+    }
+
+    return Success(exercises);
+  }
+}

--- a/src/modules/exercise/domain/validation/exercise.validation.constants.ts
+++ b/src/modules/exercise/domain/validation/exercise.validation.constants.ts
@@ -4,7 +4,7 @@ export const EXERCISE_NAME_LENGTH = {
 } as const;
 
 export const EXERCISE_DESCRIPTION_LENGTH = {
-  min: 0,
+  min: 1,
   max: 100,
 } as const;
 

--- a/src/modules/exercise/domain/validation/exercise.validation.test.ts
+++ b/src/modules/exercise/domain/validation/exercise.validation.test.ts
@@ -141,6 +141,17 @@ describe('validateExercise', () => {
         );
       });
 
+      it('should fail when is too short (less than 1 chars)', () => {
+        const validation = validateExercise({
+          ...validExerciseData,
+          description: '',
+        } as unknown as Parameters<typeof validateExercise>[0]);
+        expect(validation.success).toBe(false);
+        expect(validation.success === false && validation.error.code).toBe(
+          'INVALID_EXERCISE_DATA.DESCRIPTION'
+        );
+      });
+
       it('should fail when is too long (more than 100 chars)', () => {
         const validation = validateExercise({
           ...validExerciseData,

--- a/src/modules/muscle/domain/errors/muscle.error.code.ts
+++ b/src/modules/muscle/domain/errors/muscle.error.code.ts
@@ -1,1 +1,1 @@
-export type MuscleErrorCode = 'MUSCLE_NOT_FOUND';
+export type MuscleErrorCode = 'MUSCLE_NOT_FOUND' | 'INVALID_MUSCLE_DATA';

--- a/src/modules/muscle/domain/errors/muscle.errors.ts
+++ b/src/modules/muscle/domain/errors/muscle.errors.ts
@@ -5,3 +5,9 @@ export class MuscleNotFoundError extends DomainError {
     super('MUSCLE_NOT_FOUND');
   }
 }
+
+export class InvalidMuscleData extends DomainError {
+  constructor() {
+    super('INVALID_MUSCLE_DATA');
+  }
+}

--- a/src/modules/muscle/domain/muscle.entity.test.ts
+++ b/src/modules/muscle/domain/muscle.entity.test.ts
@@ -1,0 +1,63 @@
+import { Muscle } from './muscle.entity';
+
+function createMuscle(id: number): Muscle {
+  const muscle = new Muscle({
+    id,
+    name: 'Exercise',
+    description: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    group: {
+      id: 1,
+      name: 'Muscular Group',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      section: {
+        id: 1,
+        name: 'Section',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    },
+    userId: '1df38173-6fae-4abb-8cb2-ce33b6c24da4',
+  });
+
+  return muscle;
+}
+
+describe('Muscle entity', () => {
+  describe('Getters', () => {
+    const muscle = createMuscle(1);
+    it('should get id prop successfully', async () => {
+      expect(muscle.id).toBe(1);
+    });
+
+    it('should get name prop successfully', async () => {
+      expect(muscle.name).toBe('Exercise');
+    });
+
+    it('should get description prop successfully', async () => {
+      expect(muscle.description).toBe(null);
+    });
+
+    it('should get createdAt prop successfully', async () => {
+      expect(muscle.createdAt instanceof Date).toBe(true);
+    });
+
+    it('should get updatedAt prop successfully', async () => {
+      expect(muscle.updatedAt instanceof Date).toBe(true);
+    });
+
+    it('should get muscularGroup prop successfully', async () => {
+      expect(muscle.muscularGroup.name).toBe('Muscular Group');
+    });
+
+    it('should get userId prop successfully', async () => {
+      expect(muscle.userId).toBe('1df38173-6fae-4abb-8cb2-ce33b6c24da4');
+    });
+
+    it('should get bodySection prop successfully', async () => {
+      expect(muscle.bodySection.name).toBe('Section');
+    });
+  });
+});

--- a/src/modules/muscle/domain/muscle.entity.ts
+++ b/src/modules/muscle/domain/muscle.entity.ts
@@ -26,19 +26,4 @@ export class Muscle {
   get bodySection() {
     return this.data.group.section;
   }
-  changeName(name: MuscleProps['name']) {
-    this.data.name = name;
-  }
-  changeDescription(description: MuscleProps['name']) {
-    this.data.description = description;
-  }
-
-  static create(id: MuscleProps['id'], data: Omit<MuscleProps, 'id' | 'createdAt' | 'updatedAt'>) {
-    return new Muscle({
-      ...data,
-      id,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    });
-  }
 }

--- a/src/modules/muscle/domain/services/muscle.validation.service.test.ts
+++ b/src/modules/muscle/domain/services/muscle.validation.service.test.ts
@@ -1,0 +1,122 @@
+import '@testing-library/jest-dom';
+import { Failure } from '@/shared/domain/result';
+import { TechnicalError } from '@/shared/domain/errors/domain.errors';
+import { Muscle } from '@/modules/muscle/domain/muscle.entity';
+import { InMemoryMuscleRepository } from '@/modules/muscle/mocks/muscle.mocks.repository';
+import { MuscleValidationService } from '@/modules/muscle/domain/services/muscle.validation.service';
+
+function createMuscle(id: number): Muscle {
+  const muscle = new Muscle({
+    id,
+    name: 'Exercise',
+    description: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    group: {
+      id: 1,
+      name: 'Muscular Group',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      section: {
+        id: 1,
+        name: 'Section',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    },
+    userId: '1df38173-6fae-4abb-8cb2-ce33b6c24da4',
+  });
+
+  return muscle;
+}
+
+describe('MuscleValidationService', () => {
+  describe('Happy path', () => {
+    it('should return exercises list successfully', async () => {
+      const muscleRepoMock = new InMemoryMuscleRepository();
+      const service = new MuscleValidationService(muscleRepoMock);
+
+      const muscle = createMuscle(3);
+      muscleRepoMock.muscles.push(muscle);
+
+      const musclesResult = await service.validateAndFetch([3]);
+
+      expect(musclesResult.success).toBe(true);
+      expect(musclesResult.success && musclesResult.data?.[0] instanceof Muscle).toBe(true);
+    });
+
+    it('should return null successfully when provided undefined input', async () => {
+      const muscleRepoMock = new InMemoryMuscleRepository();
+      const service = new MuscleValidationService(muscleRepoMock);
+
+      const exerciseResult = await service.validateAndFetch(undefined);
+
+      expect(exerciseResult.success).toBe(true);
+      expect(exerciseResult.success && exerciseResult.data).toBe(null);
+    });
+
+    it('should return ampty array successfully when empty array input', async () => {
+      const muscleRepoMock = new InMemoryMuscleRepository();
+      const service = new MuscleValidationService(muscleRepoMock);
+
+      const exerciseResult = await service.validateAndFetch([]);
+
+      expect(exerciseResult.success).toBe(true);
+      expect(exerciseResult.success && exerciseResult.data).toHaveLength(0);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should return failure when input not array nor nullish', async () => {
+      const muscleRepoMock = new InMemoryMuscleRepository();
+      const service = new MuscleValidationService(muscleRepoMock);
+
+      const exercise = createMuscle(4);
+      muscleRepoMock.muscles.push(exercise);
+
+      const exerciseResult = await service.validateAndFetch({} as never);
+
+      expect(exerciseResult.success).toBe(false);
+    });
+
+    it('should return failure when input not string array ', async () => {
+      const muscleRepoMock = new InMemoryMuscleRepository();
+      const service = new MuscleValidationService(muscleRepoMock);
+
+      const exercise = createMuscle(4);
+      muscleRepoMock.muscles.push(exercise);
+
+      const exerciseResult = await service.validateAndFetch([4.5, 'Hello'] as never);
+
+      expect(exerciseResult.success).toBe(false);
+    });
+
+    it('should return failure when exercise not found ', async () => {
+      const muscleRepoMock = new InMemoryMuscleRepository();
+      const service = new MuscleValidationService(muscleRepoMock);
+
+      const exerciseResult = await service.validateAndFetch([4]);
+
+      expect(exerciseResult.success).toBe(false);
+    });
+  });
+
+  describe('Dependency Interaction', () => {
+    it('should return failure when exercise findById operation fails', async () => {
+      const muscleRepoMock = new InMemoryMuscleRepository();
+      const service = new MuscleValidationService(muscleRepoMock);
+
+      jest
+        .spyOn(muscleRepoMock, 'findById')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+
+      const exercise = createMuscle(4);
+      muscleRepoMock.muscles.push(exercise);
+
+      const exercisesResult = await service.validateAndFetch([4]);
+
+      expect(exercisesResult.success).toBe(false);
+      expect(!exercisesResult.success && exercisesResult.error.code).toBe('TECHNICAL_ERROR');
+    });
+  });
+});

--- a/src/modules/muscle/domain/services/muscle.validation.service.ts
+++ b/src/modules/muscle/domain/services/muscle.validation.service.ts
@@ -1,0 +1,37 @@
+import type { Result } from '@/shared/domain/result';
+import type { DomainError } from '@/shared/domain/errors/domain.errors';
+import type { IMuscleRepository } from '@/modules/muscle/domain/muscle.repository';
+import type { Muscle } from '@/modules/muscle/domain/muscle.entity';
+import { Failure, Success } from '@/shared/domain/result';
+import { isArray } from '@/shared/domain/validation/validation.non-primitives';
+import { isArrayOf } from '@/shared/domain/validation/validation.utils';
+import {
+  InvalidMuscleData,
+  MuscleNotFoundError,
+} from '@/modules/muscle/domain/errors/muscle.errors';
+
+export class MuscleValidationService {
+  constructor(private readonly exerciseRepository: IMuscleRepository) {}
+  async validateAndFetch(muscleIds?: number[]): Promise<Result<Muscle[] | null, DomainError>> {
+    if (!muscleIds) return Success(null);
+    if (!isArray(muscleIds)) return Failure(new InvalidMuscleData());
+    if (muscleIds.length > 0 && !isArrayOf(muscleIds, 'integer'))
+      return Failure(new InvalidMuscleData());
+
+    if (muscleIds.length === 0) return Success([]);
+
+    const distinctMuscleIds = Array.from(new Set(muscleIds));
+    const muscles: Muscle[] = [];
+
+    const findMuscles = distinctMuscleIds.map((m) => this.exerciseRepository.findById(m));
+    const muscleResults = await Promise.all(findMuscles);
+    for (const muscleResult of muscleResults) {
+      if (!muscleResult.success) return muscleResult;
+      if (!muscleResult.data) return Failure(new MuscleNotFoundError());
+
+      muscles.push(muscleResult.data);
+    }
+
+    return Success(muscles);
+  }
+}

--- a/src/modules/notification/application/use-cases/create-notification.ts
+++ b/src/modules/notification/application/use-cases/create-notification.ts
@@ -11,7 +11,7 @@ export class CreateNotification implements UseCase {
   ) {}
 
   async execute(data: CreateNotificationInput) {
-    const idResult = await this.generator.generate();
+    const idResult = this.generator.generate();
     if (!idResult.success) return idResult;
 
     const notificationId = idResult.data;

--- a/src/modules/routine/application/use-cases/create-routine.test.ts
+++ b/src/modules/routine/application/use-cases/create-routine.test.ts
@@ -76,32 +76,6 @@ describe('CreateRoutine use case', () => {
   });
 
   describe('Error Handling', () => {
-    it('should return failure when session not found', async () => {
-      const routineRepoMock = new InMemoryRoutineRepository();
-      const sessionRepoMock = new InMemorySessionRepository();
-      const idGeneratorMock = new MockIdGenerator();
-      const useCase = new CreateRoutine(routineRepoMock, sessionRepoMock, idGeneratorMock);
-
-      const routineData: CreateRoutineInput = {
-        name: 'Invalid Routine',
-        description: null,
-        active: true,
-        days: 1,
-        initialDate: new Date(),
-        cycleId: 'week',
-        userId: 'user-123',
-        routineDays: [{ name: 'Day 1', day: 1, sessionId: 'non-existent-session' }],
-      };
-
-      idGeneratorMock.id = '1df38173-6fae-4abb-8cb2-ce33b6c24da6';
-
-      const createResult = await useCase.execute(routineData);
-
-      expect(createResult.success).toBe(false);
-      expect(!createResult.success && createResult.error.code).toBe('SESSION_NOT_FOUND');
-      expect(routineRepoMock.routines).toHaveLength(0);
-    });
-
     it('should return failure when invalid routine data', async () => {
       const routineRepoMock = new InMemoryRoutineRepository();
       const sessionRepoMock = new InMemorySessionRepository();
@@ -117,6 +91,61 @@ describe('CreateRoutine use case', () => {
         cycleId: 'week',
         userId: 'user-123',
         routineDays: [{ name: 'Day 1', day: 1, sessionId: null }],
+      };
+
+      idGeneratorMock.id = '1df38173-6fae-4abb-8cb2-ce33b6c24da7';
+
+      const createResult = await useCase.execute(routineData);
+
+      expect(createResult.success).toBe(false);
+      expect(
+        !createResult.success && createResult.error.code.startsWith('INVALID_ROUTINE_DATA')
+      ).toBe(true);
+      expect(routineRepoMock.routines).toHaveLength(0);
+    });
+
+    it('should return failure when no routineDays provided', async () => {
+      const routineRepoMock = new InMemoryRoutineRepository();
+      const sessionRepoMock = new InMemorySessionRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new CreateRoutine(routineRepoMock, sessionRepoMock, idGeneratorMock);
+
+      const routineData: CreateRoutineInput = {
+        name: 'AB',
+        description: null,
+        active: true,
+        days: 1,
+        initialDate: new Date(),
+        cycleId: 'week',
+        userId: 'user-123',
+      } as never;
+
+      idGeneratorMock.id = '1df38173-6fae-4abb-8cb2-ce33b6c24da7';
+
+      const createResult = await useCase.execute(routineData);
+
+      expect(createResult.success).toBe(false);
+      expect(
+        !createResult.success && createResult.error.code.startsWith('INVALID_ROUTINE_DATA')
+      ).toBe(true);
+      expect(routineRepoMock.routines).toHaveLength(0);
+    });
+
+    it('should return failure when invalid routineDays provided', async () => {
+      const routineRepoMock = new InMemoryRoutineRepository();
+      const sessionRepoMock = new InMemorySessionRepository();
+      const idGeneratorMock = new MockIdGenerator();
+      const useCase = new CreateRoutine(routineRepoMock, sessionRepoMock, idGeneratorMock);
+
+      const routineData: CreateRoutineInput = {
+        name: 'AB',
+        description: null,
+        active: true,
+        days: 1,
+        initialDate: new Date(),
+        cycleId: 'week',
+        userId: 'user-123',
+        routineDays: [],
       };
 
       idGeneratorMock.id = '1df38173-6fae-4abb-8cb2-ce33b6c24da7';
@@ -182,36 +211,6 @@ describe('CreateRoutine use case', () => {
         userId: 'user-123',
         routineDays: [{ name: 'Day 1', day: 1, sessionId: null }],
       };
-
-      const createResult = await useCase.execute(routineData);
-
-      expect(createResult.success).toBe(false);
-      expect(!createResult.success && createResult.error.code).toBe('TECHNICAL_ERROR');
-      expect(routineRepoMock.routines).toHaveLength(0);
-    });
-
-    it('should return failure when session repository findById fails', async () => {
-      const routineRepoMock = new InMemoryRoutineRepository();
-      const sessionRepoMock = new InMemorySessionRepository();
-      const idGeneratorMock = new MockIdGenerator();
-      const useCase = new CreateRoutine(routineRepoMock, sessionRepoMock, idGeneratorMock);
-
-      jest
-        .spyOn(sessionRepoMock, 'findById')
-        .mockResolvedValue(Failure(new TechnicalError() as never));
-
-      const routineData: CreateRoutineInput = {
-        name: 'Test Routine',
-        description: null,
-        active: true,
-        days: 1,
-        initialDate: new Date(),
-        cycleId: 'week',
-        userId: 'user-123',
-        routineDays: [{ name: 'Day 1', day: 1, sessionId: 'session-1' }],
-      };
-
-      idGeneratorMock.id = '1df38173-6fae-4abb-8cb2-ce33b6c24d10';
 
       const createResult = await useCase.execute(routineData);
 

--- a/src/modules/routine/application/use-cases/create-routine.ts
+++ b/src/modules/routine/application/use-cases/create-routine.ts
@@ -1,14 +1,12 @@
+import type { UseCase } from '@/shared/application/shared.use-case';
+import type { IdGeneratorRepository } from '@/shared/application/id-generator.repository';
+import type { CreateRoutineInput } from '@/modules/routine/application/dtos/create-routine.dto';
+import type { IRoutineRepository } from '@/modules/routine/domain/routine.repository';
+import type { ISessionRepository } from '@/modules/session/domain/session.repository';
 import { Failure } from '@/shared/domain/result';
 import { Routine } from '@/modules/routine/domain/routine.entity';
 import { InvalidRoutineData } from '@/modules/routine/domain/errors/routine.errors';
-import type { CreateRoutineInput } from '@/modules/routine/application/dtos/create-routine.dto';
-import type { IdGeneratorRepository } from '@/shared/application/id-generator.repository';
-import type { IRoutineRepository } from '@/modules/routine/domain/routine.repository';
-import type { ISessionRepository } from '@/modules/session/domain/session.repository';
-import type { RoutineProps } from '@/modules/routine/domain/routine.types';
-import type { Session } from '@/modules/session/domain/session.entity';
-import type { UseCase } from '@/shared/application/shared.use-case';
-import { SessionNotFoundError } from '@/modules/auth/domain/errors/auth.errors';
+import { RoutineDaysValidationService } from '@/modules/routine/domain/services/routine-day.validation.service';
 
 export class CreateRoutine implements UseCase {
   constructor(
@@ -23,41 +21,20 @@ export class CreateRoutine implements UseCase {
 
     const routineId = idResult.data;
 
-    const sessions: (Session | null)[] = [];
-
-    for (const routineDay of routineData.routineDays) {
-      if (!routineDay.sessionId) {
-        sessions.push(null);
-        continue;
-      }
-      const sessionResult = await this.sessionRepository.findById(routineDay.sessionId);
-      if (!sessionResult.success) return sessionResult;
-      if (!sessionResult.data) return Failure(new SessionNotFoundError());
-      sessions.push(sessionResult.data);
-    }
-
-    const routineDays: RoutineProps['routineDays'] = [];
-
-    for (let i = 0; i < routineData.routineDays.length; i++) {
-      const routineDay = routineData.routineDays[i];
-      if (!routineDay) return Failure(new InvalidRoutineData('ROUTINE_DAYS'));
-
-      const sessionIdResult = await this.generator.generate();
-      if (!sessionIdResult.success) return sessionIdResult;
-      const sessionId = sessionIdResult.data;
-
-      routineDays.push({
-        id: sessionId,
-        day: routineDay.day,
-        name: routineDay.name,
-        session: sessions[i] ?? null,
-      });
-    }
+    const routineDaysService = new RoutineDaysValidationService(
+      this.sessionRepository,
+      this.generator
+    );
+    const routineDaysResult = await routineDaysService.createRoutineDays(routineData.routineDays);
+    if (!routineDaysResult.success) return routineDaysResult;
+    if (!routineDaysResult.data) return Failure(new InvalidRoutineData('ROUTINE_DAYS_LENGTH'));
+    const routineDays = routineDaysResult.data;
 
     const newRoutineResult = Routine.create(routineId, {
       ...routineData,
       routineDays,
     });
+
     if (!newRoutineResult.success) return newRoutineResult;
 
     return await this.routineRepository.create(newRoutineResult.data);

--- a/src/modules/routine/application/use-cases/update-routine.test.ts
+++ b/src/modules/routine/application/use-cases/update-routine.test.ts
@@ -96,27 +96,6 @@ describe('UpdateRoutine use case', () => {
       expect(!updateResult.success && updateResult.error.code).toBe('ROUTINE_NOT_FOUND');
     });
 
-    it('should return failure when session not found', async () => {
-      const routineRepoMock = new InMemoryRoutineRepository();
-      const sessionRepoMock = new InMemorySessionRepository();
-      const idGeneratorMock = new MockIdGenerator();
-      const useCase = new UpdateRoutine(routineRepoMock, sessionRepoMock, idGeneratorMock);
-
-      const updateResult = await useCase.execute('1df38173-6fae-4abb-8cb2-ce33b6c24d99', {
-        name: 'New Name',
-        routineDays: [
-          {
-            day: 1,
-            name: 'Day 1',
-            sessionId: 'not-existing-session',
-          },
-        ],
-      });
-
-      expect(updateResult.success).toBe(false);
-      expect(!updateResult.success && updateResult.error.code).toBe('ROUTINE_NOT_FOUND');
-    });
-
     it('should return failure when invalid data provided', async () => {
       const routineRepoMock = new InMemoryRoutineRepository();
       const sessionRepoMock = new InMemorySessionRepository();
@@ -157,7 +136,7 @@ describe('UpdateRoutine use case', () => {
 
       const routineId = '1df38173-6fae-4abb-8cb2-ce33b6c24da5';
       const routine = Routine.create(routineId, {
-        name: 'Test',
+        name: 'Routine',
         description: null,
         active: true,
         days: 1,
@@ -194,74 +173,6 @@ describe('UpdateRoutine use case', () => {
 
       const updateResult = await useCase.execute('1df38173-6fae-4abb-8cb2-ce33b6c24da6', {
         name: 'Updated',
-      });
-
-      expect(updateResult.success).toBe(false);
-      expect(!updateResult.success && updateResult.error.code).toBe('TECHNICAL_ERROR');
-    });
-
-    it('should return failure when idGenerator fails during routineDays update', async () => {
-      const routineRepoMock = new InMemoryRoutineRepository();
-      const sessionRepoMock = new InMemorySessionRepository();
-      const idGeneratorMock = new MockIdGenerator();
-      const useCase = new UpdateRoutine(routineRepoMock, sessionRepoMock, idGeneratorMock);
-
-      const routineId = '1df38173-6fae-4abb-8cb2-ce33b6c24da7';
-      const routine = Routine.create(routineId, {
-        name: 'Test',
-        description: null,
-        active: true,
-        days: 1,
-        initialDate: new Date(),
-        cycleId: 'week',
-        routineDays: [
-          { id: '1df38173-6fae-4abb-8cb2-ce33b6c24d07', day: 1, name: 'Day 1', session: null },
-        ],
-        userId: 'user-123',
-      });
-      if (!routine.success) throw new Error('Failed to create routine');
-      await routineRepoMock.create(routine.data);
-
-      jest
-        .spyOn(idGeneratorMock, 'generate')
-        .mockReturnValue(Failure(new TechnicalError() as never));
-
-      const updateResult = await useCase.execute(routineId, {
-        routineDays: [{ name: 'Day 1', day: 1, sessionId: null }],
-      });
-
-      expect(updateResult.success).toBe(false);
-      expect(!updateResult.success && updateResult.error.code).toBe('TECHNICAL_ERROR');
-    });
-
-    it('should return failure when session operation findById fails', async () => {
-      const routineRepoMock = new InMemoryRoutineRepository();
-      const sessionRepoMock = new InMemorySessionRepository();
-      const idGeneratorMock = new MockIdGenerator();
-      const useCase = new UpdateRoutine(routineRepoMock, sessionRepoMock, idGeneratorMock);
-
-      jest
-        .spyOn(sessionRepoMock, 'findById')
-        .mockResolvedValue(Failure(new TechnicalError() as never));
-
-      const routineId = '1df38173-6fae-4abb-8cb2-ce33b6c24da4';
-      const routine = Routine.create(routineId, {
-        name: 'Test',
-        description: null,
-        active: true,
-        days: 1,
-        initialDate: new Date(),
-        cycleId: 'week',
-        routineDays: [
-          { id: '1df38173-6fae-4abb-8cb2-ce33b6c24d05', day: 1, name: 'Day 1', session: null },
-        ],
-        userId: 'user-123',
-      });
-      if (!routine.success) throw new Error('Failed to create routine');
-      await routineRepoMock.create(routine.data);
-
-      const updateResult = await useCase.execute(routineId, {
-        routineDays: [{ name: 'Day 1', day: 1, sessionId: '1df38173-6fae-4abb-8cb2-ce33b6c24da4' }],
       });
 
       expect(updateResult.success).toBe(false);

--- a/src/modules/routine/application/use-cases/update-routine.ts
+++ b/src/modules/routine/application/use-cases/update-routine.ts
@@ -1,19 +1,13 @@
-import type { Result } from '@/shared/domain/result';
 import type { UseCase } from '@/shared/application/shared.use-case';
-import type { DomainError } from '@/shared/domain/errors/domain.errors';
 import type { IdGeneratorRepository } from '@/shared/application/id-generator.repository';
 import type { RoutineProps } from '@/modules/routine/domain/routine.types';
 import type { IRoutineRepository } from '@/modules/routine/domain/routine.repository';
 import type { ISessionRepository } from '@/modules/session/domain/session.repository';
 import type { UpdateRoutineInput } from '@/modules/routine/application/dtos/update-routine.dto';
-import type { Routine } from '@/modules/routine/domain/routine.entity';
-import { Failure, Success } from '@/shared/domain/result';
-import { isArray } from '@/shared/domain/validation/validation.non-primitives';
-import {
-  InvalidRoutineData,
-  RoutineNotFoundError,
-} from '@/modules/routine/domain/errors/routine.errors';
+import { Failure } from '@/shared/domain/result';
+import { RoutineNotFoundError } from '@/modules/routine/domain/errors/routine.errors';
 import { updateRoutineProperties } from '@/modules/routine/application/helpers/update-routine.use-case.helper';
+import { RoutineDaysValidationService } from '@/modules/routine/domain/services/routine-day.validation.service';
 
 export class UpdateRoutine implements UseCase {
   constructor(
@@ -24,63 +18,22 @@ export class UpdateRoutine implements UseCase {
 
   async execute(id: RoutineProps['id'], data: UpdateRoutineInput) {
     const routineResult = await this.routineRepository.findById(id);
-    if (!routineResult.success || !routineResult.data) {
-      if (!routineResult.success) return Failure(routineResult.error);
-      return Failure(new RoutineNotFoundError());
-    }
+    if (!routineResult.success) return routineResult;
+    if (!routineResult.data) return Failure(new RoutineNotFoundError());
 
     const routine = routineResult.data;
 
     const updatePropertiesResult = updateRoutineProperties(data, routine);
     if (!updatePropertiesResult.success) return updatePropertiesResult;
 
-    const updateRoutineDaysResult = await this.updateRoutineDays(data.routineDays, routine);
+    const routineDaysService = new RoutineDaysValidationService(
+      this.sessionRepository,
+      this.generatorRepository
+    );
+    const updateRoutineDaysResult = await routineDaysService.createRoutineDays(data.routineDays);
     if (!updateRoutineDaysResult.success) return updateRoutineDaysResult;
+    if (updateRoutineDaysResult.data) routine.changeRoutineDays(updateRoutineDaysResult.data);
 
     return await this.routineRepository.update(routine);
-  }
-
-  private async updateRoutineDays(
-    routineDaysInput: UpdateRoutineInput['routineDays'],
-    routine: Routine
-  ): Promise<Result<null, DomainError>> {
-    if (!routineDaysInput) return Success(null);
-    if (!isArray(routineDaysInput)) return Failure(new InvalidRoutineData('ROUTINE_DAYS'));
-
-    const routineDays: RoutineProps['routineDays'] = [];
-    const routineDaysPromises = routineDaysInput.map((r) => this.generatePromises(r.sessionId));
-    const routineDaysResults = await Promise.all(routineDaysPromises);
-
-    for (let i = 0; i < routineDaysResults.length; i++) {
-      const results = routineDaysResults[i];
-      const routineDay = routineDaysInput[i];
-      if (!results || !routineDay) continue;
-
-      const [idResult, sessionResult] = results;
-      if (!idResult.success) return idResult;
-      if (!sessionResult.success) return sessionResult;
-
-      const { day, name } = routineDay;
-      routineDays.push({
-        id: idResult.data,
-        day,
-        name,
-        session: sessionResult.data,
-      });
-    }
-    const routineDaysResult = routine.changeRoutineDays(routineDays);
-    if (!routineDaysResult.success) return routineDaysResult;
-
-    return Success(null);
-  }
-
-  private generatePromises(sessionId: string | null) {
-    if (sessionId === null)
-      return Promise.all([this.generatorRepository.generate(), Success(null)]);
-
-    return Promise.all([
-      this.generatorRepository.generate(),
-      this.sessionRepository.findById(sessionId),
-    ]);
   }
 }

--- a/src/modules/routine/domain/routine.entity.test.ts
+++ b/src/modules/routine/domain/routine.entity.test.ts
@@ -180,7 +180,7 @@ describe('Routine entity', () => {
       expect(result.success).toBe(true);
       expect(result.success && result.data).toBe(null);
       expect(routine.routineDays).toEqual(newRoutineDays);
-      expect(routine.days).toBe(2);
+      expect(routine.days).toBe(3);
     });
   });
 });

--- a/src/modules/routine/domain/routine.entity.test.ts
+++ b/src/modules/routine/domain/routine.entity.test.ts
@@ -174,23 +174,13 @@ describe('Routine entity', () => {
       const newRoutineDays = [
         { id: '1df38173-6fae-4abb-8cb2-ce33b6c24da1', name: 'Day 1', day: 1, session: null },
         { id: '1df38173-6fae-4abb-8cb2-ce33b6c24da2', name: 'Day 2', day: 2, session: null },
+        { id: '1df38173-6fae-4abb-8cb2-ce33b6c24da3', name: 'Day 3', day: 3, session: null },
       ];
       const result = routine.changeRoutineDays(newRoutineDays);
       expect(result.success).toBe(true);
       expect(result.success && result.data).toBe(null);
       expect(routine.routineDays).toEqual(newRoutineDays);
       expect(routine.days).toBe(2);
-    });
-
-    it('should return failure when routineDays is invalid', async () => {
-      const routine = createTestRoutine();
-      const newRoutineDays = [
-        { id: '15', name: 'Day 1', day: 0, session: null },
-        { id: '1df38173-6fae-4abb-8cb2-ce33b6c24da2', name: 'Day 2', day: 2, session: null },
-      ];
-      const result = routine.changeRoutineDays(newRoutineDays);
-      expect(result.success).toBe(false);
-      expect(routine.routineDays).not.toEqual(newRoutineDays);
     });
   });
 });

--- a/src/modules/routine/domain/routine.entity.ts
+++ b/src/modules/routine/domain/routine.entity.ts
@@ -79,11 +79,10 @@ export class Routine {
     return Success(null);
   }
   changeRoutineDays(routineDays: RoutineProps['routineDays']): Result<null, DomainError> {
-    if (!routineValidators.routineDays.validate(routineDays))
-      return Failure(routineValidators.routineDays.error);
-    const daysResult = this.changeDays(routineDays.length);
-    if (!daysResult.success) return daysResult;
-
+    if (this.days !== routineDays.length) {
+      const daysResult = this.changeDays(routineDays.length);
+      if (!daysResult.success) return daysResult;
+    }
     this.data.routineDays = routineDays;
     return Success(null);
   }

--- a/src/modules/routine/domain/routine.types.ts
+++ b/src/modules/routine/domain/routine.types.ts
@@ -3,6 +3,7 @@ import type { UserProps } from '@/modules/user/domain/user.types';
 import type { Session } from '@/modules/session/domain/session.entity';
 import type { RoutineCycleId } from '@/modules/routine/domain/constants/routine.constants.cycle-types';
 import type { Routine } from '@/modules/routine/domain/routine.entity';
+import type { SessionProps } from '@/modules/session/domain/session.types';
 
 export type RoutineDay = {
   id: string;
@@ -33,3 +34,10 @@ export type RoutineFactoryData = Omit<RoutineProps, 'id' | 'createdAt' | 'update
 };
 
 export type RoutineMethods = ClassMethods<Routine>;
+
+export type RoutineRoutineDayFactory = Omit<
+  RoutineProps['routineDays'][number],
+  'id' | 'session'
+> & {
+  sessionId: SessionProps['id'] | null;
+};

--- a/src/modules/routine/domain/services/routine-day.validation.service.test.ts
+++ b/src/modules/routine/domain/services/routine-day.validation.service.test.ts
@@ -1,0 +1,154 @@
+import '@testing-library/jest-dom';
+import type { RoutineRoutineDayFactory } from '@/modules/routine/domain/routine.types';
+import { InMemorySessionRepository } from '@/modules/session/mocks/session.mocks.repository';
+import { MockIdGenerator } from '@/shared/test/mocks/id-generator.repository.mock';
+import { RoutineDaysValidationService } from '@/modules/routine/domain/services/routine-day.validation.service';
+import { TechnicalError } from '@/shared/domain/errors/domain.errors';
+import { Failure } from '@/shared/domain/result';
+
+describe('ExerciseValidationService', () => {
+  describe('Happy path', () => {
+    const idGeneratorRepoMock = new MockIdGenerator();
+    const sessionRepoMock = new InMemorySessionRepository();
+    const service = new RoutineDaysValidationService(sessionRepoMock, idGeneratorRepoMock);
+    it('should return result successfully when valid routineDays array', async () => {
+      const routineDaysInput: RoutineRoutineDayFactory[] = [
+        {
+          day: 1,
+          name: 'Day 1',
+          sessionId: '1df38173-6fae-4abb-8cb2-ce33b6c24da4',
+        },
+        {
+          day: 2,
+          name: 'Day 2',
+          sessionId: null,
+        },
+      ];
+
+      const routineDaysResult = await service.createRoutineDays(routineDaysInput);
+
+      expect(routineDaysResult.success).toBe(true);
+      expect(routineDaysResult.success && routineDaysResult.data).toHaveLength(2);
+    });
+
+    it('should return result successfully when empty array', async () => {
+      const routineDaysInput: RoutineRoutineDayFactory[] = [];
+
+      const routineDaysResult = await service.createRoutineDays(routineDaysInput);
+
+      expect(routineDaysResult.success).toBe(true);
+      expect(routineDaysResult.success && routineDaysResult.data).toHaveLength(0);
+    });
+
+    it('should return result successfully when undefined input', async () => {
+      const routineDaysInput = undefined;
+
+      const routineDaysResult = await service.createRoutineDays(routineDaysInput);
+
+      expect(routineDaysResult.success).toBe(true);
+    });
+  });
+
+  describe('Error Handling', () => {
+    const idGeneratorRepoMock = new MockIdGenerator();
+    const sessionRepoMock = new InMemorySessionRepository();
+    const service = new RoutineDaysValidationService(sessionRepoMock, idGeneratorRepoMock);
+    it('should return failure when invalid input', async () => {
+      const routineDaysInput: RoutineRoutineDayFactory[] = [
+        1,
+        [
+          {
+            day: 2,
+            name: 'Day 2',
+            sessionId: null,
+          },
+        ],
+      ] as never;
+
+      const routineDaysResult = await service.createRoutineDays(routineDaysInput);
+      expect(routineDaysResult.success).toBe(false);
+    });
+
+    it('should return failure when invalid routineDays element', async () => {
+      const routineDaysInput: RoutineRoutineDayFactory[] = [
+        1,
+        [
+          {
+            day: 2,
+            name: 'Day 2',
+            sessionId: null,
+          },
+        ],
+      ] as never;
+
+      const routineDaysResult = await service.createRoutineDays(routineDaysInput);
+      expect(routineDaysResult.success).toBe(false);
+    });
+
+    it('should return failure when invalid routineDays element', async () => {
+      const routineDaysInput: RoutineRoutineDayFactory[] = [
+        {
+          day: -1,
+          name: '',
+        },
+      ] as never;
+
+      const routineDaysResult = await service.createRoutineDays(routineDaysInput);
+      expect(routineDaysResult.success).toBe(false);
+    });
+
+    it('should return failure when session not found', async () => {
+      const routineDaysInput: RoutineRoutineDayFactory[] = [
+        {
+          day: 1,
+          name: 'Day 1',
+          sessionId: '1df38173-6fae-4abb-8cb2-ce33b6c24da0',
+        },
+      ] as never;
+
+      const routineDaysResult = await service.createRoutineDays(routineDaysInput);
+      expect(routineDaysResult.success).toBe(false);
+    });
+  });
+
+  describe('Dependency Interaction', () => {
+    const routineDaysInput: RoutineRoutineDayFactory[] = [
+      {
+        day: 1,
+        name: 'Day 1',
+        sessionId: '1df38173-6fae-4abb-8cb2-ce33b6c24da4',
+      },
+      {
+        day: 2,
+        name: 'Day 2',
+        sessionId: null,
+      },
+    ];
+
+    it('should return failure when idGenerator generate operation fails', async () => {
+      const idGeneratorRepoMock = new MockIdGenerator();
+      const sessionRepoMock = new InMemorySessionRepository();
+      const service = new RoutineDaysValidationService(sessionRepoMock, idGeneratorRepoMock);
+      jest
+        .spyOn(idGeneratorRepoMock, 'generate')
+        .mockReturnValue(Failure(new TechnicalError() as never));
+
+      const routineDaysResult = await service.createRoutineDays(routineDaysInput);
+      expect(routineDaysResult.success).toBe(false);
+      expect(!routineDaysResult.success && routineDaysResult.error.code).toBe('TECHNICAL_ERROR');
+    });
+
+    it('should return failure when session findById operation fails', async () => {
+      const idGeneratorRepoMock = new MockIdGenerator();
+      const sessionRepoMock = new InMemorySessionRepository();
+      const service = new RoutineDaysValidationService(sessionRepoMock, idGeneratorRepoMock);
+      jest
+        .spyOn(sessionRepoMock, 'findById')
+        .mockResolvedValue(Failure(new TechnicalError() as never));
+
+      const routineDaysResult = await service.createRoutineDays(routineDaysInput);
+      expect(routineDaysResult.success).toBe(false);
+      expect(!routineDaysResult.success && routineDaysResult.error.code).toBe('TECHNICAL_ERROR');
+    });
+  });
+});

--- a/src/modules/routine/domain/services/routine-day.validation.service.ts
+++ b/src/modules/routine/domain/services/routine-day.validation.service.ts
@@ -1,0 +1,70 @@
+import type { Result } from '@/shared/domain/result';
+import type { DomainError } from '@/shared/domain/errors/domain.errors';
+import type { IdGeneratorRepository } from '@/shared/application/id-generator.repository';
+import type { ISessionRepository } from '@/modules/session/domain/session.repository';
+import type { Session } from '@/modules/session/domain/session.entity';
+import type {
+  RoutineProps,
+  RoutineRoutineDayFactory,
+} from '@/modules/routine/domain/routine.types';
+import { Failure, Success } from '@/shared/domain/result';
+import { isArrayOf } from '@/shared/domain/validation/validation.utils';
+import { SessionNotFoundError } from '@/modules/auth/domain/errors/auth.errors';
+import { InvalidRoutineData } from '@/modules/routine/domain/errors/routine.errors';
+import { isValidFactoryRoutineRoutineDayInput } from '@/modules/routine/domain/validation/routine.routine-day.validation';
+
+export class RoutineDaysValidationService {
+  constructor(
+    private readonly sessionRepository: ISessionRepository,
+    private readonly idGenerator: IdGeneratorRepository
+  ) {}
+
+  async createRoutineDays(
+    routineDaysInput?: RoutineRoutineDayFactory[]
+  ): Promise<Result<RoutineProps['routineDays'] | null, DomainError>> {
+    if (!routineDaysInput) return Success(null);
+
+    if (!isArrayOf(routineDaysInput, 'plainObject'))
+      return Failure(new InvalidRoutineData('ROUTINE_DAYS'));
+
+    const routineDaysPreparation = routineDaysInput.map((r) => this.validateRoutineDay(r));
+    const routineDaysResults = await Promise.all(routineDaysPreparation);
+
+    const routineDays: RoutineProps['routineDays'] = [];
+    for (const routineDaysResult of routineDaysResults) {
+      if (!routineDaysResult.success) return routineDaysResult;
+      routineDays.push(routineDaysResult.data);
+    }
+
+    return Success(routineDays);
+  }
+
+  private async validateRoutineDay(
+    routineDayInput: RoutineRoutineDayFactory
+  ): Promise<Result<RoutineProps['routineDays'][number], DomainError>> {
+    if (!isValidFactoryRoutineRoutineDayInput(routineDayInput))
+      return Failure(new InvalidRoutineData('ROUTINE_DAYS'));
+
+    const idResult = this.idGenerator.generate();
+    if (!idResult.success) return idResult;
+    const id = idResult.data;
+
+    let session: Session | null = null;
+
+    if (routineDayInput.sessionId !== null) {
+      const sessionResult = await this.sessionRepository.findById(routineDayInput.sessionId);
+      if (!sessionResult.success) return sessionResult;
+      if (!sessionResult.data) return Failure(new SessionNotFoundError());
+      session = sessionResult.data;
+    }
+
+    const { day, name } = routineDayInput;
+
+    return Success({
+      id,
+      day,
+      name,
+      session,
+    });
+  }
+}

--- a/src/modules/routine/domain/validation/routine.routine-day.validation.ts
+++ b/src/modules/routine/domain/validation/routine.routine-day.validation.ts
@@ -1,49 +1,44 @@
 import type { ValidationFunction } from '@/shared/shared.types';
-import type { RoutineDay } from '@/modules/routine/domain/routine.types';
+import type { RoutineRoutineDayFactory } from '@/modules/routine/domain/routine.types';
 import { isObject } from '@/shared/domain/validation/validation.non-primitives';
 import { isString } from '@/shared/domain/validation/validation.primitives';
-import { isKeyOf, isValidUuid } from '@/shared/domain/validation/validation.utils';
-import { Session } from '@/modules/session/domain/session.entity';
+import { isKeyOf } from '@/shared/domain/validation/validation.utils';
 import { isValidRoutineDays } from '@/modules/routine/domain/validation/routine.validation.utils';
+import { isValidSessionId } from '@/modules/session/domain/validation/session.validation.utils';
 
-const isValidRoutineDayId: ValidationFunction = (id: unknown) => {
-  return isValidUuid(id);
-};
-
-const isValidRoutineDayDay: ValidationFunction = (day: unknown) => {
+function isValidRoutineDayDay(day: unknown): boolean {
   return isValidRoutineDays(day);
-};
+}
 
-const isValidRoutineDaySession: ValidationFunction = (session: unknown) => {
-  if (session === null) return true;
-  return session instanceof Session;
-};
-
-const isValidRoutineDayName: ValidationFunction = (name: unknown) => {
+function isValidRoutineDayName(name: unknown): boolean {
   return isString(name);
+}
+
+function isValidRoutineDaySessionId(sessionId: unknown): boolean {
+  return sessionId === null || isValidSessionId(sessionId);
+}
+
+type RawRoutineDaysValidations = {
+  [K in keyof RoutineRoutineDayFactory]: ValidationFunction;
 };
 
-type RoutineDaysValidations = {
-  [K in keyof RoutineDay]: ValidationFunction;
-};
-
-const routineDaysValidation: RoutineDaysValidations = {
-  id: isValidRoutineDayId,
+const factoryRoutineDaysInputValidation: RawRoutineDaysValidations = {
   day: isValidRoutineDayDay,
   name: isValidRoutineDayName,
-  session: isValidRoutineDaySession,
+  sessionId: isValidRoutineDaySessionId,
 };
 
-export const isValidRoutineRoutineDay: ValidationFunction = (routineDay: unknown) => {
+export function isValidFactoryRoutineRoutineDayInput(routineDay: unknown): boolean {
   if (!isObject(routineDay)) return true;
-  const routineDayKeys = Object.keys(routineDaysValidation) as (keyof RoutineDay)[];
+  const routineDayKeys = Object.keys(
+    factoryRoutineDaysInputValidation
+  ) as (keyof RawRoutineDaysValidations)[];
 
   for (const key of routineDayKeys) {
     if (!isKeyOf(key, routineDay)) return false;
-
     const value = routineDay[key];
-    const validate = routineDaysValidation[key] as ValidationFunction;
+    const validate = factoryRoutineDaysInputValidation[key] as ValidationFunction;
     if (!validate(value)) return false;
   }
   return true;
-};
+}

--- a/src/modules/routine/domain/validation/routine.validation.test.ts
+++ b/src/modules/routine/domain/validation/routine.validation.test.ts
@@ -233,54 +233,6 @@ describe('validateRoutine', () => {
       });
     });
 
-    describe('ROUTINE DAYS field', () => {
-      it('should fail when is not an array', () => {
-        const validation = validateRoutine({
-          ...validRoutineData,
-          routineDays: 'not-an-array',
-        } as unknown as Parameters<typeof validateRoutine>[0]);
-        expect(validation.success).toBe(false);
-        expect(validation.success === false && validation.error.code).toBe(
-          'INVALID_ROUTINE_DATA.ROUTINE_DAYS'
-        );
-      });
-
-      describe("ROUTINE DAYS' fields", () => {
-        it('should fail missing a key', () => {
-          const validation = validateRoutine({
-            ...validRoutineData,
-            routineDays: [{ day: 1, name: 'Day 1', session: null }],
-          } as unknown as Parameters<typeof validateRoutine>[0]);
-          expect(validation.success).toBe(false);
-          expect(validation.success === false && validation.error.code).toBe(
-            'INVALID_ROUTINE_DATA.ROUTINE_DAYS'
-          );
-        });
-
-        it('should fail when has invalid day', () => {
-          const validation = validateRoutine({
-            ...validRoutineData,
-            routineDays: [{ id: validId, day: -1, name: 'Day 1', session: null }],
-          } as unknown as Parameters<typeof validateRoutine>[0]);
-          expect(validation.success).toBe(false);
-          expect(validation.success === false && validation.error.code).toBe(
-            'INVALID_ROUTINE_DATA.ROUTINE_DAYS'
-          );
-        });
-
-        it('should fail when has invalid name', () => {
-          const validation = validateRoutine({
-            ...validRoutineData,
-            routineDays: [{ id: validId, day: 1, session: null }],
-          } as unknown as Parameters<typeof validateRoutine>[0]);
-          expect(validation.success).toBe(false);
-          expect(validation.success === false && validation.error.code).toBe(
-            'INVALID_ROUTINE_DATA.ROUTINE_DAYS'
-          );
-        });
-      });
-    });
-
     describe('CYCLE ID field', () => {
       it('should fail when is not a valid cycle type', () => {
         const validation = validateRoutine({

--- a/src/modules/routine/domain/validation/routine.validation.ts
+++ b/src/modules/routine/domain/validation/routine.validation.ts
@@ -5,7 +5,6 @@ import { isObject } from '@/shared/domain/validation/validation.non-primitives';
 import { isKeyOf } from '@/shared/domain/validation/validation.utils';
 import { CYCLE_TYPES } from '@/modules/routine/domain/constants/routine.constants.cycle-types';
 import {
-  areValidRoutineRoutineDays,
   isValidRoutineActive,
   isValidRoutineDays,
   isValidRoutineDescription,
@@ -18,7 +17,10 @@ import type { Result } from '@/shared/domain/result';
 import type { DomainError } from '@/shared/domain/errors/domain.errors';
 import type { RoutineFactoryData, RoutineProps } from '@/modules/routine/domain/routine.types';
 
-type RoutineValidationKeys = Omit<RoutineProps, 'createdAt' | 'updatedAt' | 'cycle' | 'userId'>;
+type RoutineValidationKeys = Omit<
+  RoutineProps,
+  'createdAt' | 'updatedAt' | 'cycle' | 'userId' | 'routineDays'
+>;
 
 type RoutineValidators = Record<
   keyof RoutineValidationKeys,
@@ -40,10 +42,6 @@ export const routineValidators: RoutineValidators = {
   initialDate: {
     validate: isValidRoutineInitialDate,
     error: new InvalidRoutineData('INITIAL_DATE'),
-  },
-  routineDays: {
-    validate: areValidRoutineRoutineDays,
-    error: new InvalidRoutineData('ROUTINE_DAYS'),
   },
 };
 

--- a/src/modules/routine/domain/validation/routine.validation.utils.ts
+++ b/src/modules/routine/domain/validation/routine.validation.utils.ts
@@ -4,14 +4,13 @@ import {
   isIntegerNumber,
   isString,
 } from '@/shared/domain/validation/validation.primitives';
-import { isArray, isDate } from '@/shared/domain/validation/validation.non-primitives';
+import { isDate } from '@/shared/domain/validation/validation.non-primitives';
 import { isValidUuid } from '@/shared/domain/validation/validation.utils';
 import {
   ROUTINE_DAYS_LENGTH,
   ROUTINE_DESCRIPTION_LENGTH,
   ROUTINE_NAME_LENGTH,
 } from '@/modules/routine/domain/validation/routine.validation.constants';
-import { isValidRoutineRoutineDay } from '@/modules/routine/domain/validation/routine.routine-day.validation';
 
 export const isValidRoutineId: ValidationFunction = (id: unknown) => {
   return isValidUuid(id);
@@ -44,13 +43,4 @@ export const isValidRoutineDays: ValidationFunction = (days: unknown) => {
   if (!isIntegerNumber(days)) return false;
   if (days < ROUTINE_DAYS_LENGTH.min) return false;
   return days <= ROUTINE_DAYS_LENGTH.max;
-};
-
-export const areValidRoutineRoutineDays: ValidationFunction = (routineDays: unknown) => {
-  if (!isArray(routineDays)) return false;
-  if (!isValidRoutineDays(routineDays.length)) return false;
-  for (const routineDay of routineDays) {
-    if (!isValidRoutineRoutineDay(routineDay)) return false;
-  }
-  return true;
 };

--- a/src/modules/session/application/use-cases/create-session.ts
+++ b/src/modules/session/application/use-cases/create-session.ts
@@ -3,10 +3,10 @@ import type { CreateSessionInput } from '@/modules/session/application/dtos/crea
 import type { UseCase } from '@/shared/application/shared.use-case';
 import type { IdGeneratorRepository } from '@/shared/application/id-generator.repository';
 import type { IExerciseRepository } from '@/modules/exercise/domain/exercise.repository';
-import type { Exercise } from '@/modules/exercise/domain/exercise.entity';
 import { Session } from '@/modules/session/domain/session.entity';
-import { ExerciseNotFoundError } from '@/modules/exercise/domain/errors/exercise.errors';
+import { InvalidExerciseData } from '@/modules/exercise/domain/errors/exercise.errors';
 import { Failure } from '@/shared/domain/result';
+import { ExerciseValidationService } from '@/modules/exercise/domain/services/exercise.validation.service';
 
 export class CreateSession implements UseCase {
   constructor(
@@ -23,15 +23,18 @@ export class CreateSession implements UseCase {
 
     const { exerciseIds, ...sessionData } = data;
 
-    const exercises: Exercise[] = [];
-    for (const exerciseId of exerciseIds) {
-      const exerciseResult = await this.exerciseRepository.findById(exerciseId);
-      if (!exerciseResult.success) return exerciseResult;
-      if (!exerciseResult.data) return Failure(new ExerciseNotFoundError());
-      exercises.push(exerciseResult.data);
-    }
+    const exerciseValidationService = new ExerciseValidationService(this.exerciseRepository);
+    const exerciseValidatioResult = await exerciseValidationService.validateAndFetch(
+      data.exerciseIds
+    );
+    if (!exerciseValidatioResult.success) return exerciseValidatioResult;
+    if (!exerciseValidatioResult.data) return Failure(new InvalidExerciseData());
 
-    const newSessionResult = Session.create(sessionId, { ...sessionData, exercises });
+    const newSessionResult = Session.create(sessionId, {
+      ...sessionData,
+      exercises: exerciseValidatioResult.data,
+    });
+
     if (!newSessionResult.success) return newSessionResult;
     const sessionResult = await this.sessionRepository.create(newSessionResult.data);
     if (!sessionResult.success) return sessionResult;

--- a/src/modules/session/application/use-cases/update-session.ts
+++ b/src/modules/session/application/use-cases/update-session.ts
@@ -1,20 +1,12 @@
-import type { Result } from '@/shared/domain/result';
-import type { DomainError } from '@/shared/domain/errors/domain.errors';
 import type { IExerciseRepository } from '@/modules/exercise/domain/exercise.repository';
 import type { ISessionRepository } from '@/modules/session/domain/session.repository';
 import type { SessionProps } from '@/modules/session/domain/session.types';
 import type { UpdateSessionInput } from '@/modules/session/application/dtos/update-session.dto';
 import type { UseCase } from '@/shared/application/shared.use-case';
-import type { Exercise } from '@/modules/exercise/domain/exercise.entity';
-import { Failure, Success } from '@/shared/domain/result';
+import { Failure } from '@/shared/domain/result';
 import { SessionNotFoundError } from '@/modules/session/domain/errors/session.errors';
-import {
-  ExerciseNotFoundError,
-  InvalidExerciseData,
-} from '@/modules/exercise/domain/errors/exercise.errors';
-import { isArray } from '@/shared/domain/validation/validation.non-primitives';
-import { isArrayOf } from '@/shared/domain/validation/validation.utils';
 import { updateSessionProperties } from '@/modules/session/application/helpers/update-session.use-case.helpers';
+import { ExerciseValidationService } from '@/modules/exercise/domain/services/exercise.validation.service';
 
 export class UpdateSession implements UseCase {
   constructor(
@@ -32,27 +24,13 @@ export class UpdateSession implements UseCase {
     const updatePropsResult = updateSessionProperties(data, session);
     if (!updatePropsResult.success) return updatePropsResult;
 
-    const exercisesResult = await this.prepareExercises(data.exerciseIds);
-    if (!exercisesResult.success) return exercisesResult;
-    if (exercisesResult.data) session.changeExercises(exercisesResult.data);
+    const exerciseValidationService = new ExerciseValidationService(this.exerciseRepository);
+    const exerciseValidatioResult = await exerciseValidationService.validateAndFetch(
+      data.exerciseIds
+    );
+    if (!exerciseValidatioResult.success) return exerciseValidatioResult;
+    if (exerciseValidatioResult.data) session.changeExercises(exerciseValidatioResult.data);
 
     return await this.sessionRepository.update(session);
-  }
-
-  private async prepareExercises(
-    exerciseIds?: UpdateSessionInput['exerciseIds']
-  ): Promise<Result<Exercise[] | null, DomainError>> {
-    if (!exerciseIds) return Success(null);
-    if (!isArray(exerciseIds) || !isArrayOf(exerciseIds, 'string'))
-      return Failure(new InvalidExerciseData());
-    const exercises: Exercise[] = [];
-    const exercisesFindById = exerciseIds.map((id) => this.exerciseRepository.findById(id));
-    const exercisesResults = await Promise.all(exercisesFindById);
-    for (const exerciseResult of exercisesResults) {
-      if (!exerciseResult.success) return exerciseResult;
-      if (!exerciseResult.data) return Failure(new ExerciseNotFoundError());
-      exercises.push(exerciseResult.data);
-    }
-    return Success(exercises);
   }
 }

--- a/src/shared/presentation/errors/error.messages.ts
+++ b/src/shared/presentation/errors/error.messages.ts
@@ -9,6 +9,7 @@ export const errorMessages: Record<DomainErrorCode, string> = {
   'INVALID_EXERCISE_DATA.SETS': '',
   'INVALID_EXERCISE_DATA.WEIGHT': '',
   MUSCLE_NOT_FOUND: '',
+  INVALID_MUSCLE_DATA: '',
   NOTIFICATION_NOT_FOUND: '',
   ROUTINE_NOT_FOUND: '',
   SESSION_NOT_FOUND: '',


### PR DESCRIPTION
## Domain & Application Logic

### 1. The "What" and "Why"

**Intent:** Feature
**Related Issue:** N/A

**Description:** Add domain validation services

>

### 2. Clean Architecture Alignment

- [x] **Domain Layer:** 
  - Add domain validation services in `Routine`, `Exercise`, `Muscle` modules. Including their unit tests.  
  - Reduce fragility from unit tests asserting only result pattern success or failure
- [x] **Application Layer:** 
  - Implement validation services in use cases: `UpdateRoutine`, `CreateRoutine`, `CreateSession`, `UpdateSession`, `CreateExercise`, `UpdateExercise`.
- [x] **Dependency Rule:** I confirm that no Infrastructure or UI-specific code has leaked into this PR.

### 3. Verification Checklist

These commands **must** pass locally before marking the PR as "Ready for Review."

- [x] **Type Safety:** `pnpm typecheck` passes without errors.
- [x] **Code Health:** `pnpm safe-fixes` has been run and resolved linting/formatting.
- [x] **Logic Integrity:** `pnpm test` passes (specifically for the affected Use Case/Entity).

### 4. Technical Nuances
To keep single responsibility in use cases. There are created domain services that validate related entities logic. This makes use cases clean and readable. Also reduce unit test fragility by removing those detailed assertions.
---

_Note: If this PR touches UI or Database schemas, please use the **Infrastructure** or **Presentation** templates instead._
