### PR TITLE
feat(ui): add empty data components

### DIFF
--- a/src/app/dashboard/(routine)/exercises/page.tsx
+++ b/src/app/dashboard/(routine)/exercises/page.tsx
@@ -5,6 +5,7 @@ import { getAllUserExercises } from '@/modules/exercise/presentation/exercise.ac
 import { Link } from '@/presentation/modules/button/components/Link';
 import { IconPlus } from '@/presentation/globals/components/icons/outline/IconPlus';
 import { ExercisesTable } from '@/modules/exercise/presentation/components/ExercisesTable';
+import { ExerciseEmptyData } from '@/modules/exercise/presentation/components/ExerciseEmptyData';
 
 export const dynamic = 'force-dynamic';
 
@@ -12,6 +13,8 @@ export default async function ExercisesPage() {
   const exercisesRequest = await getAllUserExercises();
 
   const exercises = exercisesRequest.success ? exercisesRequest.data : [];
+
+  if (exercises.length < 1) return <ExerciseEmptyData />;
 
   return (
     <PageContainer>

--- a/src/app/dashboard/(routine)/routines/page.tsx
+++ b/src/app/dashboard/(routine)/routines/page.tsx
@@ -5,11 +5,14 @@ import { IconPlus } from '@/presentation/globals/components/icons/outline/IconPl
 import { Routine } from '@/modules/routine/presentation/ui/components/Routine';
 import { Link } from '@/presentation/modules/button/components/Link';
 import { getAllRoutines } from '@/modules/routine/presentation/routine.actions';
+import { RoutineEmptyData } from '@/modules/routine/presentation/ui/components/RoutineEmptyData';
 
 export default async function RoutinesPage() {
   const routinesResult = await getAllRoutines();
 
   const routines = routinesResult.success ? routinesResult.data : [];
+
+  if (routines.length < 1) return <RoutineEmptyData />;
 
   return (
     <PageContainer>

--- a/src/app/dashboard/(routine)/sessions/page.tsx
+++ b/src/app/dashboard/(routine)/sessions/page.tsx
@@ -5,10 +5,14 @@ import { Session } from '@/modules/session/presentation/ui/components/Session';
 import { IconPlus } from '@/presentation/globals/components/icons/outline/IconPlus';
 import { Link } from '@/presentation/modules/button/components/Link';
 import { getAllSessions } from '@/modules/session/presentation/session.actions';
+import { SessionEmptyData } from '@/modules/session/presentation/ui/components/SessionEmptyData';
 
 export default async function SessionsPage() {
   const sessionsResult = await getAllSessions();
   const sessions = sessionsResult.success ? sessionsResult.data : [];
+
+  if (sessions.length < 1) return <SessionEmptyData />;
+
   return (
     <PageContainer>
       <PageHeader title="Sessions" description="Manage your days planifications" className="">

--- a/src/modules/exercise/presentation/components/ExerciseEmptyData.tsx
+++ b/src/modules/exercise/presentation/components/ExerciseEmptyData.tsx
@@ -1,0 +1,20 @@
+import { EmptyDataPage } from '@/presentation/globals/components/empty-data/EmptyDataPage';
+import { Link } from '@/presentation/modules/button/components/Link';
+import { IconBarbell } from '@tabler/icons-react';
+
+export function ExerciseEmptyData() {
+  return (
+    <EmptyDataPage
+      Icon={IconBarbell}
+      title="No Exercises Found"
+      description="You don't have exercises. Create your custom exercises."
+    >
+      <Link
+        variant={{ color: 'primary', type: 'text', size: 'lg' }}
+        href="/dashboard/exercises/create"
+      >
+        Create Exercise
+      </Link>
+    </EmptyDataPage>
+  );
+}

--- a/src/modules/routine/presentation/ui/components/RoutineEmptyData.tsx
+++ b/src/modules/routine/presentation/ui/components/RoutineEmptyData.tsx
@@ -1,0 +1,20 @@
+import { IconRouteX } from '@tabler/icons-react';
+import { EmptyDataPage } from '@/presentation/globals/components/empty-data/EmptyDataPage';
+import { Link } from '@/presentation/modules/button/components/Link';
+
+export function RoutineEmptyData() {
+  return (
+    <EmptyDataPage
+      Icon={IconRouteX}
+      title="No Routines Found"
+      description="You don't have Routines. Create your custom Routines."
+    >
+      <Link
+        variant={{ color: 'primary', type: 'text', size: 'lg' }}
+        href="/dashboard/routines/create"
+      >
+        Create Routine
+      </Link>
+    </EmptyDataPage>
+  );
+}

--- a/src/modules/session/presentation/ui/components/SessionEmptyData.tsx
+++ b/src/modules/session/presentation/ui/components/SessionEmptyData.tsx
@@ -1,0 +1,20 @@
+import { IconSchema } from '@tabler/icons-react';
+import { EmptyDataPage } from '@/presentation/globals/components/empty-data/EmptyDataPage';
+import { Link } from '@/presentation/modules/button/components/Link';
+
+export function SessionEmptyData() {
+  return (
+    <EmptyDataPage
+      Icon={IconSchema}
+      title="No Sessions Found"
+      description="You don't have sessions. Create your custom sessions."
+    >
+      <Link
+        variant={{ color: 'primary', type: 'text', size: 'lg' }}
+        href="/dashboard/sessions/create"
+      >
+        Create Session
+      </Link>
+    </EmptyDataPage>
+  );
+}

--- a/src/presentation/globals/components/empty-data/EmptyData.tsx
+++ b/src/presentation/globals/components/empty-data/EmptyData.tsx
@@ -1,0 +1,31 @@
+import type { IconTypes } from '@/presentation/globals/presentation.types';
+import { twMerge } from 'tailwind-merge';
+
+type Props = {
+  Icon: IconTypes;
+  title: string;
+  description: string;
+  children?: React.ReactNode;
+  className?: string;
+};
+
+export function EmptyData({ Icon, title, description, className, children }: Props) {
+  return (
+    <div className={twMerge('w-76 space-y-6', className)}>
+      <div className="grid place-content-center">
+        <div className="bg-fill-base border-bd-muted grid size-20 place-content-center rounded-4xl border-2">
+          <div className="mask-linear-125 mask-linear-from-40% mask-linear-to-100%">
+            <Icon className="text-fg-default size-12" strokeWidth="1.2" />
+          </div>
+        </div>
+      </div>
+      <header className="space-y-1 text-center">
+        <h3 className="text-fg-strong font-funnel-display text-2xl font-semibold tracking-tight">
+          {title}
+        </h3>
+        <p className="text-fg-default text-base font-light">{description}</p>
+      </header>
+      <footer className="flex items-center justify-center">{children}</footer>
+    </div>
+  );
+}

--- a/src/presentation/globals/components/empty-data/EmptyDataPage.tsx
+++ b/src/presentation/globals/components/empty-data/EmptyDataPage.tsx
@@ -1,0 +1,33 @@
+import type { IconTypes } from '@/presentation/globals/presentation.types';
+import { twMerge } from 'tailwind-merge';
+import { EmptyData } from '@/presentation/globals/components/empty-data/EmptyData';
+
+type Props = {
+  Icon: IconTypes;
+  title: string;
+  description: string;
+  children?: React.ReactNode;
+  className?: string;
+};
+
+export function EmptyDataPage({ Icon, description, title, children, className }: Props) {
+  return (
+    <div
+      className={twMerge(
+        'relative grid h-full w-full place-content-center overflow-hidden',
+        className
+      )}
+    >
+      <EmptyData Icon={Icon} title={title} description={description} className="z-1">
+        {children}
+      </EmptyData>
+      <div className="absolute top-[50%] left-[50%] translate-[-50%] perspective-distant">
+        <div className="rotate-x-70 rotate-z-0 transform mask-radial-from-black/0 mask-radial-from-10% mask-radial-to-black/50 mask-radial-to-50% mask-radial-at-center transform-3d">
+          <div className="mask-linear-180 mask-linear-from-0 mask-linear-to-80%">
+            <Icon className="text-fg-muted -z-1 size-400" strokeWidth={'0.1'} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Presentation & UI

### 1. The "What" and "Why"

**Components Impacted:** `Exercise`, `Session`, `Routine` dashboard pages
**Related Issue:** N/A

**Description:** To increase user experience when initializing it's added empty data components to bring some context before start creating registers

>

### 2. Visual Proof (Before vs. After)

| Before  | After   |
| :------ | :------ |
| 
<img width="1689" height="839" alt="image" src="https://github.com/user-attachments/assets/797385c6-9fa9-4dfa-824f-47cef27d6147" />
 | 
<img width="1681" height="841" alt="image" src="https://github.com/user-attachments/assets/09f0e8b3-8996-413e-af64-c9e89f779739" />
 |

### 3. Presentation Checklist

- [x] **Humble View:** Components only handle display logic and user interaction (no business logic leaked here).
- [x] **Responsiveness:** Tested on Mobile, Tablet, and Desktop breakpoints.
- [x] **Accessibility (A11y):** Clear content and good contrast.
- [ ] **State Management:** No client resources used.
- [x] **Next.js Patterns:** Correct usage of Server components.

### 4. Verification Checklist

These commands **must** pass locally.

- [x] **Type Safety:** `pnpm typecheck` passes.
- [x] **Code Health:** `pnpm safe-fixes` has been run.
- [x] **Visual/UI Tests:** `pnpm test` pass.

### 5. Technical Nuances (The "Why")

- **Style Decisions:** Translated from Figma. It keeps the modern and minimalist style using the custom theme variables.
- **Client/Server Balance:** Fully server component. No client resources needed.
- **UX Trade-offs:** It's added empty data to display relevant information about the empty elements.

---

_Note: If this PR touches Business Logic or External APIs, please use the **Domain** or **Infrastructure** templates._
