### PR TITLE
feat: add lucide react icons library

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@tabler/icons-react": "3.44.0",
     "dotenv": "17.2.3",
     "install": "0.13.0",
+    "lucide-react": "^1.17.0",
     "next": "16.0.8",
     "next-auth": "4.24.13",
     "next-themes": "0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       install:
         specifier: 0.13.0
         version: 0.13.0
+      lucide-react:
+        specifier: ^1.17.0
+        version: 1.17.0(react@19.2.3)
       next:
         specifier: 16.0.8
         version: 16.0.8(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -2263,6 +2266,11 @@ packages:
   lru.min@1.1.3:
     resolution: {integrity: sha512-Lkk/vx6ak3rYkRR0Nhu4lFUT2VDnQSxBe8Hbl7f36358p6ow8Bnvr8lrLt98H8J1aGxfhbX4Fs5tYg2+FTwr5Q==}
     engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
+
+  lucide-react@1.17.0:
+    resolution: {integrity: sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -5426,6 +5434,10 @@ snapshots:
       yallist: 4.0.0
 
   lru.min@1.1.3: {}
+
+  lucide-react@1.17.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
 
   lz-string@1.5.0: {}
 


### PR DESCRIPTION
## Add Lucide Icons for react

### Summary
It's decided to use `Lucide Icons` library for `React` instead of `Tabler Icons`. `Lucide Icons` matches better with the AtlasWay  identity